### PR TITLE
systemd: Ensure services are started with Group pulp_group

### DIFF
--- a/CHANGES/7035.misc
+++ b/CHANGES/7035.misc
@@ -1,0 +1,3 @@
+Ensure `pulpcore-api`, `pulpcore-content` and `pulpcore-resource-manager` are started with
+group `{{ pulp_group }}`. Note: People will need to chgrp `{{ pulp_group }}` already existing
+path that are not created/managed by systemd; `/var/lib/pulp`.

--- a/roles/pulp_api/templates/pulpcore-api.service.j2
+++ b/roles/pulp_api/templates/pulpcore-api.service.j2
@@ -11,6 +11,7 @@ Environment="PATH={{ pulp_install_dir }}/bin:{{ default_bin_path }}"
 Environment="LD_LIBRARY_PATH={{ pulp_ld_library_path }}"
 {% endif %}
 User={{ pulp_user }}
+Group={{ pulp_group }}
 PIDFile=/run/pulpcore-api.pid
 RuntimeDirectory=pulpcore-api
 ExecStart={{ pulp_install_dir }}/bin/gunicorn pulpcore.app.wsgi:application \

--- a/roles/pulp_content/templates/pulpcore-content.service.j2
+++ b/roles/pulp_content/templates/pulpcore-content.service.j2
@@ -11,6 +11,7 @@ Environment="PATH={{ pulp_install_dir }}/bin:{{ default_bin_path }}"
 Environment="LD_LIBRARY_PATH={{ pulp_ld_library_path }}"
 {% endif %}
 User={{ pulp_user }}
+Group={{ pulp_group }}
 WorkingDirectory=/var/run/pulpcore-content/
 RuntimeDirectory=pulpcore-content
 ExecStart={{ pulp_install_dir }}/bin/gunicorn pulpcore.content:server \

--- a/roles/pulp_resource_manager/templates/pulpcore-resource-manager.service.j2
+++ b/roles/pulp_resource_manager/templates/pulpcore-resource-manager.service.j2
@@ -11,6 +11,7 @@ Environment="PATH={{ pulp_install_dir }}/bin:{{ default_bin_path }}"
 Environment="LD_LIBRARY_PATH={{ pulp_ld_library_path }}"
 {% endif %}
 User={{ pulp_user }}
+Group={{ pulp_group }}
 WorkingDirectory=/var/run/pulpcore-resource-manager/
 RuntimeDirectory=pulpcore-resource-manager
 ExecStart={{ pulp_install_dir }}/bin/rq worker \


### PR DESCRIPTION
Currently the `pulpcore-api` and  `pulpcore-content` have no group
specified on their unit files. Leading them to create their file and
folders to a defaulted group (gid: 100).

This commit ensures files and folders are created as `{{ pulp_user }}:{{
pulp_group }}`

```
$ ls -l /var/run/ | grep pulp
drwxr-xr-x.  2 pulp           users            60 Jun 23 09:51 pulpcore-api
drwxr-xr-x.  2 pulp           users            60 Jun 23 09:51 pulpcore-content
```

fixes #7035