### PR TITLE
Make gunicorn --workers param user configurable

### DIFF
--- a/CHANGES/6727.feature
+++ b/CHANGES/6727.feature
@@ -1,0 +1,1 @@
+Make gunicorn --workers parameter configurable

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -45,6 +45,9 @@ Role Variables:
 * `pulp_api_bind` Interface and Port where Pulp Content `gunicorn` service will listen. Defaults to
   '127.0.0.1:24817'. This variable is the value used to render the `pulpcore-api.service.j2` template
   passing to the `--bind` parameter of the `gunicorn` service.
+* `pulp_api_workers`: Number of Pulp Content `gunicorn` processes for handling requests. Defaults to 1.
+  Used to render the `pulpcore-api.servie.j2` template, passing to the `--workers` parameter of the
+  gunicorn service.
 * `pulp_settings`: A nested dictionary that is used to add custom values to the user's
     `setting.py`, which will override any default values set by pulpcore. The keys of this
     dictionary are variable names, and the values should be expressed using the [Dynaconf syntax](

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -33,6 +33,7 @@ pulp_user_home: '/var/lib/pulp'
 pulp_pip_editable: yes
 pulp_use_system_wide_pkgs: false
 pulp_api_bind: '127.0.0.1:24817'
+pulp_api_workers: 1
 prereq_pip_packages: []
 pulp_rhel_codeready_repo:
   - codeready-builder-for-rhel-8-x86_64-rpms

--- a/roles/pulp/templates/pulpcore-api.service.j2
+++ b/roles/pulp/templates/pulpcore-api.service.j2
@@ -12,6 +12,7 @@ PIDFile=/run/pulpcore-api.pid
 RuntimeDirectory=pulpcore-api
 ExecStart={{ pulp_install_dir }}/bin/gunicorn pulpcore.app.wsgi:application \
           --bind '{{ pulp_api_bind }}' \
+          --workers {{ pulp_api_workers }} \
           --access-logfile -
 ProtectSystem=full
 PrivateTmp=yes


### PR DESCRIPTION
For the galaxy-ng plugin we make API requests to the Pulp content app from within our views. If only a single worker is running, we end up in a deadlocked state. Adding a parameter that allows us to configure the number of workers from our install playbook.

closes #6727
https://pulp.plan.io/issues/6727
