### PR TITLE
6623: pulpcore and plugin pre-flight check seems to not be enforcing and then installer fails at collectstatic

### DIFF
--- a/CHANGES/6623.bugfix
+++ b/CHANGES/6623.bugfix
@@ -1,0 +1,1 @@
+Fixed several issues that cause the pre-flight check to not enforce (not terminating the install early on), which would lead to the instaler erroring at collectstatic, and leave users with a broken pulp installation.

--- a/CHANGES/6644.bugfix
+++ b/CHANGES/6644.bugfix
@@ -1,0 +1,1 @@
+Fixed the pulpcore/plugin compatibility check not enforcing on upgrades when some currently installed plugins are not specified by the user in pulp_install_plugins.

--- a/CHANGES/6645.bugfix
+++ b/CHANGES/6645.bugfix
@@ -1,0 +1,1 @@
+Fixed the pulpcore/plugin compatibility check getting not enforcing when it needs the prereq roles applied to evaluate compatibility. It now runs before (and if necessary, after) the prereq roles.

--- a/CHANGES/6689.bugfix
+++ b/CHANGES/6689.bugfix
@@ -1,0 +1,1 @@
+Fixed pre-flight check producing an error (and accidentally enforcing) when a package is installed system-wide at a version that is not available on PyPI. This issue was never present on the previous release, only on the develoment branch.

--- a/CHANGES/6690.bugfix
+++ b/CHANGES/6690.bugfix
@@ -1,0 +1,1 @@
+Fixed pre-flight check producing an error (and accidentally enforcing) when trying & failing to build certain packages from PyPI that are actually available as a system-wide (RPM/deb-installed) package in the virtualenv. This issue was never present on the previous release, only on the develoment branch.

--- a/roles/pulp-devel/tasks/bashrc.yml
+++ b/roles/pulp-devel/tasks/bashrc.yml
@@ -40,7 +40,7 @@
       && pbindings {{ item.key| replace("-", "_") }} python
     args:
       executable: /bin/bash
-    with_dict: "{{ pulp_install_plugins }}"
+    with_dict: "{{ pulp_install_plugins_normalized }}"
 
   - name: Add fzf bashrc
     copy:

--- a/roles/pulp-webserver/tasks/apache.yml
+++ b/roles/pulp-webserver/tasks/apache.yml
@@ -48,7 +48,7 @@
       args:
         executable: /usr/local/lib/pulp/bin/python
       register: snippets
-      with_dict: '{{ pulp_install_plugins }}'
+      with_dict: '{{ pulp_install_plugins_normalized }}'
       failed_when: false
       changed_when: false
       check_mode: false
@@ -59,7 +59,7 @@
     - name: Symlink Apache snippets
       file:
         src: "{{ item.stdout_lines | last }}"
-        # Note: item.item is pulp_install_plugins
+        # Note: item.item is pulp_install_plugins_normalized
         dest: "{{ pulp_webserver_apache_snippets_dir }}/{{ item.item.key | regex_replace('-', '_') }}.conf"
         state: link
       loop: '{{ snippets.results }}'

--- a/roles/pulp-webserver/tasks/nginx.yml
+++ b/roles/pulp-webserver/tasks/nginx.yml
@@ -58,7 +58,7 @@
       args:
         executable: /usr/local/lib/pulp/bin/python
       register: snippets
-      with_dict: '{{ pulp_install_plugins }}'
+      with_dict: '{{ pulp_install_plugins_normalized }}'
       failed_when: false
       changed_when: false
       check_mode: false
@@ -69,7 +69,7 @@
     - name: Symlink nginx snippets
       file:
         src: "{{ item.stdout_lines | last }}"
-        # Note: item.item is pulp_install_plugins
+        # Note: item.item is pulp_install_plugins_normalized
         dest: "/etc/nginx/pulp/{{ item.item.key | regex_replace('-', '_') }}.conf"
         state: link
       loop: '{{ snippets.results }}'

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -44,3 +44,9 @@ rhel7_optional_repo:
 epel_release_packages:
   - epel-release
   - "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
