### PR TITLE
Unify use of `pulp_content_bind` and `pulp_api_bind`

### DIFF
--- a/CHANGES/6921.feature
+++ b/CHANGES/6921.feature
@@ -1,0 +1,3 @@
+Unify the use of `pulp_content_bind` and `pulp_api_bind` across all network facing role. this
+inherently allow one to rely on Unix Domain Socket (UDS) if wanted based on the deployment
+scenario.

--- a/CHANGES/6921.removal
+++ b/CHANGES/6921.removal
@@ -1,0 +1,3 @@
+The `pulp_api_host` (127.0.0.1) and `pulp_api_port` (24817) have been removed and replaced by
+`pulp_api_bind` (127.0.0.1:24817). Same happened for `pulp_content_host` and `pulp_content_port`
+in favor of `pulp_content_bind`.

--- a/roles/pulp_webserver/README.md
+++ b/roles/pulp_webserver/README.md
@@ -12,14 +12,6 @@ Variables
 
 * `pulp_webserver_server` Set the webserver Pulp should use to reverse proxy with. Defaults to
   'nginx'.
-* `pulp_content_port` Set the port the reverse proxy should connect to for the Content app. Defaults
-  to '24816'.
-* `pulp_content_host` Set the host the reverse proxy should connect to for the Content app. Defaults
-  to '127.0.0.1'.
-* `pulp_api_port` Set the port the reverse proxy should connect to for the API server. Defaults to
-  '24817'.
-* `pulp_api_host` Set the host the reverse proxy should connect to for the API server. Defaults to
-  '127.0.0.1'.
 * `pulp_configure_firewall` Install and configure a firewall. Valid values are 'auto', 'firewalld',
   and 'none'. Defaults to 'auto' (which is the same as 'firewalld', but may change in the future).
 
@@ -73,3 +65,7 @@ role.
   to look for and use.
 
 * `pulp_user_home`: equivalent to `MEDIA_ROOT` from `pulpcore` i.e. absolute path for pulp user home.
+* `pulp_content_bind` Set the host the reverse proxy should connect to for the Content app. Defaults
+  to '127.0.0.1:24816'.
+* `pulp_api_bind` Set the host the reverse proxy should connect to for the API server. Defaults
+  to '127.0.0.1:24817'.

--- a/roles/pulp_webserver/defaults/main.yml
+++ b/roles/pulp_webserver/defaults/main.yml
@@ -1,8 +1,6 @@
 ---
 pulp_webserver_server: nginx
-pulp_content_host: 127.0.0.1
-pulp_content_port: 24816
-pulp_api_host: 127.0.0.1
-pulp_api_port: 24817
+pulp_content_bind: '127.0.0.1:24816'
+pulp_api_bind: '127.0.0.1:24817'
 pulp_configure_firewall: auto
 pulp_user_home: '/var/lib/pulp'

--- a/roles/pulp_webserver/templates/nginx.conf.j2
+++ b/roles/pulp_webserver/templates/nginx.conf.j2
@@ -23,11 +23,11 @@ http {
     types_hash_max_size 4096;
 
     upstream pulp-content {
-         server {{ pulp_content_host }}:{{ pulp_content_port }};
+        server {{ pulp_content_bind }};
     }
 
     upstream pulp-api {
-         server {{ pulp_api_host }}:{{ pulp_api_port }};
+        server {{ pulp_api_bind }};
     }
 
     server {

--- a/roles/pulp_webserver/templates/pulp-vhost.conf.j2
+++ b/roles/pulp_webserver/templates/pulp-vhost.conf.j2
@@ -1,5 +1,5 @@
-Define pulp-content {{ pulp_content_host }}:{{ pulp_content_port }}
-Define pulp-api {{ pulp_api_host }}:{{ pulp_api_port }}
+Define pulp-content {{ pulp_content_bind }}
+Define pulp-api {{ pulp_api_bind }}
 
 <VirtualHost *:80>
   ServerName {{ ansible_nodename }}


### PR DESCRIPTION
In its current state, the installer relies on `pulp_content_bind` and
`pulp_api_bind` for the following roles: `pulp` and `pulp_content`.
Yet, for `pulp_webserver` it relies on a new set of parameters for the
exact same purposes (note: those parameters are only used in this role);
namely: `pulp_content_host`, `pulp_content_port`, `pulp_api_host` and
`pulp_api_port`.

While it would be less error prone to follow the 'define it once use
it everywhere pattern', the following PR also allows has the benefit
of:

  * Enabling the use of Unix Domain Socket (UDS) to improve scale
    (ie. `/var/run/pulpcore-api/pulpcore-api.sock`) and apply best
    practice (if you only deal with localhost you don't need to get
    the network stack involved)

  * Pave the way for a better IPv6 integration. 127.0.0.1 doesn't
    exist in IPv6 only servers. By using UDS as previously mentionned
    this limitation becomes void for those two (api and content)
    components

fixes #6921