### PR TITLE
Redis: Update doc for better experience

### DIFF
--- a/molecule/release-dynamic/converge.yml
+++ b/molecule/release-dynamic/converge.yml
@@ -13,8 +13,8 @@
       include_role:
         name: "{{ roleinputvar }}"
       loop:
-        - pulp_redis
         - pulp_database
+        - pulp_redis
         - pulp_workers
         - pulp_resource_manager
         - pulp_webserver

--- a/molecule/source-dynamic/converge.yml
+++ b/molecule/source-dynamic/converge.yml
@@ -13,8 +13,8 @@
       include_role:
         name: "{{ roleinputvar }}"
       loop:
-        - pulp_redis
         - pulp_database
+        - pulp_redis
         - pulp_workers
         - pulp_resource_manager
         - pulp_webserver

--- a/playbooks/example-source/playbook.yml
+++ b/playbooks/example-source/playbook.yml
@@ -9,8 +9,8 @@
         msg: >
           "You must update Ansible to at least 2.8 to use this version of Pulp 3 Installer."
   roles:
-    - pulp_redis
     - pulp_database
+    - pulp_redis
     - pulp_workers
     - pulp_resource_manager
     - pulp_webserver

--- a/playbooks/example-use/playbook.yml
+++ b/playbooks/example-use/playbook.yml
@@ -9,8 +9,8 @@
         msg: >
           "You must update Ansible to at least 2.8 to use this version of Pulp 3 Installer."
   roles:
-    - pulp_redis
     - pulp_database
+    - pulp_redis
     - pulp_workers
     - pulp_resource_manager
     - pulp_webserver


### PR DESCRIPTION
Redis requires epel to be install fot thre prereq packages
(python38-devel). The role per-se doesn't enable EPEL. So if we put it
after pulp_database that requires pulp then it will work out of the box
without user to have to enable EPEL themselves.

[noissue]