### PR TITLE
Problem: firewall may fail to be configured for certain pulp_installe…

### DIFF
--- a/CHANGES/7062.bugfix
+++ b/CHANGES/7062.bugfix
@@ -1,0 +1,2 @@
+Fix issue whereby for certain users, the firewall may not be configured.
+Also fix an issue whereby for certain pulp_devel role users, the Galaxy NG WebUI may not be built.

--- a/roles/pulp_devel/tasks/main.yml
+++ b/roles/pulp_devel/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
-- import_tasks: galaxy_ui.yml
+- name: include_tasks to build Galaxy WebUI if galaxy-ng is among the plugins
+  include_tasks:
+    file: galaxy_ui.yml
+    apply:
+      become: true
   when: pulp_install_plugins_normalized['galaxy-ng'] is defined
-  become: true
 
 - import_tasks: install_basic_packages.yml
   become: true

--- a/roles/pulp_webserver/tasks/main.yml
+++ b/roles/pulp_webserver/tasks/main.yml
@@ -43,5 +43,5 @@
     - ansible_selinux.status == 'enabled'
     - not (pulp_api_bind.startswith('unix:') and pulp_content_bind.startswith('unix:'))
 
-- import_tasks: firewalld.yml
+- include_tasks: firewalld.yml
   when: pulp_configure_firewall in ['firewalld', 'auto']


### PR DESCRIPTION
…r users

Similarly, the Galaxy NG WebUI may not build.

Solution: Convert all the import_tasks with when conditions to include_tasks.

fixes: #7062
firewall may fail to be configured for certain pulp_installer users
https://pulp.plan.io/issues/7062