### PR TITLE
Disable molecule builds

### DIFF
--- a/.github/workflows/build_molecule_images.yaml
+++ b/.github/workflows/build_molecule_images.yaml
@@ -19,4 +19,5 @@ jobs:
         env:
           DOCKER_BOT_PASSWORD: ${{ secrets.DOCKER_BOT_PASSWORD }}
         run: |
-          ansible-playbook ./.github/build_container.yaml
+          # ansible-playbook ./.github/build_container.yaml
+          echo "Disabled"


### PR DESCRIPTION
Disabling builds for now, as it is making the CI times out

ref: https://github.com/pulp/pulp_installer/pull/367