### PR TITLE
pulp_webserver: Listen for IPv6 connections

### DIFF
--- a/CHANGES/6923.feature
+++ b/CHANGES/6923.feature
@@ -1,0 +1,1 @@
+Allow Nginx to listen for both IPv4 and IPv6 connections.

--- a/roles/pulp_webserver/templates/nginx.conf.j2
+++ b/roles/pulp_webserver/templates/nginx.conf.j2
@@ -1,4 +1,3 @@
-# TODO: Support IPv6.
 # TODO: Configure SSL certificates.
 # TODO: Maybe serve multiple `location`s, not just one.
 
@@ -34,6 +33,7 @@ http {
     server {
         # Gunicorn docs suggest the use of the "deferred" directive on Linux.
         listen 80 default_server deferred;
+        listen [::]:80 default_server deferred;
         server_name $hostname;
 
         # The default client_max_body_size is 1m. Clients uploading


### PR DESCRIPTION
Currently Nginx configuration is hard coded to be IPv4 only.
This commit makes it so it listen for both IPv4 and IPv6 connections.

For the httpd conffiguration, the piece that defines whether or not we
listen to ipv6 is outside the pulp/pulp_installer scope.

fixes #6923