### PR TITLE
Problem: pulp_installer molecule CI fails with python-sh 1.13.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ deps =
     docker
     molecule
     molecule-inspec
+    sh != 1.13.0
 passenv = TEST_TYPE
 # For reference on the commands, see:
 # `molecule matrix test`


### PR DESCRIPTION
Solution: Exclude the 1.13.0 version specifically, assuming
that 1.13.1 will have it fixed.

fixes: #6587