### PR TITLE
Enforce new lines on requirements.in

### DIFF
--- a/CHANGES/6697.bugfix
+++ b/CHANGES/6697.bugfix
@@ -1,0 +1,1 @@
+Enforce new lines when listing plugins on requirements.in

--- a/roles/pulp/templates/requirements.in.j2
+++ b/roles/pulp/templates/requirements.in.j2
@@ -6,6 +6,8 @@ pulpcore=={{ pulp_version }}
 # Any plugins listed below were already installed but not specified in
 # pulp_install_plugins
 {% for plugin in pip_pkgs.packages[pulp_install_dir + '/bin/pip'].keys() %}
-{% if ("pulp-" in plugin or plugin in pulp_irregularly_named_plugins) and plugin not in pulp_install_plugins_normalized.keys() %}{{ plugin }}{% endif %}
+{% if ("pulp-" in plugin or plugin in pulp_irregularly_named_plugins) and plugin not in pulp_install_plugins_normalized.keys() %}
+{{ plugin }}
+{% endif %}
 
 {%- endfor %}


### PR DESCRIPTION
Before:
```
[vagrant@pulp3-source-fedora31 ~]$ cat /usr/local/lib/pulp/requirements.in
pulpcore==3.3.1
pulp-ansible
pulp-rpm
pulp-file
pulp-ansible-clientpulp-file-clientpulp-npmpulp-npm-clientpulp-rpm-clientpulp-smash
```

After:
```
[vagrant@pulp3-source-fedora31 ~]$ cat /usr/local/lib/pulp/requirements.in
pulpcore==3.3.1
pulp-ansible
pulp-rpm
pulp-file
pulp-ansible-client
pulp-file-client
pulp-npm
pulp-npm-client
pulp-rpm-client
pulp-smash
```
https://pulp.plan.io/issues/6697
closes #6697