+# The names of any pip packages that are plugins but do not begin with "pulp-"
+# These are specified regardless of whether or not the user is installing it.
+# We will advertise this to users once we feel there is a need for them to ever
+# set it, and even then we may just help them to append to a list.
+pulp_irregularly_named_plugins:
+  - galaxy-ng

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -166,7 +166,7 @@
   become: true
   become_user: '{{ pulp_user }}'
 
-- name: pre-flight check for pulpcore/plugin version compatibility
+- name: Prepare for preflight checks
   block:
 
     - name: Obtain list of packages in the venv to see if any plugins are installed
@@ -186,56 +186,56 @@
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
 
-    # When there are no plugin prereqs roles
-    - name: Run pre-flight check (no prereq roles)
-      include_tasks: preflight_function.yml
-      when: pulp_install_plugins_normalized | dict2items | selectattr('value.prereq_role', 'defined') | list | count == 0
-
   when: pulp_source_dir is undefined
   become: true
 
-- name: Run plugins prereq roles & related preflight checks
-  block:
+# When there are no plugin prereqs roles
+- name: Run pre-flight check (no prereq roles)
+  include_tasks: preflight_function.yml
+  when:
+    - pulp_source_dir is undefined
+    - pulp_install_plugins_normalized | dict2items | selectattr('value.prereq_role', 'defined') | list | count == 0
 
-    # When there are plugin prereq roles
-    #
-    # Some plugins have deps that need to be installed for setup.py to load. When an error
-    # occurs due to those missing deps, the version comparison will not occur.
-    # So we will ignore all other errors this time. The version comparison occurs before
-    # that error is raised. We only care about that contain this string.
-    - name: Run preflight check before prereq roles
-      include_tasks: preflight_function.yml
-      vars:
-        failed_condition: '"Could not find a version" in compatibility.stderr'
-      when:
-        - pulp_source_dir is undefined
-
-    # Note: We would do a static import like in pulp-database, but
-    # looping does not work with it, so we do a dynamic include.
-    - name: Include plugins prereq roles
-      include_role:
-        name: "{{ item.value.prereq_role }}"
-      with_dict: "{{ pulp_install_plugins_normalized }}"
-      when: item.value.prereq_role is defined
-      register: prereq_roles
-
-    # No loop over pulp_install_plugins_normalized; let's run this only once.
-    # Also, this time it must succeed, a return code of 0.
-    - name: Re-run pre-flight check after plugin prereq roles
-      include_tasks: preflight_function.yml
-      # if it didn't succeed last time
-      vars:
-        failed_condition: >
-          (compatibility.rc != 0) and
-          ("AttributeError: module \'setuptools.build_meta\' has no attribute \'__legacy__\'" not in compatibility.stderr)
-      when:
-        - pulp_source_dir is undefined
-        - compatibility is defined
-        - compatibility.rc != 0
-
+# When there are plugin prereq roles
+# We are not using a block for these next few tasks; see preflight_function.yml
+#
+# Some plugins have deps that need to be installed for setup.py to load. When an error
+# occurs due to those missing deps, the version comparison will not occur.
+# So we will ignore all other errors this time. The version comparison occurs before
+# that error is raised. We only care about that contain this string.
+- name: Run preflight check before prereq roles
+  include_tasks: preflight_function.yml
+  vars:
+    failed_condition: '"Could not find a version" in compatibility.stderr'
   # When there is at least 1 prereq role.
