### PR TITLE
Assuring static root for django collect static

### DIFF
--- a/roles/pulp-webserver/README.md
+++ b/roles/pulp-webserver/README.md
@@ -22,10 +22,6 @@ Variables:
   '127.0.0.1'.
 * `pulp_configure_firewall` Install and configure a firewall. Valid values are 'auto', 'firewalld',
   and 'none'. Defaults to 'auto' (which is the same as 'firewalld', but may change in the future).
-* `pulp_static_url` equivalent to `STATIC_URL` from `pulpcore` i.e. url pattern to use when referring to
-  static files located in `pulp_webserver_static_dir`.
-* `pulp_webserver_static_dir` equivalent to `STATIC_ROOT` from `pulpcore` i.e. absolute path where to find
-  static files.
 
 Plugin Webserver Configs:
 -------------------------
@@ -74,3 +70,7 @@ role.
   must match the value used in the `pulp` role.
 
 * `pulp_user_home`: equivalent to `MEDIA_ROOT` from `pulpcore` i.e. absolute path for pulp user home.
+* `pulp_static_url` equivalent to `STATIC_URL` from `pulpcore` i.e. url pattern to use when referring to
+  static files located in `pulp_webserver_static_dir`.
+* `pulp_webserver_static_dir` equivalent to `STATIC_ROOT` from `pulpcore` i.e. absolute path where to find
+  static files.

--- a/roles/pulp-webserver/templates/nginx.conf.j2
+++ b/roles/pulp-webserver/templates/nginx.conf.j2
@@ -81,9 +81,5 @@ http {
 
         include conf.d/*;
 
-        location / {
-            # checks for static file, if not found proxy to app
-            try_files $uri =404;
-        }
     }
 }

--- a/roles/pulp-webserver/templates/pulp-vhost.conf.j2
+++ b/roles/pulp-webserver/templates/pulp-vhost.conf.j2
@@ -32,6 +32,6 @@ Define pulp-api {{ pulp_api_host }}:{{ pulp_api_port }}
   ProxyPass /pulp/content http://${pulp-content}/pulp/content
   ProxyPassReverse /pulp/content http://${pulp-content}/pulp/content
 
-  IncludeOptional pulp/*.conf
+  IncludeOptional pulp/*
 
 </VirtualHost>

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -14,6 +14,10 @@ Role Variables:
 * `pulp_install_dir`: Location of a virtual environment for Pulp and its Python
   dependencies. Defaults to "/usr/local/lib/pulp".
 * `pulp_user_home`: equivalent to `MEDIA_ROOT` from `pulpcore` i.e. absolute path for pulp user home.
+* `pulp_static_url` equivalent to `STATIC_URL` from `pulpcore` i.e. url pattern to use when referring to
+  static files located in `pulp_webserver_static_dir`.
+* `pulp_webserver_static_dir` equivalent to `STATIC_ROOT` from `pulpcore` i.e. absolute path where to find
+  static files.
 * `pulp_install_plugins`: A nested dictionary of plugin configuration options.
   Defaults to "{}", which will not install any plugins.
   * Dictionary Key: The pip installable plugin name. This is defined in each

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -30,6 +30,8 @@ pulp_user_id:
 pulp_group: pulp
 pulp_group_id:
 pulp_user_home: '/var/lib/pulp'
+pulp_static_url: 'assets'
+pulp_webserver_static_dir: "{{ pulp_user_home | regex_replace('\\/$', '') }}/{{ pulp_static_url | regex_replace('^\\/|\\/$', '') }}/"
 pulp_pip_editable: yes
 pulp_use_system_wide_pkgs: false
 pulp_api_bind: '127.0.0.1:24817'

--- a/roles/pulp/handlers/main.yml
+++ b/roles/pulp/handlers/main.yml
@@ -22,3 +22,4 @@
   notify: Restart pulpcore-api.service
   environment:
     PULP_SETTINGS: "{{ pulp_settings_file }}"
+    PULP_STATIC_ROOT: "{{ pulp_webserver_static_dir }}"


### PR DESCRIPTION
This PR addresses:
- assure the `STATIC_ROOT` is what the installer expects
- improves nginx for allowing snippets to change the behavior of the root (needs https://github.com/ansible/galaxy_ng/pull/66 merged) 