### PR TITLE
As a user, I can specify a single role to install Pulp itself

### DIFF
--- a/CHANGES/7038.feature
+++ b/CHANGES/7038.feature
@@ -1,0 +1,2 @@
+Provide the "pulp_services" role that users can specify to install all of Pulp's first-party
+services, but not its third-party services (database server, redis server & webserver.)

--- a/docs/index.md
+++ b/docs/index.md
@@ -153,3 +153,14 @@ Roles
 - [pulp_webserver](roles/pulp_webserver): install, configure, start, and enable a web server.
 - [pulp_workers](roles/pulp_workers): install, configure, and set the state of pulp workers.
 - [pulp_devel](roles/pulp_devel): installs useful tools and adds some config files for a Pulp 3 development environment.
+
+pulp_installer also is equipped with these prereq roles that perform additional tasks to install specific plugins:
+
+- [pulp_rpm_prerequisites](/prereq_roles/pulp_rpm_prerequisites): installs prerequisites for pulp-rpm plugin use
+
+pulp_installer also provides the following meta roles, which depend on a set of other roles. These provide
+the convenience of writing playbooks that specify one role, rather than a list of roles that often changes.
+
+- [pulp_all_services](meta_roles/pulp_all_services/): A role to install all Pulp services (first-party & third-party) on a single host.
+- [pulp_services](meta_roles/pulp_services/): A role to install & configure Pulp's
+  first-party services (including the state of the Pulp database) on a single host.

--- a/docs/meta_roles/pulp_all_services.md
+++ b/docs/meta_roles/pulp_all_services.md
@@ -1,0 +1,1 @@
+../../roles/pulp_all_services/README.md

--- a/docs/meta_roles/pulp_services.md
+++ b/docs/meta_roles/pulp_services.md
@@ -1,0 +1,1 @@
+../../roles/pulp_services/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,5 +24,8 @@ nav:
       - Pulp Workers: roles/pulp_workers.md
   - Prereq Roles:
       - Pulp RPM prerequisites: prereq_roles/pulp_rpm_prerequisites.md
+  - Meta Roles:
+      - Pulp All Services: meta_roles/pulp_all_services.md
+      - Pulp Services: meta_roles/pulp_services.md
 markdown_extensions:
   - pymdownx.superfences

--- a/roles/pulp_all_services/README.md
+++ b/roles/pulp_all_services/README.md
@@ -1,7 +1,8 @@
 pulp_all_services
 =================
 
