### PR TITLE
[WIP] Ensure resource-manager has a unique name when horizontally scaled

### DIFF
--- a/CHANGES/6979.misc
+++ b/CHANGES/6979.misc
@@ -1,0 +1,1 @@
+Ensure resource-manager has a unique name when horizontally scaled.

--- a/roles/pulp_resource_manager/templates/pulpcore-resource-manager.service.j2
+++ b/roles/pulp_resource_manager/templates/pulpcore-resource-manager.service.j2
@@ -14,7 +14,7 @@ User={{ pulp_user }}
 WorkingDirectory=/var/run/pulpcore-resource-manager/
 RuntimeDirectory=pulpcore-resource-manager
 ExecStart={{ pulp_install_dir }}/bin/rq worker \
-          -w pulpcore.tasking.worker.PulpWorker -n resource-manager \
+          -w pulpcore.tasking.worker.PulpWorker -n resource-manager-{{ inventory_hostname }} \
           --pid=/var/run/pulpcore-resource-manager/resource-manager.pid \
           -c 'pulpcore.rqconfig' \
           --disable-job-desc-logging


### PR DESCRIPTION
As a user I want to be able to horizontally scale my resource manager
services.

In its current state, the installer doesn't quite allow that because the
worker name is hardcoded[1]

Leading to the user being presented with:

```
rq[13249]: ValueError: There exists an active worker named
'resource-manager' already
```

fixes #6979