### PR TITLE
Problem: pulp_installer doesn't install webserver snippets

### DIFF
--- a/CHANGES/6956.bugfix
+++ b/CHANGES/6956.bugfix
@@ -1,0 +1,1 @@
+Fix webserver snippets not being installed when pulp_install_dir is changed from the default value.

--- a/roles/pulp_webserver/tasks/apache.yml
+++ b/roles/pulp_webserver/tasks/apache.yml
@@ -46,10 +46,11 @@
       script:
         cmd: check_snippet.py {{ item.key | regex_replace("-", "_") | quote }} apache.conf
       args:
-        executable: /usr/local/lib/pulp/bin/python
+        executable: "{{ pulp_install_dir }}/bin/python"
       register: snippets
       with_dict: '{{ pulp_install_plugins_normalized }}'
-      failed_when: false
+      failed_when: >
+        snippets.stderr is search("env: 'python': No such file or directory")
       changed_when: false
       check_mode: false
 

--- a/roles/pulp_webserver/tasks/nginx.yml
+++ b/roles/pulp_webserver/tasks/nginx.yml
@@ -56,10 +56,11 @@
       script:
         cmd: check_snippet.py {{ item.key | regex_replace("-", "_") | quote }} nginx.conf
       args:
-        executable: /usr/local/lib/pulp/bin/python
+        executable: "{{ pulp_install_dir }}/bin/python"
       register: snippets
       with_dict: '{{ pulp_install_plugins_normalized }}'
-      failed_when: false
+      failed_when: >
+        snippets.stderr is search("env: 'python': No such file or directory")
       changed_when: false
       check_mode: false
 


### PR DESCRIPTION
when pulp_install_dir is changed

Solution: Use pulp_install_dir rather than hardcode the path.

Also fail the task if the python intepreter is not found.

fixes: #6956