### PR TITLE
Update roles' Ansible Galaxy metadata for EL8 support

### DIFF
--- a/roles/pulp-content/meta/main.yml
+++ b/roles/pulp-content/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
   galaxy_tags:
     - pulp
     - pulpcore

--- a/roles/pulp-database/meta/main.yml
+++ b/roles/pulp-database/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
   galaxy_tags:
     - pulp
     - pulpcore

--- a/roles/pulp-devel/meta/main.yml
+++ b/roles/pulp-devel/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
   galaxy_tags:
     - pulp
     - pulpcore

--- a/roles/pulp-redis/meta/main.yml
+++ b/roles/pulp-redis/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
   galaxy_tags:
     - pulp
     - pulpcore

--- a/roles/pulp-resource-manager/meta/main.yml
+++ b/roles/pulp-resource-manager/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
   galaxy_tags:
     - pulp
     - pulpcore

--- a/roles/pulp-webserver/meta/main.yml
+++ b/roles/pulp-webserver/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
   galaxy_tags:
     - pulp
     - pulpcore

--- a/roles/pulp-workers/meta/main.yml
+++ b/roles/pulp-workers/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
   galaxy_tags:
     - pulp
     - pulpcore

--- a/roles/pulp/meta/main.yml
+++ b/roles/pulp/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
   galaxy_tags:
     - pulp
     - pulpcore


### PR DESCRIPTION
Note that these are not visible on Galaxy yet; they will be
when published as a collection.

re: #6458
As a user, I can consume pulp_installer as a collection from
Ansible Galaxy
https://pulp.plan.io/issues/6458

re: #6259
Add support for CentOS 8 & RHEL8 to the ansible-pulp installer
https://pulp.plan.io/issues/6259


[noissue]