### PR TITLE
pulp_devel: Implement support for signing service script

### DIFF
--- a/CHANGES/7247.dev
+++ b/CHANGES/7247.dev
@@ -1,0 +1,1 @@
+For developers, install the RPM signing service script. Copy & register it.

--- a/roles/pulp_devel/defaults/main.yml
+++ b/roles/pulp_devel/defaults/main.yml
@@ -3,3 +3,4 @@ pulp_devel_install_podman: true
 pulp_devel_package_retries: 5
 pulp_devel_supplement_bashrc: false
 pulp_workers: 2
+__pulp_devel_rpm_sign_script_path: "{{ pulp_user_home }}/sign-metadata.sh"

--- a/roles/pulp_devel/tasks/main.yml
+++ b/roles/pulp_devel/tasks/main.yml
@@ -64,6 +64,21 @@
   become_user: "{{ developer_user }}"
   when: pulp_install_plugins_normalized['galaxy-ng'] is defined
 
+# For the use case of it being installed to the venv
+# from PyPI, but the git repo being cloned.
+- name: check if pulp_rpm exists on disk
+  stat:
+    path: "{{ developer_user_home }}/devel/pulp_rpm"
+  register: rpm_stat
+
+- name: include_tasks to create signing service if pulp_rpm is among the plugins
+  include_tasks:
+    file: rpm_signing_service.yml
+  when:
+    - pulp_install_plugins_normalized['pulp-rpm'] is defined
+    - pulp_install_plugins_normalized['pulp-rpm'].source_dir is defined
+      or rpm_stat.stat.exists
+
 - name: Set the message of the day
   copy:
     src: motd

--- a/roles/pulp_devel/tasks/rpm_signing_service.yml
+++ b/roles/pulp_devel/tasks/rpm_signing_service.yml
@@ -1,0 +1,63 @@
+---
+# Setup the RPM signing service
+#
+# Maintain parity with:
+# https://github.com/pulp/pulp_rpm/blob/master/.travis/post_before_script.sh
+
+- name: Copy the signing service script to {{ __pulp_devel_rpm_sign_script_path }}
+  copy:
+    src: >-
+      {{ pulp_install_plugins_normalized['pulp-rpm'].source_dir | default (developer_user_home ~ '/devel/pulp_rpm')
+      }}/pulp_rpm/tests/functional/sign-metadata.sh
+    dest: "{{ __pulp_devel_rpm_sign_script_path }}"
+    remote_src: true
+    owner: "{{ pulp_user }}"
+    group: "{{ pulp_group }}"
+    mode: 0755
+  become: true
+  become_user: root
+
+- name: Import GPG key
+  shell: |
+    set -o pipefail
+    curl -L https://github.com/pulp/pulp-fixtures/raw/master/common/GPG-PRIVATE-KEY-pulp-qe | gpg --import
+  args:
+    executable: /bin/bash
+  # Retries in case github access issue.
+  retries: 3
+  delay: 3
+  register: result
+  until: result.rc == 0
+  changed_when: '"secret keys imported: 1" in result.stderr'
+  become: true
+  become_user: "{{ pulp_user }}"
+  when: not ansible_check_mode
+
+- name: Import to trust database
+  command:
+    cmd: gpg --import-ownertrust
+    stdin: 6EDF301256480B9B801EBA3D05A5E6DA269D9D98:6
+  register: result
+  changed_when: '"gpg: inserting ownertrust of" in result.stderr'
+  become: true
+  become_user: "{{ pulp_user }}"
+  when: not ansible_check_mode
+
+- name: Create the Signing Service
+  shell:
+    cmd: >
+         {{ pulp_django_admin_path }} shell -c
+         "from pulpcore.app.models.content import AsciiArmoredDetachedSigningService;
+         AsciiArmoredDetachedSigningService.objects.create(name='sign-metadata',
+         script='{{ __pulp_devel_rpm_sign_script_path }}')"
+  environment:
+    PULP_SETTINGS: "{{ pulp_settings_file }}"
+  register: result
+  changed_when:
+    - result.rc == 0
+  failed_when:
+    - result.rc != 0
+    - '"DETAIL:  Key (name)=(sign-metadata) already exists." not in result.stderr'
+  become: true
+  become_user: "{{ pulp_user }}"
+  when: not ansible_check_mode


### PR DESCRIPTION
being copied & registered.

This is in pulp_devel because the signing service is not in
its permanent packaging. This is a temporary installation
method.

Fixes: #7247
https://pulp.plan.io/issues/7247
As a pulp_installer developer-user, the pulp_rpm signing service will be installed for me

Related to 4812
https://pulp.plan.io/issues/4812
As a user, I can publish a Yum repository that works with repo_gpgcheck=1 (Signed Repositories)