### PR TITLE
pulp: Add rhel-7-server-rhui-optional-rpms as RHEL7 repo

### DIFF
--- a/CHANGES/6960.bugfix
+++ b/CHANGES/6960.bugfix
@@ -1,0 +1,1 @@
+Add new RHUI repo name `rhel-7-server-rhui-optional-rpms` in `rhel7_optional_repo`.

--- a/roles/pulp/defaults/main.yml
+++ b/roles/pulp/defaults/main.yml
@@ -41,6 +41,7 @@ pulp_rhel_codeready_repo:
   - codeready-builder-for-rhel-8-rhui-rpms
 rhel7_optional_repo:
   - rhui-rhel-7-server-rhui-optional-rpms
+  - rhel-7-server-rhui-optional-rpms
   - rhel-7-server-optional-rpms
   - rhel-7-workstation-optional-rpms
 epel_release_packages:


### PR DESCRIPTION
The repository name provided by RHUI has changed in a recent update.

Before

```
[root@ip-10-0-12-140 yum.repos.d]# rpm -qa | grep rh-
rh-amazon-rhui-client-3.0.18-1.el7.noarch
[root@ip-10-0-12-140 yum.repos.d]# grep 'optional-rpms' redhat-rhui.repo
[rhui-rhel-7-server-rhui-optional-rpms]
```

Now

```
[root@ip-10-0-12-58 yum.repos.d]# rpm -qa | grep rh-
rh-amazon-rhui-client-3.0.28-1.el7.noarch
[root@ip-10-0-12-58 yum.repos.d]# grep 'optional-rpms' redhat-rhui.repo
[rhel-7-server-rhui-optional-rpms]
```

fixes #6960