### PR TITLE
cluster: Allow installer to finish with no failures

### DIFF
--- a/CHANGES/6973.misc
+++ b/CHANGES/6973.misc
@@ -1,0 +1,1 @@
+Do not run db migration several time if deploying a cluster scenario.

--- a/roles/pulp_database/tasks/main.yml
+++ b/roles/pulp_database/tasks/main.yml
@@ -48,6 +48,7 @@
       no_log: true
       when: pulp_default_admin_password is defined and migrate_auth.changed
 
+  run_once: true
   become: true
   become_user: '{{ pulp_user }}'
   environment:


### PR DESCRIPTION
Currently running the installer in cluster setup will trigger 2 errors
becauee it tries to run the db migration more than one time.

The following commit ensures that db migration are just run once from
the pool of node selected.

fix #6973