-A role to install all Pulp services on a single host.
+A role to install all Pulp 3 services ([first-party](#first-party-services) &
+[third-party](#third-party-services)) on a single host.
 
 Users are supposed to specify this role as a single stable role name
 in their playbooks, rather than every single service role name, which
@@ -10,12 +11,37 @@ on certain hosts.
 
 Currently, all it does is depend on the required roles, which are
 subject to change over time:
+
   - pulp_database
   - pulp_redis
-  - pulp_database_config
-  - pulp_api
-  - pulp_content
-  - pulp_resource_manager
-  - pulp_workers
+  - pulp_services
   - pulp_webserver
+  - pulp_database_config (implicitly)
+  - pulp_api (implicitly)
+  - pulp_content (implicitly)
+  - pulp_resource_manager (implicitly)
+  - pulp_workers (implicitly)
   - pulp_common (implicitly)
+
+Related Roles
+-------------
+- [pulp_services](../pulp_services/): A role to install & configure Pulp 3's
+  first-party services (including the state of the Pulp database) on a single host.
+
+Definitions
+-----------
+
+### First-Party Services
+
+The first-party services are services written by the Pulp project itself.
+
+### Third-Party Services
+
+The third-party services are services written by other open source projects, but
+Pulp depends on them as the middle tier in 3-tier application architecture to
+run.
+
+The 2 backends are the PostgreSQL database server and the redis server.
+
+The 1 frontend is the Nginx or Apache webserver, with special config to combine
+multiple Pulp services into one.

--- a/roles/pulp_rpm_prerequisites/README.md
+++ b/roles/pulp_rpm_prerequisites/README.md
@@ -18,9 +18,10 @@ Here's an example playbook for using pulp_rpm_prerequisites as part of pulp_inst
     ---
     - hosts: all
       vars:
-        pulp_default_admin_password: password
+        pulp_default_admin_password: << YOUR PASSWORD HERE >>
         pulp_settings:
-          secret_key: secret
+          secret_key: << YOUR SECRET HERE >>
+          content_origin: "http://{{ ansible_fqdn }}"
         pulp_install_plugins:
           pulp-rpm: {} #no need to set subvar prereq_role for pulp_rpm specifically
       roles:

--- a/roles/pulp_services/README.md
+++ b/roles/pulp_services/README.md
@@ -1,0 +1,91 @@
+pulp_services
+=============
+
+A role to install & configure Pulp 3's [first-party services](#first-party-services)
+(including the state of the Pulp database) on a single host. [1]
+
+Does not include [third-party services](#third-party-services), which is
+significant because Pulp 3 requires special config for 1 of them, the webserver,
+to combine multiple Pulp services into one.
+
+Users are supposed to specify this role as a single stable role name
+in their playbooks, rather than every single service role name, which
+are subject to change. The exception is when they want certain services
+on certain hosts.
+
+Currently, all it does is depend on the required roles, which are
+subject to change over time:
+
+  - pulp_database_config
+  - pulp_api
+  - pulp_content
+  - pulp_resource_manager
+  - pulp_workers
+  - pulp_common (implicitly)
+
+Example Usage
+-------------
+
+1. Install your own PostgreSQL server.
+1. Install your own Redis server.
+1. Run the example playbook below against a Pulp host.
+1. Install your own webserver (nginx or apache). Consult the pulp_webserver role for
+   the necessary config that is not plugin specific.
+1. On the Pulp host, check if any plugins have webserver snippets, like in the command seen below.
+1. Copy over & install any webserver snippets to the webserver.
+
+Here is an example command & output for checking if any plugins have any webserver snippets.
+```
+$ ls /usr/local/lib/pulp/lib/python*/site-packages/pulp_*/app/webserver_snippets/{apache.conf,nginx.conf}
+/usr/local/lib/pulp/lib/python3.6/site-packages/pulp_container/app/webserver_snippets/apache.conf
+/usr/local/lib/pulp/lib/python3.6/site-packages/pulp_container/app/webserver_snippets/nginx.conf
+```
+
+Here's an example playbook for using pulp_services in pulp_installer. It assumes the database, redis & webserver are on a separate hosts, `redis1`, `postgres1` & `webserver1`. The database and redis must already be up & running.
+
+    ---
+    - hosts: all
+      vars:
+        pulp_default_admin_password: << YOUR PASSWORD FOR THE PULP APPLICATION HERE >>
+        content_origin: "http://webserver1.fqdn"
+        pulp_settings:
+          secret_key: << YOUR SECRET HERE >>
+          redis_host: redis1
+          redis_port: 6380
+          redis_password: << YOUR REDIS PASSWORD HERE >>
+          databases:
+            default:
+              HOST: postgres1
+              ENGINE: django.db.backends.postgresql_psycopg2
+              NAME: pulp
+              USER: pulp
+              PASSWORD: << YOUR DATABASE PASSWORD HERE >>
+        pulp_install_plugins:
+          pulp-rpm: {} #no need to set subvar prereq_role for pulp_rpm specifically
+      roles:
+        - pulp_services
+      environment:
+        DJANGO_SETTINGS_MODULE: pulpcore.app.settings
+
+Related Roles
+-------------
+- [pulp_all_services](../pulp_all_services/): A role to install all Pulp 3
+services (first-party & third-party) on a single host.
+
+Definitions
+-----------
+
+### First-Party Services
+
+The first-party services are services written by the Pulp project itself.
+
+### Third-Party Services
+
+The third-party services are services written by other open source projects, but
+Pulp depends on them as the middle tier in 3-tier application architecture to
+run.
+
+The 2 backends are the PostgreSQL database server and the redis server.
+
+The 1 frontend is the Nginx or Apache webserver, with special config to combine
+multiple Pulp services into one.

--- a/roles/pulp_services/defaults/main.yml
+++ b/roles/pulp_services/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for pulp_services

--- a/roles/pulp_services/handlers/main.yml
+++ b/roles/pulp_services/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for pulp_services

--- a/roles/pulp_services/meta/main.yml
+++ b/roles/pulp_services/meta/main.yml
@@ -1,7 +1,7 @@
 ---
 galaxy_info:
   author: Pulp Team
-  description: A role to install all Pulp services (first-party & third-party) on a single host.
+  description: A role to install Pulp's first-party services on a single host.
   issue_tracker_url: https://pulp.plan.io/projects/pulp/issues/new
   license: GPL-2.0-or-later
   company: Red Hat
@@ -22,7 +22,8 @@ galaxy_info:
     - pulp
     - pulpcore
 dependencies:
-  - pulp_database
-  - pulp_redis
-  - pulp_services
-  - pulp_webserver
+  - pulp_database_config
+  - pulp_api
+  - pulp_content
+  - pulp_resource_manager
+  - pulp_workers

--- a/roles/pulp_services/tasks/main.yml
+++ b/roles/pulp_services/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+# tasks file for pulp_services
+
+# This role simply uses dependencies at this time.
+# meta/main.yml

--- a/roles/pulp_services/vars/main.yml
+++ b/roles/pulp_services/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for pulp_services


### PR DESCRIPTION
It is named "pulp_services", and "pulp_all_services" now depends
on it.

fixes: #7038
https://pulp.plan.io/issues/7038
As a user, I can specify a single role to install Pulp itself

Also includes some missing docs updates from previous changes.