### PR TITLE
Problem: pre-flight check often errors when pip-tools is too old

### DIFF
--- a/CHANGES/6864.bugfix
+++ b/CHANGES/6864.bugfix
@@ -1,0 +1,1 @@
+Ensure that pip-tools is at least 5.2.0, so that the pre-flight (compatibility) check does not error on the attribute "editable".

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -181,7 +181,7 @@
 
     - name: Install pip-tools, which provides pip-compile to check version compatibility
       pip:
-        name: pip-tools
+        name: pip-tools>=5.2.0
         state: present
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'


### PR DESCRIPTION
Solution: Make sure it is at least 5.2.0.

Fixes the error:
"AttributeError: 'ParsedRequirement' object has no attribute 'editable'"

fixes: #6864