### PR TITLE
pulp_webserver: Ensure we become root to set sebool

### DIFF
--- a/roles/pulp_webserver/tasks/main.yml
+++ b/roles/pulp_webserver/tasks/main.yml
@@ -37,6 +37,7 @@
     name: httpd_can_network_connect
     state: true
     persistent: true
+  become: true
   when:
     - ansible_os_family == 'RedHat'
     - ansible_selinux.status == 'enabled'


### PR DESCRIPTION
This was introduced by https://github.com/pulp/pulp_installer/commit/59dd134c472381735b3599d1a797fdea68f642c3. This commit was tested while being `root` on the machine.


[noissue]