### PR TITLE
Make disabling SELinux optional

### DIFF
--- a/CHANGES/7041.feature
+++ b/CHANGES/7041.feature
@@ -1,0 +1,1 @@
+Make disabling SELinux optional

--- a/roles/pulp_common/README.md
+++ b/roles/pulp_common/README.md
@@ -100,6 +100,9 @@ Role Variables
   subscription-manager/katello.
   Also accepts a single string or empty string.
   Only affects RHEL7 (RHEL8 no longer has an optional repo.)
+* pulp_selinux_mode: For Enterprise Linux distros, set the desired SELinux state.
+  Set to one of the following values: `enforcing`, `disabled`, `permissive`.
+  Defaults to `enforcing`.
 
 Role Variables if installing from RPMs
 --------------------------------------

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -63,3 +63,6 @@ pulp_pkg_undeclared_deps:
   - python3-djangorestframework-queryfields
 pulp_pkg_upgrade_all: false
 pulp_upgraded_manually: false
+# For Enterprise Linux distros, set the desired SELinux state.
+# Set to one of the following values: 'enforcing', 'disabled', 'permissive'
+pulp_selinux_mode: 'enforcing'

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -14,6 +14,12 @@
         name: '{{ pulp_preq_packages }}'
         state: present
 
+    - name: Disable SELinux
+      selinux:
+        policy: targeted
+        state: '{{ pulp_selinux_mode }}'
+      when: ansible_os_family == 'RedHat'
+
     # Become root so as to search paths like /usr/sbin.
     - name: Find the nologin executable
       command: which nologin


### PR DESCRIPTION
Allow user to set the state of SELinux via `pulp_selinux_mode` variable. Can be set to one of the following values: `enforcing`, `disabled`, `permissive`. Defaults to `enforcing`.

fixes #7041