### PR TITLE
Problem: pulp_installer fails idempotency tests with pip 20.2

### DIFF
--- a/CHANGES/7254.bugfix
+++ b/CHANGES/7254.bugfix
@@ -1,0 +1,1 @@
+Fix the tasks "Install pulpcore via PyPI" & "Install Pulp plugins via PyPI" always reporting CHANGED when pip 20.2 is installed.

--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -20,9 +20,12 @@
         virtualenv_site_packages: yes
       when: pulp_use_system_wide_pkgs | bool
 
+    # 20.2 fails idempotency with ruamel.yaml due to this bug:
+    # https://github.com/pypa/pip/pull/8659
+    # Should be fixed in 20.2.1
     - name: Upgrade to a recent edition of pip (supporting manylinux2014)
       pip:
-        name: pip>=20.0
+        name: pip>=20.0,!=20.2
         state: present
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'


### PR DESCRIPTION
Solution: Do not upgrade to pip 20.2 specifically.

fixes: #7254
https://pulp.plan.io/issues/7254
pulp_installer fails idempotency tests with pip 20.2