-  when: pulp_install_plugins_normalized | dict2items | selectattr('value.prereq_role', 'defined') | list | count > 0
-  become: true
+  when:
+    - pulp_source_dir is undefined
+    - pulp_install_plugins_normalized | dict2items | selectattr('value.prereq_role', 'defined') | list | count > 0
+
+# Note: We would do a static import like in pulp-database, but
+# looping does not work with it, so we do a dynamic include.
+- name: Include plugins prereq roles
+  include_role:
+    name: "{{ item.value.prereq_role }}"
+  with_dict: "{{ pulp_install_plugins_normalized }}"
+  when:
+    - item.value.prereq_role is defined
+
+# No loop over pulp_install_plugins_normalized; let's run this only once.
+# Also, this time it must succeed, a return code of 0.
+- name: Re-run pre-flight check after plugin prereq roles
+  include_tasks: preflight_function.yml
+  vars:
+    failed_condition: >
+      (compatibility.rc != 0) and
+      ("AttributeError: module \'setuptools.build_meta\' has no attribute \'__legacy__\'" not in compatibility.stderr)
+  # if it didn't succeed last time
+  when:
+    - pulp_source_dir is undefined
+    - pulp_install_plugins_normalized | dict2items | selectattr('value.prereq_role', 'defined') | list | count > 0
+    - compatibility is defined
+    - compatibility.rc is defined
+    - compatibility.rc != 0
 
 - name: Install Pulp via Pip
   block:

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -169,6 +169,11 @@
 - name: pre-flight check for pulpcore/plugin version compatibility
   block:
 
+    - name: Obtain list of packages in the venv to see if any plugins are installed
+      pip_package_info:
+        clients: "{{ pulp_install_dir }}/bin/pip"
+      register: pip_pkgs
+
     - name: Create requirements.in file to check pulpcore/plugin compatibility
       template:
         src: templates/requirements.in.j2
@@ -184,7 +189,7 @@
     # When there are no plugin prereqs roles
     - name: Run pre-flight check once & only once
       include_tasks: preflight_function.yml
-      when: pulp_install_plugins | dict2items | selectattr('value.prereq_role', 'defined') | list | count == 0
+      when: pulp_install_plugins_normalized | dict2items | selectattr('value.prereq_role', 'defined') | list | count == 0
 
   when: pulp_source_dir is undefined
   become: true
@@ -210,11 +215,11 @@
     - name: Include plugins prereq roles
       include_role:
         name: "{{ item.value.prereq_role }}"
-      with_dict: "{{ pulp_install_plugins }}"
+      with_dict: "{{ pulp_install_plugins_normalized }}"
       when: item.value.prereq_role is defined
       register: prereq_roles
 
-    # No loop over pulp_install_plugins; let's run this only once.
+    # No loop over pulp_install_plugins_normalized; let's run this only once.
     # Also, this time it must succeed, a return code of 0.
     - name: Re-run pre-flight check after plugin prereq roles
       include_tasks: preflight_function.yml
@@ -225,7 +230,7 @@
         - compatibility.rc != 0
 
   # When there is at least 1 prereq role.
-  when: pulp_install_plugins | dict2items | selectattr('value.prereq_role', 'defined') | list | count > 0
+  when: pulp_install_plugins_normalized | dict2items | selectattr('value.prereq_role', 'defined') | list | count > 0
   become: true
 
 - name: Install Pulp via Pip
@@ -279,7 +284,7 @@
     # register the installed version, because when tested (Ansible 2.9, with no
     # changes applied), the registered result from "Install pulpcore package
     # from source" left the version field "null".
-    - name: Obtain list of packages & versions in the venv
+    - name: Obtain list of packages & versions in the venv after pulpcore install
       pip_package_info:
         clients: "{{ pulp_install_dir }}/bin/pip"
       register: pip_pkgs
@@ -301,8 +306,8 @@
         extra_args: "-c {{ pulp_install_dir }}/pip_constraints_for_plugins.txt"
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
-      with_dict: '{{ pulp_install_plugins }}'
-      when: pulp_install_plugins[item.key].source_dir is undefined
+      with_dict: '{{ pulp_install_plugins_normalized }}'
+      when: item.value.source_dir is undefined
       notify:
         - Collect static content
         - Restart all Pulp services
@@ -317,7 +322,7 @@
         extra_args: "-c {{ pulp_install_dir }}/pip_constraints_for_plugins.txt"
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
-      with_dict: '{{ pulp_install_plugins }}'
+      with_dict: '{{ pulp_install_plugins_normalized }}'
       when: item.value.source_dir is defined
       register: result
       # This is a hack. Editable pip installs are always changed, which fails molecule's

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -187,7 +187,7 @@
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
 
     # When there are no plugin prereqs roles
