### PR TITLE
Problem: pulp_installer adds a redis PPA

### DIFF
--- a/CHANGES/7063.removal
+++ b/CHANGES/7063.removal
@@ -1,0 +1,2 @@
+Removed the task to add a redis PPA on all Ubuntu releases.
+Existing Ubuntu Pulp installations will still have the PPA enabled.

--- a/roles/pulp_redis/tasks/main.yml
+++ b/roles/pulp_redis/tasks/main.yml
@@ -13,12 +13,6 @@
   tags:
     - always
 
-- name: Add redis repository
-  apt_repository:
-    repo: ppa:chris-lea/redis-server
-  become: yes
-  when: ansible_distribution == 'Ubuntu'
-
 - block:
 
     - name: Install Redis


### PR DESCRIPTION
on all Ubuntu releases

Solution: Remove the task that adds the redis PPA.
It was probably only ever needed on Ubuntu 14.04, which is EOL.

fixes: #7063
pulp_installer adds a redis PPA on all Ubuntu releases
https://pulp.plan.io/issues/7063