### PR TITLE
Fix Ansible warning when enabling PowerTools repo

### DIFF
--- a/roles/pulp/tasks/repos.yml
+++ b/roles/pulp/tasks/repos.yml
@@ -84,7 +84,7 @@
         path: "{{ repo_file.stdout }}"
         section: "PowerTools"
         option: enabled
-        value: 1
+        value: "1"
         no_extra_spaces: true
       when: repo_file.rc == 0
       become: true


### PR DESCRIPTION
This fixes the following warning:

```
[WARNING]: The value 1 (type int) in a string field was converted to '1' (type string). If this does not look like what you expect, quote the entire value to ensure it does not change.
```

[noissue]