### PR TITLE
Partialy revert "Ensure pulp3 works in an SELinux enforced system"

### DIFF
--- a/CHANGES/6998.feature
+++ b/CHANGES/6998.feature
@@ -1,1 +1,1 @@
-Ensure pulp3 works in an SELinux enforced system.
+Set httpd_can_network_connect SELinux boolean when needed.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -63,3 +63,8 @@ pulp_pkg_undeclared_deps:
   - python3-djangorestframework-queryfields
 pulp_pkg_upgrade_all: false
 pulp_upgraded_manually: false
+
+# Unadvertised because we do not want to maintain this feature anymore after
+# the installer adds support for installing the SElinux policies.
+# Useful for testing the policies in the meantime.
+pulp_disable_selinux: true

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -14,6 +14,12 @@
         name: '{{ pulp_preq_packages }}'
         state: present
 
+    - name: Disable SELinux
+      selinux:
+        policy: targeted
+        state: permissive
+      when: ansible_os_family == 'RedHat' and pulp_disable_selinux | bool
+
     # Become root so as to search paths like /usr/sbin.
     - name: Find the nologin executable
       command: which nologin


### PR DESCRIPTION
We want the boolean set, but we should still set it to permissive
until the policies are available.

https://pulp.plan.io/issues/6998
https://pulp.plan.io/issues/7041

[noissue]