### PR TITLE
pulp_redis; Remove pulp_preq_packages and add become for handlers

### DIFF
--- a/roles/pulp_redis/README.md
+++ b/roles/pulp_redis/README.md
@@ -1,7 +1,7 @@
 pulp_redis
 ==========
 
-Install and start Redis, and install RQ in the Pulp virtualenv.
+Install and start Redis.
 
 Role Variables
 --------------

--- a/roles/pulp_redis/handlers/main.yml
+++ b/roles/pulp_redis/handlers/main.yml
@@ -4,3 +4,4 @@
     name: "{{ pulp_redis_server_name | default(_pulp_redis_server_name) }}"
     state: restarted
     daemon_reload: true
+  become: true

--- a/roles/pulp_redis/tasks/main.yml
+++ b/roles/pulp_redis/tasks/main.yml
@@ -21,11 +21,6 @@
 
 - block:
 
-    - name: Install requirements
-      package:
-        name: "{{ pulp_preq_packages }}"
-        state: present
-
     - name: Install Redis
       package:
         name: '{{ pulp_redis_package_name }}'

--- a/roles/pulp_redis/vars/CentOS.yml
+++ b/roles/pulp_redis/vars/CentOS.yml
@@ -1,6 +1,3 @@
 ---
-pulp_preq_packages:
-  - python36
-  - python36-devel
 _pulp_redis_server_name: redis
 _pulp_redis_conf_file: '/etc/redis.conf'

--- a/roles/pulp_redis/vars/Debian.yml
+++ b/roles/pulp_redis/vars/Debian.yml
@@ -1,7 +1,4 @@
 ---
-pulp_preq_packages:
-  - python3
-  - python3-dev
 _pulp_redis_server_name: redis-server
 _pulp_redis_conf_file: '/etc/redis/redis.conf'
 ...

--- a/roles/pulp_redis/vars/Fedora.yml
+++ b/roles/pulp_redis/vars/Fedora.yml
@@ -1,7 +1,3 @@
 ---
-pulp_preq_packages:
-  - python3
-  - python3-devel
-
 _pulp_redis_server_name: redis
 _pulp_redis_conf_file: '/etc/redis.conf'

--- a/roles/pulp_redis/vars/Ubuntu.yml
+++ b/roles/pulp_redis/vars/Ubuntu.yml
@@ -1,6 +1,3 @@
 ---
-pulp_preq_packages:
-  - python3
-  - python3-dev
 _pulp_redis_server_name: redis-server
 _pulp_redis_conf_file: '/etc/redis/redis.conf'


### PR DESCRIPTION
The pulp_preq_packages are not required for pulp to install and run
properly hence they are being removed.

The README.md has been updated to be more accurate. And a small fix has
been added to the restart redis handler.

[noissue]