### PR TITLE
problem: pulp_installer doesn't document required variables

### DIFF
--- a/CHANGES/6958.bugfix
+++ b/CHANGES/6958.bugfix
@@ -1,0 +1,2 @@
+Fix documentation about certain variables being required, and error early with clear error messages
+if they are unset or set to empty strings.

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ Thus you, yourself, must research plugin compatibility with the pulpcore version
 installing 1 plugin, or more than 1 plugin.
 
 Recommended Workflows for Pulpcore & Plugin Versioning
------------------------------------------------------
+------------------------------------------------------
 
 ### Latest Version with Minimal Work:
 

--- a/roles/pulp/README.md
+++ b/roles/pulp/README.md
@@ -7,12 +7,24 @@ The default administrative user for the Pulp application is: 'admin'
 
 Role Variables
 --------------
-* `pulp_install_plugins`: A nested dictionary of plugin configuration options.
-  Defaults to "{}", which will not install any plugins.
-    * *Dictionary Key*: The pip installable plugin name. This is defined in each plugin's `setup.py`. **Required**.
-    * `version`: Specific release of the plugin to install from PyPI. If `source_dir` is set, this has no effect. Note that if the specified release of the plugin is incompatible with pulpcore's version, pulp_installer will fail (and exit the play) when it goes to install or upgrade the plugin. Defaults to nothing.
-    * `version` and `upgrade` **cannot be used together**. Even though a command like `pip install --upgrade pulp-file=0.3.0` is valid, the ansible pip module refuses to let you specify version and `state=latest` (`state=latest` maps to `pip --upgrade`, and to our upgrade: true).
-    * `upgrade`: Whether to update/upgrade the plugin to the latest stable release from PyPI. Only affects systems where the plugin is already installed. If `source_dir` is set, this has no effect and is effectively always `true`. Mutually exclusive with `version`. Note that if the latest stable release of the plugin is incompatible with pulpcore's version, pulp_installer will fail (and exit the play) when it goes to upgrade the plugin. Defaults to "false".
+* `pulp_install_plugins`: **Required** A nested dictionary of plugins to install & their
+  installation options.
+    * *Dictionary Key*: **Required**. The pip installable plugin name. This is defined in each
+    plugin's `setup.py`.
+    * `version`: Specific release of the plugin to install from PyPI initially, or to upgrade to.
+    If `source_dir` is set, this has no effect. Note that if the specified release of the plugin is
+    incompatible with pulpcore's version, pulp_installer will fail (and exit the play) before it
+    tries to install or upgrade the plugin. Defaults to nothing, which means the latest release from
+    PyPI will be installed initially, and no upgrades will be performed unless `upgrade` is set.
+    * `version` and `upgrade` **cannot be used together**. Even though a command like `pip install
+    --upgrade pulp-file=0.3.0` is valid, the ansible pip module refuses to let you specify version
+    and `state=latest` (`state=latest` maps to `pip --upgrade`, and to our upgrade: true).
+    * `upgrade`: Whether to update/upgrade the plugin to the latest stable release from PyPI.
+    Only affects systems where the plugin is already installed. If `source_dir` is set,
+    this has no effect and is effectively always `true`. Mutually exclusive with `version`.
+    Note that if the latest stable release of the plugin is incompatible with pulpcore's version,
+    pulp_installer will fail (and exit the play) when it goes to upgrade the plugin.
+    Defaults to "false".
     * `source_dir`: Optional. Absolute path to the plugin source code. If present,
   plugin will be installed from source in editable mode.
   Also accepts a pip VCS URL, to (for example) install the master branch.
@@ -32,7 +44,7 @@ Role Variables
       pulp-three:
         source_dir: "/var/lib/pulp/pulp_three" # path to the plugin source code
       pulp-four:
-        prereq_role: "pulp.pulp_three_role" # role to run immediately before the venv is created
+        prereq_role: "pulp.pulp_four_role" # role to run immediately before the venv is created
     ```
 * `pulp_install_api_service`: Whether to create systemd service files for
   pulpcore-api. Defaults to "true".
@@ -109,9 +121,8 @@ RPM packages instead if this variable is set. Other distro packaging formats may
   Defaults to "pip".
 
 If it is set to "packages", the following variables are used, or behave *differently* from above:
-* `pulp_install_plugins`: A nested dictionary of plugin configuration options.
-  Defaults to "{}", which will not install any plugins.
-    * *Dictionary Key*: The plugin name. **Required**.
+* `pulp_install_plugins`: **Required** A nested dictionary of plugins to install & their installation options.
+    * *Dictionary Key*: **Required**. The plugin name.
     * `pkg_name`: If this is left undefined, each Linux distro package will be installed by the name `pulp_pkg_name_prefix`
     with the Dictionary Key appended to it. `pulp_pkg_name_prefix` defaults to "python3-", so if the Dictionary key is, "pulp-file",
     the package `python3-pulp-file` will be installed. This variable overrides the entire package name.

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -5,7 +5,6 @@ pulp_config_dir: '/etc/pulp'
 # This var intentionally not advertised to users, because there is no
 # foreseeable need for them to change the filename, only pulp_config_dir.
 pulp_settings_file: '{{ pulp_config_dir }}/settings.py'
-pulp_default_admin_password: ''
 # Users should not set this variable, instead using `pulp_settings.databases`
 pulp_settings_db_defaults:
   databases:
@@ -17,7 +16,6 @@ pulp_settings_db_defaults:
       PASSWORD: pulp
 pulp_install_source: pip
 pulp_install_dir: '{{ (pulp_install_source == "packages") | ternary("/usr", "/usr/local/lib/pulp") }}'
-pulp_install_plugins: {}
 pulp_install_api_service: true
 # Deprecated unused. Variables for dependency upgrades are TBD
 pulp_upgrade: false

--- a/roles/pulp/tasks/main.yml
+++ b/roles/pulp/tasks/main.yml
@@ -1,9 +1,5 @@
 ---
 
-- name: Fail when pulp_secret_key is not set
-  assert:
-    that: pulp_settings.secret_key is defined
-
 - debug:
     var: pulp_install_plugins
     verbosity: 1
@@ -13,6 +9,27 @@
 - debug:
     var: pulp_install_plugins_normalized
     verbosity: 1
+
+- name: Check if required variables are set
+  assert:
+    that:
+      # This check runs it through jinja2 templating twice: built-in
+      # "that:" (like when:), and then the {{ }}
+      # It converts from item, to the string like pulp_default_admin_password ,
+      # to the value of pulp_default_admin_password .
+      - "{{ item }} | default('', true) | length > 0"
+    fail_msg: >
+      {{ item }} is undefined, null, an empty string, or an empty dictionary "{}" . Please
+      set it in your variables
+      (e.g. pulp_installer/playbooks/example-use/group_vars/all)
+      and run pulp_installer again.
+      See https://pulp-installer.readthedocs.io/en/latest/ or
+      pulp_installer/roles/pulp/README.md for more info.
+  loop:
+    - pulp_default_admin_password
+    - pulp_settings.content_origin
+    - pulp_settings.secret_key
+    - pulp_install_plugins
 
 - name: Load OS specific variables
   include_vars: "{{ lookup('first_found', params) }}"

--- a/roles/pulp_devel/README.md
+++ b/roles/pulp_devel/README.md
@@ -16,11 +16,16 @@ Example Usage
 Variables
 ---------
 
-The variables that this role uses, along with their default values, are listed
-below:
+The variables that this role uses are listed below:
 
+The following variables have a default value:
 ```yaml
 pulp_devel_package_retries: 5
+```
+
+The following variables have no default value, and we recommend the following
+for development purposes on vagrant (as part of [pulplift](https://github.com/pulp/pulplift).)
+```yaml
 developer_user: vagrant
 developer_user_home: /home/vagrant
 pulp_default_admin_password: password


### PR DESCRIPTION
correctly or provide clear errors if they are unset

Solution:
1. Error early if they are null, unset an empty string, or
an empty dict with a clearer error message.
2. Remove pointless setting of some to empty values.
3. Correct the documentation: They have no default values.

fixes: #6958

Test vars:
```
pulp_install_plugins: {}
  # galaxy-ng: {}
  # pulp-ansible: {}
  # pulp-certguard: {}
  # pulp-container: {}
  # pulp-cookbook: {}
  # pulp-deb: {}
  # pulp-file: {}
  # pulp-gem: {}
  # pulp-maven: {}
  # pulp-npm: {}
  # pulp-python: {}
  # pulp-rpm:
  #   prereq_role: "pulp.pulp_rpm_prerequisites" # RPM needs a prereq_role: https://galaxy.ansible.com/pulp/pulp_rpm_prerequisites
pulp_settings:
  secret_key:
  content_origin: ""
```