-    - name: Run pre-flight check once & only once
+    - name: Run pre-flight check (no prereq roles)
       include_tasks: preflight_function.yml
       when: pulp_install_plugins_normalized | dict2items | selectattr('value.prereq_role', 'defined') | list | count == 0
 
@@ -203,7 +203,7 @@
     # occurs due to those missing deps, the version comparison will not occur.
     # So we will ignore all other errors this time. The version comparison occurs before
     # that error is raised. We only care about that contain this string.
-    - name: Run preflight check that might need to be re-run later
+    - name: Run preflight check before prereq roles
       include_tasks: preflight_function.yml
       vars:
         failed_condition: '"Could not find a version" in compatibility.stderr'

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -1,5 +1,6 @@
 ---
-- block:
+- name: General system changes before installation
+  block:
 
     - name: Update apt package index
       apt:
@@ -135,7 +136,8 @@
 
   become: true
 
-- block:
+- name: Prepare the virtualenv itself
+  block:
 
     # Hack for use system-wide packages when enabled by user - Must be first usage of virtualenv
     - name: Create a venv with system-wide packages setting if the venv does not exist
@@ -161,65 +163,48 @@
         line: "include-system-site-packages = true"
       when: pulp_use_system_wide_pkgs | bool
 
+  become: true
+  become_user: '{{ pulp_user }}'
+
+- name: pre-flight check for pulpcore/plugin version compatibility
+  block:
+
     - name: Create requirements.in file to check pulpcore/plugin compatibility
       template:
         src: templates/requirements.in.j2
         dest: "{{ pulp_install_dir }}/requirements.in"
-      when: pulp_source_dir is undefined
 
-    - name: Install pip-tools before running pip-compile to check version compatibility
+    - name: Install pip-tools, which provides pip-compile to check version compatibility
       pip:
         name: pip-tools
         state: present
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
 
-    - block:
+    # When there are no plugin prereqs roles
+    - name: Run pre-flight check once & only once
+      include_tasks: preflight_function.yml
+      when: pulp_install_plugins | dict2items | selectattr('value.prereq_role', 'defined') | list | count == 0
 
-        # pip-compile creates requirements.txt, but we need to create it for these
-        # use cases:
-        # 1. upgrades from pulp installs older than the pip-compile check
-        # 2. Users manually modifying their venv
-        #
-        # We need requirements.txt because it affects what happens when users
-        # specify "pulp-file" (for example) without any version or an upgrade;
-        # pip-compile behaves differently depending on whether or not pulp-file is
-        # already installed (attempt to install newest version, vs leave it be.)
-        - name: list currently installed packages for the pip-compile check
-          shell: '{{ pulp_install_dir }}/bin/pip freeze > {{ pulp_install_dir }}/requirements.txt'
-          changed_when: false
-
-        - name: Backup currently installed packages for any potential troubleshooting purposes
-          copy:
-            src: '{{ pulp_install_dir }}/requirements.txt'
-            dest: '{{ pulp_install_dir }}/requirements.txt.orig'
-            remote_src: true
-          changed_when: false
-
-        - name: Run pip-compile to check pulpcore/plugin compatibility
-          command: '{{ pulp_install_dir }}/bin/pip-compile
-{% for plugin, value in pulp_install_plugins.items() %}
-{% if value["upgrade"]|default(false, true) %} -P {{ plugin }} {% endif %}
-{% endfor %}'
-          args:
-            chdir: '{{ pulp_install_dir }}'
-          register: compatibility
-          when: pulp_source_dir is undefined
-          # Some plugins have deps that need to be installed for setup.py to load. When an error
-          # occurs due to those missing deps, we can ignore it. The version comparison occurs before
-          # that error is raised. We only care about that contain this string.
-          failed_when: '"Could not find a version" in compatibility.stderr'
-          changed_when: false
-
-      environment:
-        LC_ALL: en_US.UTF-8
-        LANG: en_US.UTF-8
-      when: pulp_source_dir is undefined
-
+  when: pulp_source_dir is undefined
   become: true
