### PR TITLE
Problem: pulp_redis & pulp_database list pulp_install_dir

### DIFF
--- a/roles/pulp_database/README.md
+++ b/roles/pulp_database/README.md
@@ -32,7 +32,6 @@ This role **is tightly coupled** with the required the `pulp` role and uses some
 variables which are documented in that role:
 
 * `pulp_user`
-* `pulp_install_dir`
 * `pulp_default_admin_password`
 * `pulp_settings`
 

--- a/roles/pulp_redis/README.md
+++ b/roles/pulp_redis/README.md
@@ -19,9 +19,6 @@ variables. When used in the same play, the values are inherited from the `pulp`
 role. When not used together, this role provides identical defaults.
 
 * `pulp_user`: User that owns and runs Redis. Defaults to "pulp".
-* `pulp_install_dir`: Location of a virtual environment for Redis and its Python
-  dependencies. Defaults to "/usr/local/lib/pulp".
-
 
 Operating Systems Variables
 ---------------------------

--- a/roles/pulp_redis/defaults/main.yml
+++ b/roles/pulp_redis/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
-pulp_install_dir: '/usr/local/lib/pulp'
 pulp_user: pulp
 pulp_redis_bind: '127.0.0.1:6379'


### PR DESCRIPTION
as a variable they use, but they do not use it at all.

Solution: Remove it from README.md & defaults/main.yml

[noissue]