### PR TITLE
Problem: pulp_installer CI often fails to test more than 1 OS at a time

### DIFF
--- a/CHANGES/7263.dev
+++ b/CHANGES/7263.dev
@@ -1,0 +1,1 @@
+Fix molecule (CI or local) often failing to test more than 1 OS a time.

--- a/molecule/scenario_resources/group_vars/all
+++ b/molecule/scenario_resources/group_vars/all
@@ -1,2 +1,3 @@
 ---
 ansible_ssh_pipelining: True
+__pulp_database_config_run_once: false

--- a/roles/pulp_database_config/defaults/main.yml
+++ b/roles/pulp_database_config/defaults/main.yml
@@ -4,3 +4,6 @@
 # /usr/bin/python pointing to python2, on Fedora 30. This in turn breaks
 # running pulp_installer a 2nd time, because F30 lacks python2-dnf.
 ansible_python_interpreter: auto
+
+# Limit the actual tasks of the role to be run on only 1 node in a cluster deployment.
+__pulp_database_config_run_once: true

--- a/roles/pulp_database_config/tasks/main.yml
+++ b/roles/pulp_database_config/tasks/main.yml
@@ -36,7 +36,7 @@
       no_log: true
       when: pulp_default_admin_password is defined and migrate_auth.changed
 
-  run_once: true
+  run_once: "{{ __pulp_database_config_run_once }}"
   become: true
   become_user: '{{ pulp_user }}'
   environment:


### PR DESCRIPTION
Solution: Run pulp_database_config's block of task for each OS,
disabling the run_once. Via a private variable.

fixes: #7263
https://pulp.plan.io/issues/7263