-  become_user: '{{ pulp_user }}'
 
-- block:
+- name: Run plugins prereq roles & related preflight checks
+  block:
+
+    # When there are plugin prereq roles
+    #
+    # Some plugins have deps that need to be installed for setup.py to load. When an error
+    # occurs due to those missing deps, the version comparison will not occur.
+    # So we will ignore all other errors this time. The version comparison occurs before
+    # that error is raised. We only care about that contain this string.
+    - name: Run preflight check that might need to be re-run later
+      include_tasks: preflight_function.yml
+      vars:
+        failed_condition: '"Could not find a version" in compatibility.stderr'
+      when:
+        - pulp_source_dir is undefined
+
     # Note: We would do a static import like in pulp-database, but
     # looping does not work with it, so we do a dynamic include.
     - name: Include plugins prereq roles
@@ -227,10 +212,24 @@
         name: "{{ item.value.prereq_role }}"
       with_dict: "{{ pulp_install_plugins }}"
       when: item.value.prereq_role is defined
+      register: prereq_roles
 
+    # No loop over pulp_install_plugins; let's run this only once.
+    # Also, this time it must succeed, a return code of 0.
+    - name: Re-run pre-flight check after plugin prereq roles
+      include_tasks: preflight_function.yml
+      # if it didn't succeed last time
+      when:
+        - pulp_source_dir is undefined
+        - compatibility is defined
+        - compatibility.rc != 0
+
+  # When there is at least 1 prereq role.
+  when: pulp_install_plugins | dict2items | selectattr('value.prereq_role', 'defined') | list | count > 0
   become: true
 
-- block:
+- name: Install Pulp via Pip
+  block:
 
     - name: Install the prereq_pip_packages
       pip:

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -224,6 +224,10 @@
     - name: Re-run pre-flight check after plugin prereq roles
       include_tasks: preflight_function.yml
       # if it didn't succeed last time
+      vars:
+        failed_condition: >
+          (compatibility.rc != 0) and
+          ("AttributeError: module \'setuptools.build_meta\' has no attribute \'__legacy__\'" not in compatibility.stderr)
       when:
         - pulp_source_dir is undefined
         - compatibility is defined

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -188,6 +188,7 @@
 
   when: pulp_source_dir is undefined
   become: true
+  become_user: '{{ pulp_user }}'
 
 # When there are no plugin prereqs roles
 - name: Run pre-flight check (no prereq roles)

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -191,7 +191,7 @@
   become_user: '{{ pulp_user }}'
 
 # When there are no plugin prereqs roles
-- name: Run pre-flight check (no prereq roles)
+- name: Run preflight check (no prereq roles)
   include_tasks: preflight_function.yml
   when:
     - pulp_source_dir is undefined
@@ -224,7 +224,7 @@
 
 # No loop over pulp_install_plugins_normalized; let's run this only once.
 # Also, this time it must succeed, a return code of 0.
-- name: Re-run pre-flight check after plugin prereq roles
+- name: Re-run preflight check after plugin prereq roles
   include_tasks: preflight_function.yml
   vars:
     failed_condition: >

--- a/roles/pulp/tasks/main.yml
+++ b/roles/pulp/tasks/main.yml
@@ -4,6 +4,16 @@
   assert:
     that: pulp_settings.secret_key is defined
 
+- debug:
+    var: pulp_install_plugins
+    verbosity: 1
+- debug:
+    var: pulp_install_plugins_normalized_yml
+    verbosity: 1
+- debug:
+    var: pulp_install_plugins_normalized
+    verbosity: 1
+
 - name: Load OS specific variables
   include_vars: "{{ lookup('first_found', params) }}"
   vars:

