### PR TITLE
Ensure pulp3 works in an SELinux enforced system

### DIFF
--- a/CHANGES/6998.feature
+++ b/CHANGES/6998.feature
@@ -1,0 +1,1 @@
+Ensure pulp3 works in an SELinux enforced system.

--- a/roles/pulp/tasks/install.yml
+++ b/roles/pulp/tasks/install.yml
@@ -14,12 +14,6 @@
         name: '{{ pulp_preq_packages }}'
         state: present
 
-    - name: Disable SELinux (Pulp 3 is currently incompatible with SELinux)
-      selinux:
-        policy: targeted
-        state: permissive
-      when: ansible_os_family == 'RedHat'
-
     # Become root so as to search paths like /usr/sbin.
     - name: Find the nologin executable
       command: which nologin

--- a/roles/pulp_webserver/tasks/main.yml
+++ b/roles/pulp_webserver/tasks/main.yml
@@ -32,5 +32,15 @@
 
 - import_tasks: "{{ pulp_webserver_server }}.yml"
 
+- name: Set httpd_can_network_connect flag on and keep it persistent across reboots
+  seboolean:
+    name: httpd_can_network_connect
+    state: true
+    persistent: true
+  when:
+    - ansible_os_family == 'RedHat'
+    - ansible_selinux.status == 'enabled'
+    - not (pulp_api_bind.startswith('unix:') and pulp_content_bind.startswith('unix:'))
+
 - import_tasks: firewalld.yml
   when: pulp_configure_firewall in ['firewalld', 'auto']


### PR DESCRIPTION
In its current state pulp3 installs fine with SELInux enforced but fails
to execute, because nginx is trying to connect to another network
service (api and content - on port 24817 and port 24816).

While this is easily solved by the introduction of Unix Domain Socket in
https://github.com/pulp/pulp_installer/pull/322 one may still want to
use network services (if api is on another host) and hence the proper
SELinux flag must be set.

Flag to enable: httpd_can_network_connect

fixes #6998