### PR TITLE
Switch to using pulp-fixtures from docker

### DIFF
--- a/roles/pulp_devel/templates/alias.bashrc.j2
+++ b/roles/pulp_devel/templates/alias.bashrc.j2
@@ -150,7 +150,7 @@ pfixtures () {
     jq "setpath([\"custom\",\"fixtures_origin\"]; \"http://localhost:8000/fixtures/\")" > /tmp/temp_pfixtures.json
     cat /tmp/temp_pfixtures.json > ~/.config/pulp_smash/settings.json
     rm /tmp/temp_pfixtures.json
-    podman run -d --rm -p 8000:80 quay.io/pulp/pulp-fixtures:latest
+    podman run -d --rm -p 8000:80 docker.io/pulp/pulp-fixtures:latest
 }
 _pfixtures_help="Run pulp-fixtures container in foreground"
 


### PR DESCRIPTION
We publish to both quay and docker hub but the latter seems to have
better reliability.

[noissue]