### PR TITLE
[Design RFC] The ansible-pulp installer needs to handle multiple versions of Pulp

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ component of Pulp. The roles are not currently available on Ansible Galaxy; to r
 Ansible installer, the [ansible-pulp](https://github.com/pulp/ansible-pulp) git repository must
 be cloned.
 
+Supported Pulp Versions
+-----------------------
+Pulpcore 3.0 and the current state of the master branch (3.1).
+
 System Requirements
 -------------------
 

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -1,7 +1,7 @@
 Pulp
 ====
 
-Ansible role that installs Pulp 3 from PyPi or source and provides basic config.
+Ansible role that installs Pulp 3 from PyPi or source and provides config.
 
 The default administrative user for the Pulp application is: 'admin'
 
@@ -17,6 +17,9 @@ Role Variables:
   Defaults to "{}", which will not install any plugins.
   * Dictionary Key: The pip installable plugin name. This is defined in each
   plugin's* `setup.py`. **Required**.
+  * `update`: Whether to update/upgrade the plugin to the latest stable release from PyPI that is compatible with the version of pulpcore that is installed. (NEEDS TESTING TO MAKE SURE ONLY COMPATIBLE VERSIONS ARE INSTALLED. ansible-pulp installs/updates pulpcore 1st, then the plugins. pulpcore's version will be kept at whatever its current version is (via a pip "Constraints File") when ansible-pulp goes to install the plugins.)
+  * `version`: Optional. A specific version of the plugin to install from PyPI. Ignored if `source_dir` is set.
+  * `branch`: Optional: A specific branch of the plugin to install from PyPI (or update/upgrade to the latest release from, see `update`. An example value is "1.0". Ignored if `source_dir` or `version` is set.
   * `source_dir`: Optional. Absolute path to the plugin source code. If present,
   plugin will be installed from source in editable mode.
   Also accepts a pip VCS URL, to (for example) install the master branch.
@@ -26,9 +29,12 @@ Role Variables:
     See `prereq_pip_packages` also.
 * `pulp_install_api_service`: Whether to create systemd service files for
   pulpcore-api. Defaults to "true".
+* `pulp_update`: Whether to update/upgrade pulpcore to the latest stable release from PyPI. Only affects systems where Pulp is already installed. To limit this to micro (z-stream) updates, make sure to set `pulp_branch`. If `pulpcore_version` is set, or `pulp_source_dir` is set, this has no effect and is effectively always `true`. Setting it to "false" enables your Ansible play is idempotent if run in the future (once new pulpcore releases come out). Defaults to "false".
+* `pulp_branch`: Install a specific branch of pulpcore (or update/upgrade to the latest release from, see `pulp_update`). Has no default; the latest stable release from PyPI will be installed. It is recommended to set this if you re-run the ansible installer; when a new branch is released, some of your content plugins may not be compatible yet. An example value is "3.0". Ignored if `pulp_source_dir` or `pulp_version` is set.
+* `pulp_version`: Optional. A specific version of pulp to install from PyPI. Ignored if `pulp_source_dir` is set.
 * `pulp_source_dir`: Optional. Absolute path to pulpcore source code. If
   present, pulpcore will be installed from source in editable mode. Also accepts
-  a pip VCS URL, to (for example) install the master branch.
+  a pip VCS URL, to (for example) install the master branch, or an arbitrary commitish (tag, branch, commit, etc.)
 * `pulp_user`: User that owns and runs Pulp. Defaults to "pulp".
 * `pulp_user_id`: Integer value of uid for the `pulp_user`. Defaults to nothing and uid is assigned
   by the system.
@@ -74,7 +80,6 @@ Role Variables:
   subscription-manager/katello.
   Also accepts a single string or empty string.
   Only affects RHEL7 (RHEL8 no longer has an optional repo.)
-
 
 Shared Variables:
 -----------------

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -5,15 +5,6 @@ Ansible role that installs Pulp 3 from PyPi or source and provides config.
 
 The default administrative user for the Pulp application is: 'admin'
 
-Note on Plugin Compatibility with Pulpcore
-------------------------------------------
-
-Pulp 3 has a plugin architecture so that new content types, and new features, can be added by the larger community. However, both pulpcore & plugins are installed via pip, which has limited dependency resolution. Plugins release at their own lifecycles; the 2 stable branches of plugin pulp_juicy could depend on the current branch of pulpcore, while the 2 stable branches of pulp_sugary could depend on the current branch of pulpcore.
-
-In order to avoid breaking multiple plugins for the sake of 1 plugin, and to avoid breaking existing installs, updating a plugin will not cause pulpcore to be updated as dependency. Similarly, if a plugin were to be attempted to be updated to an incompatible version with pulpcore, the installer will fail & exit.
-
-Thus you, yourself, must research compatibility with pulpcore whether you are installing 1 plugin, or more than 1 plugin.
-
 Role Variables:
 ---------------
 * `pulp_cache_dir`: Location of Pulp cache. Defaults to "/var/lib/pulp/tmp".
@@ -26,9 +17,9 @@ Role Variables:
   Defaults to "{}", which will not install any plugins.
   * Dictionary Key: The pip installable plugin name. This is defined in each
   plugin's* `setup.py`. **Required**.
-  * `update`: Whether to update/upgrade the plugin to the latest stable release from PyPI. To limit this to micro (z-stream) updates, make sure to set `branch`. Note that if `pulp_branch` is set, but `branch` is either unset or set to branch that is incompatible with `pulp_branch`, ansible-pulp may fail (and exit the play) when it goes to update the plugin.
-  * `version`: Optional. A specific version of the plugin to install from PyPI. Ignored if `source_dir` is set.
-  * `branch`: Optional: A specific branch of the plugin to install from PyPI (or update/upgrade to the latest release from, see `update`. An example value is "1.0". Ignored if `source_dir` or `version` is set. You need to set this to a branch that is compatible with either `pulp_branch` or `pulp_version`, if they are set.
+  * `update`: Whether to update/upgrade the plugin to the latest stable release from PyPI. To limit this to micro (z-stream) updates, make sure to set `branch`. Note that if the latest stable release of the plugin is incompatible with `pulp_branch`, ansible-pulp will fail (and exit the play) when it goes to update the plugin. Defaults to "false".
+  * `version`: Optional. A specific version of the plugin to install from PyPI. Ignored if `source_dir` is set. Overrides `update` to `true`.
+  * `branch`: Optional: A specific branch of the plugin to install from PyPI (or update/upgrade to the latest release from, see `update`). An example value is "1.0". Ignored if `source_dir` or `version` is set. You need to set this to a branch that is compatible with either `pulp_branch` or `pulp_version`, if they are set.
   * `source_dir`: Optional. Absolute path to the plugin source code. If present,
   plugin will be installed from source in editable mode.
   Also accepts a pip VCS URL, to (for example) install the master branch.
@@ -38,9 +29,9 @@ Role Variables:
     See `prereq_pip_packages` also.
 * `pulp_install_api_service`: Whether to create systemd service files for
   pulpcore-api. Defaults to "true".
-* `pulp_update`: Whether to update/upgrade pulpcore to the latest stable release from PyPI. Only affects systems where Pulp is already installed. To limit this to micro (z-stream) updates, make sure to set `pulp_branch`. If `pulpcore_version` is set, or `pulp_source_dir` is set, this has no effect and is effectively always `true`. Setting it to "false" enables your Ansible play is idempotent if run in the future (once new pulpcore releases come out). Defaults to "false".
-* `pulp_branch`: Install a specific branch of pulpcore (or update/upgrade to the latest release from, see `pulp_update`). Has no default; the latest stable release from PyPI will be installed. It is recommended to set this if you re-run the ansible installer; when a new branch is released, some of your content plugins may not be compatible yet. An example value is "3.0". Ignored if `pulp_source_dir` or `pulp_version` is set.
-* `pulp_version`: Optional. A specific version of pulp to install from PyPI. Ignored if `pulp_source_dir` is set.
+* `pulp_update`: Whether to update/upgrade pulpcore to the latest stable release from PyPI within `pulp_branch`. Only affects systems where Pulp is already installed. To limit this to micro (z-stream) updates, make sure to set `pulp_branch`. If `pulpcore_version` is set, or `pulp_source_dir` is set, this has no effect and is effectively always `true`. Defaults to "false".
+* `pulp_branch`: The branch of of pulpcore (or update/upgrade to the latest release from, see `pulp_update`). Defaults to the latest stable branch release of pulpcore at the time of ansible-pulp being released, which is currently `3.0`. It is recommended to set this if you ever plan to re-run the ansible installer; when a new branch is released and if you update ansible-pulp, some of your content plugins may not be compatible yet. An example value is `3.1`. Ignored if `pulp_source_dir` or `pulp_version` is set. Do not set this to a version higher than the current default (unless you are installing a development branch of pulpcore, and have updated ansible-pulp 1st.)
+* `pulp_version`: Optional. A specific version of pulp to install from PyPI. Ignored if `pulp_source_dir` is set. Overrides `pulp_update` to `true`.
 * `pulp_source_dir`: Optional. Absolute path to pulpcore source code. If
   present, pulpcore will be installed from source in editable mode. Also accepts
   a pip VCS URL, to (for example) install the master branch, or an arbitrary commitish (tag, branch, commit, etc.)
@@ -109,6 +100,21 @@ Operating System Variables:
 
 Each currently supported operating system has a matching file in the "vars"
 directory.
+
+Idempotency:
+------------
+This role is idempotent by default. It is dependent on these settings remaining `false`:
+* `pulp_update`
+* Every `update` under `pulp_install_plugins`
+
+Note on Plugin Version Compatibility with Pulpcore
+--------------------------------------------------
+
+Pulp 3 has a plugin architecture so that new content types, and new features, can be added by the larger community. However, both pulpcore & plugins are installed via pip, which has limited dependency resolution. Plugins release at their own lifecycles. Thus in the worst case scenario, the 2 stable branches of plugin pulp_juicy could depend on the current branch of pulpcore, while the 2 stable branches of pulp_sugary could depend on the current branch of pulpcore.
+
+In order to avoid breaking multiple plugins for the sake of 1 plugin, and to avoid breaking existing installs, updating a plugin will not cause pulpcore to be updated as dependency. Similarly, if a plugin were to be attempted to be updated to an incompatible version with pulpcore, the installer will fail & exit.
+
+Thus you, yourself, must research plugin compatibility with pulpcore whether you are installing 1 plugin, or more than 1 plugin.
 
 License
 -------

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -116,6 +116,65 @@ In order to avoid breaking multiple plugins for the sake of 1 plugin, and to avo
 
 Thus you, yourself, must research plugin compatibility with pulpcore whether you are installing 1 plugin, or more than 1 plugin.
 
+Suggested Workflows for Pulpcore & Plugin Versioning:
+-----------------------------------------------------
+
+### Latest versions with minimal work:
+
+Initial install:
+
+1. Observe the latest branch of pulpcore (3.0).
+2. Confirm that all the latest stable releases of your desired plugins are compatibile with pulpcore 3.0, such as by reading their README.md.
+3. Do not set `pulp_branch`. Do not set `branch` under `pulp_install_plugins`.
+4. Run ansible-pulp.
+
+Updating your install:
+
+1. Check if `pulp_branch` has changed to a new stable branch in the latest version of the installer. This will happen whenever a new branch of `pulpcore` is released. Let's assume 3.0 is stil the latest, but there are new micro updates (like pulpcore 3.0.3 -> 3.0.4, and pulp_juicy 1.0.3 -> 1.0.4)
+2. Update ansible-pulp
+3. re-run the ansible-pulp with `update` set to `true` under `pulp_install_plugins`, and `pulp_update` set to `true`.
+
+Upgrading your install:
+
+1. Check if `pulp_branch` has changed to a new stable branch in the latest version of the installer. This will happen whenever a new branch of `pulpcore` is released. Let's assume 3.1 is released.
+2. Check if your plugins are compatible yet with pulpcore 3.1 yet. **Wait** for the plugins to be updated for compatibility if they are not updated yet before you attempt to update.
+3. If they are updated for compatibility:
+    1. Update ansible-pulp
+    2. re-run the ansible-pulp with `update` set to `true` under `pulp_install_plugins`, and `pulp_update` set to `true`.
+
+### Specifying your desired branch:
+
+Initial install:
+
+1. Observe the latest branch of pulpcore (3.0).
+2. Confirm that all the latest stable releases of your desired plugins are compatibile with pulpcore 3.0, such as by reading their README.md. If they are not all compatible, look into whether the older version is compatible. If not, try an even older version. Let's assume the newest version compatible with all is called `X.Y`.
+3. Set `pulp_branch` to `X.Y`. Set `branch` under each of the  `pulp_install_plugins` to their own compatible semantic minor branch versions `a.b`.
+4. Run ansible-pulp
+
+Updating your install:
+
+1. Check if `pulp_branch` has changed to a new stable branch in the latest version of the installer. This will happen whenever a new branch of `pulpcore` is released. Let's assume 3.0 is stil the latest, but there are new micro updates (like pulpcore 3.0.3 -> 3.0.4, and plugin pulp_juicy 1.0.3 -> 1.0.4)
+2. Update ansible-pulp
+3. re-run the ansible-pulp with `update` set to `true` under `pulp_install_plugins`, and `pulp_update` set to `true`.
+
+Upgrading your plugins, but not pulpcore:
+
+1. Check if `pulp_branch` has changed to a new stable branch in the latest version of the installer, and if new branches of the plugins have been released. This will happen whenever a new branch of `pulpcore` is released. Let's assume 3.0 is still the latest branch of pulpcore.
+2. Repeat step 2 from the initial install. Let's assume that , but pulp_juicy has gone to a new branch (pulp_juicy 1.0.3 -> 2.0.0) with major new features, while still being compatible with your pulpcore version (3.0).
+3.`Change pulp_install_plugins.pulp_juicy.branch` to `2.0`. This is its new current & perpetual value.
+4. set `pulp_install_plugins.pulp_juicy.update` to `true`; it will upgrade it. Set `pulp_update` to true as a precaution for the latest bugfixes  that the plugins may depend on.
+5. Update ansible-pulp
+6. Run ansible-pulp
+
+Upgrading your plugins, and pulpcore:
+
+1. Check if `pulp_branch` has changed to a new stable branch in the latest version of the installer, and if new branches of the plugins have been released. This will happen whenever a new branch of `pulpcore` is released. Let's assume 3.0 is still the latest branch of pulpcore.
+2. Repeat step 2 from the initial install. Let's assume that pulpcore is now on branch 3.1, and pulp_juicy has gone to a new minor branch (pulp_juicy 2.0.0 -> 3.0.0) for compatibility purposes with pulpcore version 3.1. All your other plugins have as well.
+3. set `pulp_install_plugins.pulp_juicy.update` to `true`; it will upgrade it. Set `update` for all your other `pulp_install_plugins` as well. Set `pulp_update` to true; it will upgrade pulpcore.
+4.`Change pulp_install_plugins.pulp_juicy.branch` to `2.0`. This is its new current & perpetual value. Repeat with the correct values you determined for `branch` for all the other `pulp_install_plugins`.
+5. Update ansible-pulp
+6. Run ansible-pulp
+
 License
 -------
 

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -5,6 +5,15 @@ Ansible role that installs Pulp 3 from PyPi or source and provides config.
 
 The default administrative user for the Pulp application is: 'admin'
 
+Note on Plugin Compatibility with Pulpcore
+------------------------------------------
+
+Pulp 3 has a plugin architecture so that new content types, and new features, can be added by the larger community. However, both pulpcore & plugins are installed via pip, which has limited dependency resolution. Plugins release at their own lifecycles; the 2 stable branches of plugin pulp_juicy could depend on the current branch of pulpcore, while the 2 stable branches of pulp_sugary could depend on the current branch of pulpcore.
+
+In order to avoid breaking multiple plugins for the sake of 1 plugin, and to avoid breaking existing installs, updating a plugin will not cause pulpcore to be updated as dependency. Similarly, if a plugin were to be attempted to be updated to an incompatible version with pulpcore, the installer will fail & exit.
+
+Thus you, yourself, must research compatibility with pulpcore whether you are installing 1 plugin, or more than 1 plugin.
+
 Role Variables:
 ---------------
 * `pulp_cache_dir`: Location of Pulp cache. Defaults to "/var/lib/pulp/tmp".
@@ -17,9 +26,9 @@ Role Variables:
   Defaults to "{}", which will not install any plugins.
   * Dictionary Key: The pip installable plugin name. This is defined in each
   plugin's* `setup.py`. **Required**.
-  * `update`: Whether to update/upgrade the plugin to the latest stable release from PyPI that is compatible with the version of pulpcore that is installed. (NEEDS TESTING TO MAKE SURE ONLY COMPATIBLE VERSIONS ARE INSTALLED. ansible-pulp installs/updates pulpcore 1st, then the plugins. pulpcore's version will be kept at whatever its current version is (via a pip "Constraints File") when ansible-pulp goes to install the plugins.)
+  * `update`: Whether to update/upgrade the plugin to the latest stable release from PyPI. To limit this to micro (z-stream) updates, make sure to set `branch`. Note that if `pulp_branch` is set, but `branch` is either unset or set to branch that is incompatible with `pulp_branch`, ansible-pulp may fail (and exit the play) when it goes to update the plugin.
   * `version`: Optional. A specific version of the plugin to install from PyPI. Ignored if `source_dir` is set.
-  * `branch`: Optional: A specific branch of the plugin to install from PyPI (or update/upgrade to the latest release from, see `update`. An example value is "1.0". Ignored if `source_dir` or `version` is set.
+  * `branch`: Optional: A specific branch of the plugin to install from PyPI (or update/upgrade to the latest release from, see `update`. An example value is "1.0". Ignored if `source_dir` or `version` is set. You need to set this to a branch that is compatible with either `pulp_branch` or `pulp_version`, if they are set.
   * `source_dir`: Optional. Absolute path to the plugin source code. If present,
   plugin will be installed from source in editable mode.
   Also accepts a pip VCS URL, to (for example) install the master branch.


### PR DESCRIPTION
I am requesting feedback from the Pulp user community on this design (variables, docs, and behavior stated/implied by them) of implementing:
[[Epic] The ansible-pulp installer needs to handle multiple versions of Pulp](https://pulp.plan.io/issues/5890)
(Extended details are in the subtasks.)

The following are the design decisions:
1. The installer is focused around the pulpcore version, not the plugin versions, and locks it when the plugins get installed via pip "constraints." (Think of how you install your desired version of an app like LibreOffice, and then obtain plugins (LibreOffice extensions) for that version. This is the opposite of pulp_juicy depending on pulpcore, and therefore upgrading pulpcore as needed per the pip model.)
2. One plugin's need for a newer version of pulpcore should not break a currently working system with a set of plugins installed (because the rest require an older version of pulpcore.) This applies to both adding a new plugin, and upgrading an existing plugin. It is better for ansible-pulp to error out than to cause breakage.
3. ansible-pulp should be idempotent by default and not modify/upgrade currently working systems, unless there was configuration drift somehow (e.g., file permissions modified by 3rd party utility.)
4. Most users care about z-stream branches: Like pulpcore 3.0.z and pulp_file 0.1.z, not individual versions/releases. When a plugin adds support for a new pulpcore z-stream branch, it will have its own new z-stream branch. When a plugin adds major new features that users may be reluctant to upgrade to, they will have their own new y-stream or z-stream branch.
5. As always, ansible-pulp is neutral towards plugins and does not have any bundled specific logic for any of them. We love pulp_cardboardbox just as much as pulp_rpm.

The following limitations are being worked around:
1. Ansible galaxy does not let you download desired branches for a role, or a collection of roles (ansible-pulp will become a collection). It only supports a specific version, or the latest version. So the latest version of ansible-pulp should support multiple recent branches of Pulp. This is similar to [FreeIPA's ansible collection.](https://galaxy.ansible.com/freeipa/ansible_freeipa).
2. pip [does not have a complete dependency resolver](https://github.com/pypa/pip/issues/988) like RPM/DEB/etc do.
3. We cannot tell pip "install the latest version of pulp_juicy that is compatible with pulpcore 3.0's branch."
4. We cannot tell pip "install whatever version of pulpcore satisfies all the plugins' required versions" because pip does "first found wins".
5. Upgrading pulpcore can always break a plugin; it's up to the user to research instead when to upgrade pulpcore.

The following alternatives are being strongly considered:
1. wrt limitation 1, just do versioned releases. (Obtaining the latest ansible-pulp 3.0.z once pulpcore 3.1.z comes out will be more complex.)
2. wrt limitations 2-5, use a layer like `pip-compile` to overcome pip's limitations. Perhaps as a preflight script.