### PR TITLE
Problem: pulp_installer fails to set selinux booleans

### DIFF
--- a/CHANGES/7276.bugfix
+++ b/CHANGES/7276.bugfix
@@ -1,0 +1,3 @@
+Fix pulp_installer failing on task "pulp_webserver : Set httpd_can_network_connect flag on and keep
+it persistent across reboots" on hosts with SELinux enabled (enforcing/permissive) by installing
+the SELinux python RPM dependencies.

--- a/roles/pulp_webserver/tasks/main.yml
+++ b/roles/pulp_webserver/tasks/main.yml
@@ -65,11 +65,19 @@
 
 - include_tasks: "{{ pulp_webserver_server }}.yml"
 
-- name: Set httpd_can_network_connect flag on and keep it persistent across reboots
-  seboolean:
-    name: httpd_can_network_connect
-    state: true
-    persistent: true
+- block:
+
+    - name: Install packages for Ansible seboolean module
+      yum:
+        name: "{{ pulp_seboolean_packages }}"
+        state: present
+
+    - name: Set httpd_can_network_connect flag on and keep it persistent across reboots
+      seboolean:
+        name: httpd_can_network_connect
+        state: true
+        persistent: true
+
   become: true
   when:
     - ansible_os_family == 'RedHat'

--- a/roles/pulp_webserver/vars/CentOS-7.yml
+++ b/roles/pulp_webserver/vars/CentOS-7.yml
@@ -1,6 +1,9 @@
 ---
 # We set the following to mod_ssl as httpd is a dependency
 # and hence will be pulled.
+pulp_seboolean_packages:
+  - libselinux-python
+  - libsemanage-python
 pulp_webserver_apache_package: mod_ssl
 pulp_webserver_apache_service: httpd
 pulp_webserver_apache_vhost_dir: /etc/httpd/conf.d

--- a/roles/pulp_webserver/vars/Fedora.yml
+++ b/roles/pulp_webserver/vars/Fedora.yml
@@ -1,6 +1,9 @@
 ---
 # We set the following to mod_ssl as httpd is a dependency
 # and hence will be pulled.
+pulp_seboolean_packages:
+  - python3-libselinux
+  - python3-libsemanage
 pulp_webserver_apache_package: mod_ssl
 pulp_webserver_apache_service: httpd
 pulp_webserver_apache_vhost_dir: /etc/httpd/conf.d


### PR DESCRIPTION
 due to missing dependencies

Solution: Install those dependencies. They differ based on OS release.

Fixes: #7276
https://pulp.plan.io/issues/7276