### PR TITLE
pulp_redis: Allow to configure Unix Domain Socket

### DIFF
--- a/CHANGES/6931.feature
+++ b/CHANGES/6931.feature
@@ -1,0 +1,1 @@
+Allow a user to use Unix Domain Socket (UDS) for the redis server.

--- a/roles/pulp_redis/README.md
+++ b/roles/pulp_redis/README.md
@@ -3,6 +3,12 @@ pulp_redis
 
 Install and start Redis, and install RQ in the Pulp virtualenv.
 
+Role Variables
+--------------
+
+* `pulp_redis_bind`: Interface and Port where Redis service will listen. One can specify a unix
+   path (ie. 'unix:/var/run/redis/redis.sock'). Defaults to `127.0.0.1:6379`
+
 Shared Variables
 ----------------
 

--- a/roles/pulp_redis/defaults/main.yml
+++ b/roles/pulp_redis/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 pulp_install_dir: '/usr/local/lib/pulp'
 pulp_user: pulp
+pulp_redis_bind: '127.0.0.1:6379'

--- a/roles/pulp_redis/handlers/main.yml
+++ b/roles/pulp_redis/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart redis
+  systemd:
+    name: "{{ pulp_redis_server_name }}"
+    state: restarted
+    daemon_reload: true

--- a/roles/pulp_redis/tasks/configure_tcp.yml
+++ b/roles/pulp_redis/tasks/configure_tcp.yml
@@ -1,0 +1,17 @@
+---
+- name: Set pulp_redis_host and pulp_redis_port fact
+  set_fact:
+    pulp_redis_host: '{{ pulp_redis_bind.split(":")[0] }}'
+    pulp_redis_port: '{{ pulp_redis_bind.split(":")[1] }}'
+
+- name: Ensure Redis will listen on the specified TCP socket
+  lineinfile:
+    path: '{{ pulp_redis_conf_file }}'
+    regexp: '{{ item.regexp }}'
+    line: '{{ item.line }}'
+  loop:
+    - regexp: '^port '
+      line: 'port {{ pulp_redis_port }}'
+    - regexp: '^bind '
+      line: 'bind {{ pulp_redis_host }}'
+  notify: restart redis

--- a/roles/pulp_redis/tasks/configure_uds.yml
+++ b/roles/pulp_redis/tasks/configure_uds.yml
@@ -1,0 +1,24 @@
+---
+- name: Configure pulp_redis_socket_file fact
+  set_fact:
+    pulp_redis_socket_file: '{{ pulp_redis_bind | replace("unix:", "") }}'
+
+- name: Ensure pulp is part of group redis
+  user:
+    name: '{{ pulp_user }}'
+    groups: redis
+    append: true
+
+- name: Ensure Redis will not listen on a TCP socket
+  lineinfile:
+    path: '{{ pulp_redis_conf_file }}'
+    regexp: '{{ item.regexp }}'
+    line: '{{ item.line }}'
+  loop:
+    - regexp: '^port '
+      line: 'port 0'
+    - regexp: '^unixsocket '
+      line: 'unixsocket {{ pulp_redis_socket_file }}'
+    - regexp: '^unixsocketperm '
+      line: 'unixsocketperm 775'
+  notify: restart redis

--- a/roles/pulp_redis/tasks/main.yml
+++ b/roles/pulp_redis/tasks/main.yml
@@ -32,6 +32,14 @@
         name: redis
         state: present
 
+    - name: Configure Redis to listen on Unix Domain Socket
+      include_tasks: configure_uds.yml
+      when: "pulp_redis_bind.startswith('unix:')"
+
+    - name: Configure Redis to listen on TCP socket
+      include_tasks: configure_tcp.yml
+      when: "not pulp_redis_bind.startswith('unix:')"
+
     - name: Start Redis
       systemd:
         name: "{{ pulp_redis_server_name }}"

--- a/roles/pulp_redis/vars/CentOS.yml
+++ b/roles/pulp_redis/vars/CentOS.yml
@@ -3,3 +3,4 @@ pulp_preq_packages:
   - python36
   - python36-devel
 pulp_redis_server_name: redis
+pulp_redis_conf_file: '/etc/redis.conf'

--- a/roles/pulp_redis/vars/Debian.yml
+++ b/roles/pulp_redis/vars/Debian.yml
@@ -3,4 +3,5 @@ pulp_preq_packages:
   - python3
   - python3-dev
 pulp_redis_server_name: redis-server
+pulp_redis_conf_file: '/etc/redis/redis.conf'
 ...

--- a/roles/pulp_redis/vars/Fedora.yml
+++ b/roles/pulp_redis/vars/Fedora.yml
@@ -4,3 +4,4 @@ pulp_preq_packages:
   - python3-devel
 
 pulp_redis_server_name: redis
+pulp_redis_conf_file: '/etc/redis.conf'

--- a/roles/pulp_redis/vars/Ubuntu.yml
+++ b/roles/pulp_redis/vars/Ubuntu.yml
@@ -3,3 +3,4 @@ pulp_preq_packages:
   - python3
   - python3-dev
 pulp_redis_server_name: redis-server
+pulp_redis_conf_file: '/etc/redis/redis.conf'


### PR DESCRIPTION
This commit ensures one can configure redis so it listens to unix domain
socket (if wanted) rather than forcing it to listen on TCP socket.

Benefits of this commit has been higlighted in previous PR[1].

Also, this commit introduces `pulp_redis_bind` to offer an expected
experience for people using `pulp/pulp_installer` when it comes to
configure network services (ie. `pulp_api_bind`, `pulp_content_bind`).

fixes #6931

[1] https://github.com/pulp/pulp_installer/pull/322