### PR TITLE
Problem: pulp_installer via RPM does not account for pulp_install_dir

### DIFF
--- a/CHANGES/7255.bugfix
+++ b/CHANGES/7255.bugfix
@@ -1,0 +1,2 @@
+Fix services not starting due to pulp_installer putting the wrong path to binaries like gunicorn in
+systemd unit files. Only occured when installing in packages mode.

--- a/roles/pulp_api/README.md
+++ b/roles/pulp_api/README.md
@@ -1,12 +1,10 @@
 pulp_api
-=========
+========
 
 Install, configure, and set the state of the pulp API service.
 
 Role Variables
 --------------
-
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
 
 * `pulp_api_bind` Interface and Port where Pulp Content `gunicorn` service will listen. Defaults to
   '127.0.0.1:24817'. This variable is the value used to render the `pulpcore-api.service.j2` template
@@ -24,6 +22,7 @@ This role **is tightly coupled** to the required `pulp_common` role, and inherit
 some of its variables.
 
 * `pulp_config_dir`
+* `pulp_group`
 * `pulp_install_dir`
 * `pulp_ld_library_path`: An optional LD_LIBRARY_PATH environment variable for the pulpcore-api systemd process
 * `pulp_settings_file`

--- a/roles/pulp_api/defaults/main.yml
+++ b/roles/pulp_api/defaults/main.yml
@@ -2,7 +2,3 @@
 # defaults file for pulp_api
 pulp_api_bind: '127.0.0.1:24817'
 pulp_api_workers: 1
-pulp_config_dir: "/etc/pulp"
-pulp_install_dir: '/usr/local/lib/pulp'
-pulp_settings_file: "{{ pulp_config_dir }}/settings.py"
-pulp_user: pulp

--- a/roles/pulp_content/README.md
+++ b/roles/pulp_content/README.md
@@ -1,10 +1,10 @@
 pulp_content
-=============
+============
 
 Install, configure, and set the state of pulp content app.
 
-Variables
----------
+Role Variables
+--------------
 
 * `pulp_content_bind`: Interface and Port where Pulp Content `gunicorn` service will listen.
 
@@ -21,8 +21,9 @@ Shared variables
 This role **is tightly coupled** to the required `pulp_common` role, and inherits
 some of its variables.
 
-* `pulp_user`
-* `pulp_install_dir`
 * `pulp_config_dir`
+* `pulp_group`
+* `pulp_install_dir`
+* `pulp_ld_library_path`: An optional LD_LIBRARY_PATH environment variable for the pulpcore-api systemd process
 * `pulp_settings_file`
-* `pulp_ld_library_path`: An optional LD_LIBRARY_PATH environment variable for the pulpcore-content systemd process
+* `pulp_user`

--- a/roles/pulp_content/defaults/main.yml
+++ b/roles/pulp_content/defaults/main.yml
@@ -1,6 +1,2 @@
 ---
 pulp_content_bind: '127.0.0.1:24816'
-pulp_config_dir: "/etc/pulp"
-pulp_settings_file: "{{ pulp_config_dir }}/settings.py"
-pulp_install_dir: "/usr/local/lib/pulp"
-pulp_user: pulp

--- a/roles/pulp_resource_manager/README.md
+++ b/roles/pulp_resource_manager/README.md
@@ -3,8 +3,8 @@ pulp_resource_manager
 
 Install, configure, and set the state of the pulp resouce manager.
 
-Configurable Variables
-----------------------
+Role Variables
+--------------
 
 * `pulp_resouce_manager_state`: This variable can be configured with any of the
   states allowed by the systemd module's "state" directive. Defaults to "started."
@@ -20,6 +20,7 @@ This role **is tightly coupled** to the required `pulp_common` role, and inherit
 some of its variables.
 
 * `pulp_config_dir`
+* `pulp_group`
 * `pulp_install_dir`
 * `pulp_ld_library_path`: An optional LD_LIBRARY_PATH environment variable for the pulpcore-resource-manager systemd process
 * `pulp_settings_file`

--- a/roles/pulp_resource_manager/defaults/main.yml
+++ b/roles/pulp_resource_manager/defaults/main.yml
@@ -1,7 +1,3 @@
 ---
 pulp_resource_manager_state: started
 pulp_resource_manager_enabled: true
-pulp_config_dir: "/etc/pulp"
-pulp_settings_file: "{{ pulp_config_dir }}/settings.py"
-pulp_install_dir: '/usr/local/lib/pulp'
-pulp_user: pulp

--- a/roles/pulp_webserver/README.md
+++ b/roles/pulp_webserver/README.md
@@ -10,8 +10,8 @@ By default TLS will be enabled (with self-signed certificates if none are provid
 redirect from http to https will take place.
 
 
-Variables
----------
+Role Variables
+--------------
 
 * `pulp_webserver_server` Set the webserver Pulp should use to reverse proxy with. Defaults to
   'nginx'.

--- a/roles/pulp_webserver/defaults/main.yml
+++ b/roles/pulp_webserver/defaults/main.yml
@@ -3,7 +3,6 @@ pulp_webserver_server: nginx
 pulp_content_bind: '127.0.0.1:24816'
 pulp_api_bind: '127.0.0.1:24817'
 pulp_configure_firewall: auto
-pulp_user_home: '/var/lib/pulp'
 
 pulp_webserver_disable_https: false
 pulp_webserver_tls_folder: '{{ pulp_config_dir }}'

--- a/roles/pulp_workers/README.md
+++ b/roles/pulp_workers/README.md
@@ -3,8 +3,8 @@ pulp_workers
 
 Install, configure, and set the state of pulp workers.
 
-Configurable Variables
-----------------------
+Role Variables
+--------------
 
 * `pulp_workers`: Specify how many workers. Defaults to 2 workers.
 
@@ -17,6 +17,7 @@ This role **is tightly coupled** to the required `pulp_common` role, and inherit
 some of its variables.
 
 * `pulp_config_dir`
+* `pulp_group`
 * `pulp_install_dir`
 * `pulp_ld_library_path`: An optional LD_LIBRARY_PATH environment variable for the pulpcore-worker systemd processes
 * `pulp_settings_file`

--- a/roles/pulp_workers/defaults/main.yml
+++ b/roles/pulp_workers/defaults/main.yml
@@ -1,7 +1,2 @@
 ---
-pulp_config_dir: "/etc/pulp"
-pulp_settings_file: "{{ pulp_config_dir }}/settings.py"
-pulp_group: pulp
 pulp_workers: 2
-pulp_install_dir: '/usr/local/lib/pulp'
-pulp_user: pulp


### PR DESCRIPTION
in systemd unit files, and any other task in the roles:
pulp_api,pulp_content,pulp_workers,pulp_resource_manager,
pulp_webserver

Solution: Delete all redundant default variables from these roles.
Let them be inherited from pulp_common, now that the roles actually
depend on pulp_common.


fixes: #7255
pulp_installer via RPM does not account for pulp_install_dir
https://pulp.plan.io/issues/7255

Bug introduced during:
re: #6793
https://pulp.plan.io/issues/6793
As a pulp_installer user, I can install Pulp from RPMs

Redundant default variables are leftover from:
re: #7005
https://pulp.plan.io/issues/7005
As a user, I can run a single stably-named Ansible role to install Pulp