### PR TITLE
Do not call packages module iteratively

### DIFF
--- a/roles/pulp_redis/tasks/main.yml
+++ b/roles/pulp_redis/tasks/main.yml
@@ -23,9 +23,8 @@
 
     - name: Install requirements
       package:
-        name: "{{ item }}"
+        name: "{{ pulp_preq_packages }}"
         state: present
-      with_items: "{{ pulp_preq_packages }}"
 
     - name: Install Redis
       package:

--- a/roles/pulp_rpm_prerequisites/tasks/main.yml
+++ b/roles/pulp_rpm_prerequisites/tasks/main.yml
@@ -22,22 +22,11 @@
     - ansible_distribution == "Ubuntu"
   become: true
 
-# Much faster than the package module at installing multiple packages
-- name: Install requested RPM packages
-  yum:
-    name: '{{ item }}'
-    state: present
-  with_items: '{{ packages }}'
-  become: true
-  when: ansible_pkg_mgr in ["yum","dnf"]
-
 - name: Install requested non-RPM packages
   package:
-    name: '{{ item }}'
+    name: '{{ packages }}'
     state: present
-  with_items: '{{ packages }}'
   become: true
-  when: ansible_pkg_mgr not in ["yum","dnf"]
 
 - name: Fail if we do not have prereq_pip_packages
   fail:


### PR DESCRIPTION
This improves performance on one task, cleans up code for
another.

https://github.com/oasis-roles/meta_standards/blob/1.0.0/README.md
Avoid calling the package module iteratively with the {{ item }}
argument, as this is impressively more slow than calling it with
the line name: "{{ foo_packages }}". The same can go for many
other modules that can be given an entire list of items all at once.

[noissue]