### PR TITLE
Problem: Import to Galaxy fails

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -32,7 +32,10 @@ license:
 
 # The path to the license file for the collection. This path is relative to the root of the collection. This key is
 # mutually exclusive with 'license'
-license_file: LICENSE
+#
+# We prefer specifying "license" instead because we have 2 files: LICENSE (GPLv2), and COPYRIGHT (which says
+# v2 or later.)
+# license_file: LICENSE
 
 # A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
 # requirements as 'namespace' and 'name'
@@ -40,9 +43,9 @@ tags:
   - pulp
   - pulpcore
   - content
-  - software-repositories
-  - lifecycle-management
-  - content-delivery
+  - software_repositories
+  - lifecycle_management
+  - content_delivery
 
 # Collections that this collection requires to be installed for it to be usable. The key of the dict is the
 # collection label 'namespace.name'. The value is a version range


### PR DESCRIPTION
Solution: Fix license metadata in 2 ways:
1. tags need underscores
2. license_file could not be specified in addition to license

These were done manually during 3.4.0 import time.

[noissue]