### PR TITLE
pulp_installer often fails to add the RPM repo to the system

### DIFF
--- a/CHANGES/7275.bugfix
+++ b/CHANGES/7275.bugfix
@@ -1,0 +1,2 @@
+Fix pulp_installer failing on the task "pulp_common: Add pulpcore RPM repositories" when installing
+in packages mode, and when ansible_user is not root.

--- a/roles/pulp_common/tasks/repos.yml
+++ b/roles/pulp_common/tasks/repos.yml
@@ -123,3 +123,4 @@
   when:
     - ansible_os_family == "RedHat"
     - pulp_pkg_repo is not none
+  become: true


### PR DESCRIPTION
Solution: Add `become: true` to the task.

fixes: #7275
https://pulp.plan.io/issues/7275