--- a/roles/pulp/tasks/preflight_function.yml
+++ b/roles/pulp/tasks/preflight_function.yml
@@ -1,0 +1,39 @@
+---
+# preflight_function.yml: preflight check tasks that may need to be re-run,
+# with certain vars. Like a function in programming languages.
+# vars: failed_condition
+
+# pip-compile creates requirements.txt, but we need to create it for these
+# use cases:
+# 1. upgrades from pulp installs older than the pip-compile check
+# 2. Users manually modifying their venv
+#
+# We need requirements.txt because it affects what happens when users
+# specify "pulp-file" (for example) without any version or an upgrade;
+# pip-compile behaves differently depending on whether or not pulp-file is
+# already installed (attempt to install newest version, vs leave it be.)
+- name: List currently installed packages for the pip-compile check
+  shell: '{{ pulp_install_dir }}/bin/pip freeze > {{ pulp_install_dir }}/requirements.txt'
+  changed_when: false
+
+- name: Backup currently installed packages for any potential troubleshooting purposes
+  copy:
+    src: '{{ pulp_install_dir }}/requirements.txt'
+    dest: '{{ pulp_install_dir }}/requirements.txt.orig'
+    remote_src: true
+    backup: true
+  changed_when: false
+
+- name: Run pip-compile to check pulpcore/plugin compatibility
+  command: '{{ pulp_install_dir }}/bin/pip-compile
+{% for plugin, value in pulp_install_plugins.items() %}
+{% if value["upgrade"]|default(false, true) %} -P {{ plugin }} {% endif %}
+{% endfor %}'
+  args:
+    chdir: '{{ pulp_install_dir }}'
+  register: compatibility
+  environment:
+    LC_ALL: en_US.UTF-8
+    LANG: en_US.UTF-8
+  failed_when: '{{ failed_condition | default("compatibility.rc != 0") }}'
+  changed_when: false

--- a/roles/pulp/tasks/preflight_function.yml
+++ b/roles/pulp/tasks/preflight_function.yml
@@ -13,7 +13,7 @@
 # pip-compile behaves differently depending on whether or not pulp-file is
 # already installed (attempt to install newest version, vs leave it be.)
 - name: List currently installed packages for the pip-compile check
-  shell: '{{ pulp_install_dir }}/bin/pip freeze > {{ pulp_install_dir }}/requirements.txt'
+  shell: '{{ pulp_install_dir }}/bin/pip freeze --local > {{ pulp_install_dir }}/requirements.txt'
   changed_when: false
 
 - name: Backup currently installed packages for any potential troubleshooting purposes

--- a/roles/pulp/tasks/preflight_function.yml
+++ b/roles/pulp/tasks/preflight_function.yml
@@ -20,6 +20,7 @@
   shell: '{{ pulp_install_dir }}/bin/pip freeze --local > {{ pulp_install_dir }}/requirements.txt'
   changed_when: false
   become: true
+  become_user: '{{ pulp_user }}'
 
 - name: Backup currently installed packages for any potential troubleshooting purposes
   copy:
@@ -29,6 +30,7 @@
     backup: true
   changed_when: false
   become: true
+  become_user: '{{ pulp_user }}'
 
 - name: Run pip-compile to check pulpcore/plugin compatibility
   command: '{{ pulp_install_dir }}/bin/pip-compile
@@ -44,3 +46,4 @@
   failed_when: '{{ failed_condition | default("compatibility.rc != 0") }}'
   changed_when: false
   become: true
+  become_user: '{{ pulp_user }}'

--- a/roles/pulp/tasks/preflight_function.yml
+++ b/roles/pulp/tasks/preflight_function.yml
@@ -26,7 +26,7 @@
 
 - name: Run pip-compile to check pulpcore/plugin compatibility
   command: '{{ pulp_install_dir }}/bin/pip-compile
-{% for plugin, value in pulp_install_plugins.items() %}
+{% for plugin, value in pulp_install_plugins_normalized.items() %}
 {% if value["upgrade"]|default(false, true) %} -P {{ plugin }} {% endif %}
 {% endfor %}'
   args:

