### PR TITLE
docs: Add inline anchor links

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,3 +29,5 @@ nav:
       - Pulp Services: meta_roles/pulp_services.md
 markdown_extensions:
   - pymdownx.superfences
+  - toc:
+      permalink: True


### PR DESCRIPTION
This adds anchor links (a little icon) to the right of each header.

Without it, the links to the headers are only available on the
left navigation bar.

[noissue]