### PR TITLE
Allow user to specify redis package and service name

### DIFF
--- a/CHANGES/6895.feature
+++ b/CHANGES/6895.feature
@@ -1,0 +1,1 @@
+Allow user to specify redis package and service name.

--- a/roles/pulp_redis/README.md
+++ b/roles/pulp_redis/README.md
@@ -8,6 +8,9 @@ Role Variables
 
 * `pulp_redis_bind`: Interface and Port where Redis service will listen. One can specify a unix
    path (ie. 'unix:/var/run/redis/redis.sock'). Defaults to `127.0.0.1:6379`
+* `pulp_redis_package_name`: Name of the redis package server to install. Defaults to: `redis`
+* `pulp_redis_server_name`: Name of the redis server service to run. Defaults to: OS specific
+* `pulp_redis_conf_file`: Path to the redis server configuration file. Defaults to: os specific
 
 Shared Variables
 ----------------

--- a/roles/pulp_redis/defaults/main.yml
+++ b/roles/pulp_redis/defaults/main.yml
@@ -2,3 +2,4 @@
 pulp_install_dir: '/usr/local/lib/pulp'
 pulp_user: pulp
 pulp_redis_bind: '127.0.0.1:6379'
+pulp_redis_package_name: redis

--- a/roles/pulp_redis/handlers/main.yml
+++ b/roles/pulp_redis/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart redis
   systemd:
-    name: "{{ pulp_redis_server_name }}"
+    name: "{{ pulp_redis_server_name | default(_pulp_redis_server_name) }}"
     state: restarted
     daemon_reload: true

--- a/roles/pulp_redis/tasks/configure_tcp.yml
+++ b/roles/pulp_redis/tasks/configure_tcp.yml
@@ -6,7 +6,7 @@
 
 - name: Ensure Redis will listen on the specified TCP socket
   lineinfile:
-    path: '{{ pulp_redis_conf_file }}'
+    path: '{{ pulp_redis_conf_file | default(_pulp_redis_conf_file) }}'
     regexp: '{{ item.regexp }}'
     line: '{{ item.line }}'
   loop:

--- a/roles/pulp_redis/tasks/configure_uds.yml
+++ b/roles/pulp_redis/tasks/configure_uds.yml
@@ -11,7 +11,7 @@
 
 - name: Ensure Redis will not listen on a TCP socket
   lineinfile:
-    path: '{{ pulp_redis_conf_file }}'
+    path: '{{ pulp_redis_conf_file | default(_pulp_redis_conf_file) }}'
     regexp: '{{ item.regexp }}'
     line: '{{ item.line }}'
   loop:

--- a/roles/pulp_redis/tasks/main.yml
+++ b/roles/pulp_redis/tasks/main.yml
@@ -29,8 +29,17 @@
 
     - name: Install Redis
       package:
-        name: redis
+        name: '{{ pulp_redis_package_name }}'
         state: present
+
+    - name: Enable Redis SCL
+      template:
+        src: templates/redis_scl_profile.j2
+        dest: "/etc/profile.d/redis.sh"
+      when:
+        - ansible_os_family == 'RedHat'
+        - ansible_distribution_major_version|int == 7
+        - pulp_redis_package_name.startswith('rh-')
 
     - name: Configure Redis to listen on Unix Domain Socket
       include_tasks: configure_uds.yml
@@ -42,7 +51,7 @@
 
     - name: Start Redis
       systemd:
-        name: "{{ pulp_redis_server_name }}"
+        name: "{{ pulp_redis_server_name | default(_pulp_redis_server_name) }}"
         state: started
         enabled: yes
         daemon_reload: yes

--- a/roles/pulp_redis/templates/redis_scl_profile.j2
+++ b/roles/pulp_redis/templates/redis_scl_profile.j2
@@ -1,0 +1,2 @@
+#!/bin/bash
+source scl_source enable {{ pulp_redis_package_name }}

--- a/roles/pulp_redis/vars/CentOS.yml
+++ b/roles/pulp_redis/vars/CentOS.yml
@@ -2,5 +2,5 @@
 pulp_preq_packages:
   - python36
   - python36-devel
-pulp_redis_server_name: redis
-pulp_redis_conf_file: '/etc/redis.conf'
+_pulp_redis_server_name: redis
+_pulp_redis_conf_file: '/etc/redis.conf'

--- a/roles/pulp_redis/vars/Debian.yml
+++ b/roles/pulp_redis/vars/Debian.yml
@@ -2,6 +2,6 @@
 pulp_preq_packages:
   - python3
   - python3-dev
-pulp_redis_server_name: redis-server
-pulp_redis_conf_file: '/etc/redis/redis.conf'
+_pulp_redis_server_name: redis-server
+_pulp_redis_conf_file: '/etc/redis/redis.conf'
 ...

--- a/roles/pulp_redis/vars/Fedora.yml
+++ b/roles/pulp_redis/vars/Fedora.yml
@@ -3,5 +3,5 @@ pulp_preq_packages:
   - python3
   - python3-devel
 
-pulp_redis_server_name: redis
-pulp_redis_conf_file: '/etc/redis.conf'
+_pulp_redis_server_name: redis
+_pulp_redis_conf_file: '/etc/redis.conf'

--- a/roles/pulp_redis/vars/Ubuntu.yml
+++ b/roles/pulp_redis/vars/Ubuntu.yml
@@ -2,5 +2,5 @@
 pulp_preq_packages:
   - python3
   - python3-dev
-pulp_redis_server_name: redis-server
-pulp_redis_conf_file: '/etc/redis/redis.conf'
+_pulp_redis_server_name: redis-server
+_pulp_redis_conf_file: '/etc/redis/redis.conf'


### PR DESCRIPTION
Currently redis package is hardcoded and a user can not overwrite it.
This commits aims to bring more flexibility while keeping the default
the same as they are today.

fixes #6895