### PR TITLE
Problem: pulp_installer molecule CI fails with python-sh 1.13.1

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,8 @@ deps =
     docker
     molecule
     molecule-inspec
-    sh != 1.13.0
+    # molecule dep that is incompatible with python 2 as of 1.13.0 & 1.13.1
+    sh < 1.13 ; python_version < "3"
 passenv = TEST_TYPE
 # For reference on the commands, see:
 # `molecule matrix test`


### PR DESCRIPTION
Solution: Keep it on 1.12.x for python 2, since both 1.13.0 & 1.13.1
seem to be incompatible with python 2, despite what the project's
homepage says.

fixes: #6587