### PR TITLE
LD_LIBRARY_PATH: Allow one to specify a specific path

### DIFF
--- a/CHANGES/6913.misc
+++ b/CHANGES/6913.misc
@@ -1,0 +1,1 @@
+Allow one to specify a `pulp_ld_library_path` when wanted

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -109,6 +109,8 @@ This role is required by the `pulp_database` role and uses some variables from i
 
 * `pulp_settings_db_defaults`: See pulp_database README.
 
+* `pulp_ld_library_path`: An optional LD_LIBRARY_PATH environment variable for the pulpcore-api systemd process
+
 Operating System Variables
 --------------------------
 

--- a/roles/pulp/templates/pulpcore-api.service.j2
+++ b/roles/pulp/templates/pulpcore-api.service.j2
@@ -7,6 +7,9 @@ Wants=network-online.target
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS={{ pulp_settings_file }}"
 Environment="PATH={{ pulp_install_dir }}/bin:{{ default_bin_path }}"
+{% if pulp_ld_library_path is defined and pulp_ld_library_path != '' %}
+Environment="LD_LIBRARY_PATH={{ pulp_ld_library_path }}"
+{% endif %}
 User={{ pulp_user }}
 PIDFile=/run/pulpcore-api.pid
 RuntimeDirectory=pulpcore-api

--- a/roles/pulp_content/README.md
+++ b/roles/pulp_content/README.md
@@ -26,3 +26,4 @@ these values are **required**.
 * `pulp_install_dir`
 * `pulp_config_dir`
 * `pulp_settings_file`
+* `pulp_ld_library_path`: An optional LD_LIBRARY_PATH environment variable for the pulpcore-content systemd process

--- a/roles/pulp_content/templates/pulpcore-content.service.j2
+++ b/roles/pulp_content/templates/pulpcore-content.service.j2
@@ -7,6 +7,9 @@ Wants=network-online.target
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS={{ pulp_settings_file }}"
 Environment="PATH={{ pulp_install_dir }}/bin:{{ default_bin_path }}"
+{% if pulp_ld_library_path is defined and pulp_ld_library_path != '' %}
+Environment="LD_LIBRARY_PATH={{ pulp_ld_library_path }}"
+{% endif %}
 User={{ pulp_user }}
 WorkingDirectory=/var/run/pulpcore-content/
 RuntimeDirectory=pulpcore-content

--- a/roles/pulp_resource_manager/README.md
+++ b/roles/pulp_resource_manager/README.md
@@ -34,6 +34,7 @@ the role. When not used together, these values are **required**.
 
 * `pulp_config_dir`
 * `pulp_settings_file`
+* `pulp_ld_library_path`: An optional LD_LIBRARY_PATH environment variable for the pulpcore-resource-manager systemd process
 
 Dependencies
 ------------

--- a/roles/pulp_resource_manager/templates/pulpcore-resource-manager.service.j2
+++ b/roles/pulp_resource_manager/templates/pulpcore-resource-manager.service.j2
@@ -7,6 +7,9 @@ Wants=network-online.target
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS={{ pulp_settings_file }}"
 Environment="PATH={{ pulp_install_dir }}/bin:{{ default_bin_path }}"
+{% if pulp_ld_library_path is defined and pulp_ld_library_path != '' %}
+Environment="LD_LIBRARY_PATH={{ pulp_ld_library_path }}"
+{% endif %}
 User={{ pulp_user }}
 WorkingDirectory=/var/run/pulpcore-resource-manager/
 RuntimeDirectory=pulpcore-resource-manager

--- a/roles/pulp_workers/README.md
+++ b/roles/pulp_workers/README.md
@@ -32,6 +32,7 @@ the role. When not used together, these values are **required**.
 * `pulp_config_dir`
 * `pulp_settings_file`
 * `pulp_group`
+* `pulp_ld_library_path`: An optional LD_LIBRARY_PATH environment variable for the pulpcore-workers systemd process
 
 Dependencies
 ------------

--- a/roles/pulp_workers/templates/pulpcore-worker@.service.j2
+++ b/roles/pulp_workers/templates/pulpcore-worker@.service.j2
@@ -9,6 +9,9 @@ EnvironmentFile=-/etc/default/pulp-workers-%i
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS={{ pulp_settings_file }}"
 Environment="PATH={{ pulp_install_dir }}/bin:{{ default_bin_path }}"
+{% if pulp_ld_library_path is defined and pulp_ld_library_path != '' %}
+Environment="LD_LIBRARY_PATH={{ pulp_ld_library_path }}"
+{% endif %}
 User={{ pulp_user }}
 Group={{ pulp_group }}
 WorkingDirectory=/var/run/pulpcore-worker-%i/


### PR DESCRIPTION
When using SCL, per its pattern, the LD_LIBRARY_PATH needs to be
specified in order for the libraries/binariess to find the "right"
version.

The scripts dropped in `/etc/profile.d` are working for login shells
but tasks we are running are using the pulp user which has no login
shell (/sbin/nologin).

Given `rh-postgresql96` is currently used (and `postgresql-devel-9.2`)
gets installed during installation the lack of explicitly specifying it
might have gone un-noticed.

But when dealing with replacing `rh-postgresql96` by `rh-postgresql10`
(and all related files) or simply installing the
`rh-postgresql10-postgresql-libs` and `rh-postgresql10-postgresql-devel`
to connect to a PG10 server setup else where it fails with the following
errors:

 * django.db.utils.OperationalError: SCRAM authentication requires libpq
   version 10 or above

 * /opt/rh/rh-postgresql10/root/bin/initdb: error while loading shared
   libraries: libpq.so.rh-postgresql10-5: cannot open shared object
   file: No such file or directory

Issue: https://pulp.plan.io/issues/6913
fixes: #6913