--- a/roles/pulp/tasks/preflight_function.yml
+++ b/roles/pulp/tasks/preflight_function.yml
@@ -1,7 +1,11 @@
 ---
 # preflight_function.yml: preflight check tasks that may need to be re-run,
 # with certain vars. Like a function in programming languages.
-# vars: failed_condition
+#
+# vars: failed_condition (optional)
+#
+# Limitations: `include_tasks:` within a block seems to cause arbitrary skipped
+# tasks (problem with `when:`) and break ansible-lint.
 
 # pip-compile creates requirements.txt, but we need to create it for these
 # use cases:
@@ -15,6 +19,7 @@
 - name: List currently installed packages for the pip-compile check
   shell: '{{ pulp_install_dir }}/bin/pip freeze --local > {{ pulp_install_dir }}/requirements.txt'
   changed_when: false
+  become: true
 
 - name: Backup currently installed packages for any potential troubleshooting purposes
   copy:
@@ -23,6 +28,7 @@
     remote_src: true
     backup: true
   changed_when: false
+  become: true
 
 - name: Run pip-compile to check pulpcore/plugin compatibility
   command: '{{ pulp_install_dir }}/bin/pip-compile
@@ -37,3 +43,4 @@
     LANG: en_US.UTF-8
   failed_when: '{{ failed_condition | default("compatibility.rc != 0") }}'
   changed_when: false
+  become: true

--- a/roles/pulp/templates/requirements.in.j2
+++ b/roles/pulp/templates/requirements.in.j2
@@ -1,5 +1,11 @@
 pulpcore=={{ pulp_version }}
-{% for plugin, value in pulp_install_plugins.items() %}
+{% for plugin, value in pulp_install_plugins_normalized.items() %}
 {{ plugin }}{% if value['version'] is defined and value['version']|length %}=={{ value['version'] }}{% endif %}
 
 {% endfor %}
+# Any plugins listed below were already installed but not specified in
+# pulp_install_plugins
+{% for plugin in pip_pkgs.packages[pulp_install_dir + '/bin/pip'].keys() %}
+{% if ("pulp-" in plugin or plugin in pulp_irregularly_named_plugins) and plugin not in pulp_install_plugins_normalized.keys() %}{{ plugin }}{% endif %}
+
+{%- endfor %}

--- a/roles/pulp/vars/main.yml
+++ b/roles/pulp/vars/main.yml
@@ -1,0 +1,12 @@
+---
+# Intermediate var for pulp_install_plugins_normalized, based on this example;
+# https://gist.github.com/kcem/5ec90b97c08fafd0397f248e8c31b25b
+# With the to_json fix for Python2:
+# https://stackoverflow.com/questions/41521138/ansible-template-adds-u-to-array-in-template
+pulp_install_plugins_normalized_yml: |-
+  {% for key, value in pulp_install_plugins.items() %}
+  {{ key.replace('_', '-') }}: {{ value | to_json }}
+  {% endfor %}
+# A pulp_install_plugins but with the plugin names corrected:
+# pip/PyPI only uses dashes, not underscores.
+pulp_install_plugins_normalized: "{{ pulp_install_plugins_normalized_yml | from_yaml }}"


### PR DESCRIPTION
This will be 8 commits; 2 sub-issues of 6623, and 1 to mark 6623 as done, 2 for sub-issues of 6688, and 3 for misc changes/fixes that cannot be easily squashed.

2 commits for 6623 were already merged in https://github.com/pulp/pulp_installer/pull/288

re: #6623
pulpcore and plugin pre-flight check seems to not be enforcing and then installer fails at collectstatic
https://pulp.plan.io/issues/6623

re: #6688
pulp_installer: preflight check and system-wide packages are incompatible
https://pulp.plan.io/issues/6688

I have done functional testing via pulplift or molecule of all of the issues (with their different conditions) described in the tickets.

pulp_rpm_prereqs test: https://github.com/pulp/pulp_rpm_prerequisites/pull/56
(the upgrade scenario there with system-wide packages was previously broken by the merge of https://github.com/pulp/pulp_installer/pull/288 )