### PR TITLE
Drop hardcoded Redis dependency

### DIFF
--- a/CHANGES/6975.misc
+++ b/CHANGES/6975.misc
@@ -1,0 +1,1 @@
+Removed pulp-redis dependency from pulp_workers and pulp_resource_manager

--- a/molecule/release-dynamic/converge.yml
+++ b/molecule/release-dynamic/converge.yml
@@ -13,6 +13,7 @@
       include_role:
         name: "{{ roleinputvar }}"
       loop:
+        - pulp_redis
         - pulp_database
         - pulp_workers
         - pulp_resource_manager

--- a/molecule/source-dynamic/converge.yml
+++ b/molecule/source-dynamic/converge.yml
@@ -13,6 +13,7 @@
       include_role:
         name: "{{ roleinputvar }}"
       loop:
+        - pulp_redis
         - pulp_database
         - pulp_workers
         - pulp_resource_manager

--- a/playbooks/example-source/playbook.yml
+++ b/playbooks/example-source/playbook.yml
@@ -9,6 +9,7 @@
         msg: >
           "You must update Ansible to at least 2.8 to use this version of Pulp 3 Installer."
   roles:
+    - pulp_redis
     - pulp_database
     - pulp_workers
     - pulp_resource_manager

--- a/playbooks/example-use/playbook.yml
+++ b/playbooks/example-use/playbook.yml
@@ -9,6 +9,7 @@
         msg: >
           "You must update Ansible to at least 2.8 to use this version of Pulp 3 Installer."
   roles:
+    - pulp_redis
     - pulp_database
     - pulp_workers
     - pulp_resource_manager

--- a/roles/pulp_resource_manager/defaults/main.yml
+++ b/roles/pulp_resource_manager/defaults/main.yml
@@ -3,3 +3,5 @@ pulp_resource_manager_state: started
 pulp_resource_manager_enabled: true
 pulp_config_dir: "/etc/pulp"
 pulp_settings_file: "{{ pulp_config_dir }}/settings.py"
+pulp_install_dir: '/usr/local/lib/pulp'
+pulp_user: pulp

--- a/roles/pulp_resource_manager/meta/main.yml
+++ b/roles/pulp_resource_manager/meta/main.yml
@@ -21,5 +21,3 @@ galaxy_info:
   galaxy_tags:
     - pulp
     - pulpcore
-dependencies:
-  - pulp_redis

--- a/roles/pulp_workers/defaults/main.yml
+++ b/roles/pulp_workers/defaults/main.yml
@@ -3,3 +3,5 @@ pulp_config_dir: "/etc/pulp"
 pulp_settings_file: "{{ pulp_config_dir }}/settings.py"
 pulp_group: pulp
 pulp_workers: 2
+pulp_install_dir: '/usr/local/lib/pulp'
+pulp_user: pulp

--- a/roles/pulp_workers/meta/main.yml
+++ b/roles/pulp_workers/meta/main.yml
@@ -21,5 +21,3 @@ galaxy_info:
   galaxy_tags:
     - pulp
     - pulpcore
-dependencies:
-  - pulp_redis


### PR DESCRIPTION
In order to embrace a Service Oriented Architecture, where things like
Postgres and Redis could be run anywhere (localhost, other machine on
the network, SaaS offering) having an hardcoded requirement on those
services to be installed along side pulp services ian'r oprimal.

With this commit, if one wants to install Redis, onc would need to
explicitly list it in the role list one wants installed. But if one
wants to use a SaaS offering, simply specifying `redis_host` or
`redis_url` would work - without installing or running extra software on
the server.

fixes #6975