### PR TITLE
Fixing the RHUI name for the CodeReady repo.

### DIFF
--- a/CHANGES/6805.bugfix
+++ b/CHANGES/6805.bugfix
@@ -1,0 +1,1 @@
+Fixed CodeReady repo name for RHEL8 AWS installations

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -38,6 +38,7 @@ prereq_pip_packages: []
 pulp_rhel_codeready_repo:
   - codeready-builder-for-rhel-8-x86_64-rpms
   - rhui-codeready-builder-for-rhel-8-rhui-rpms
+  - codeready-builder-for-rhel-8-rhui-rpms
 rhel7_optional_repo:
   - rhui-rhel-7-server-rhui-optional-rpms
   - rhel-7-server-optional-rpms


### PR DESCRIPTION
Fixing the CodeReady RHUI repo name for installations on RHEL 8.