### PR TITLE
Let's Encrypt

### DIFF
--- a/CHANGES/6846.feature
+++ b/CHANGES/6846.feature
@@ -1,0 +1,1 @@
+Misc webserver changes so that Let's Encrypt and other ACME protocol CAs can be used via 3rd-party ansible roles, primarily for HTTP-01 verification. See docs/letsencrypt.md for a full HTTP-01 example playbook and explanation.

--- a/docs/letsencrypt.md
+++ b/docs/letsencrypt.md
@@ -1,0 +1,125 @@
+Let's Encrypt
+=============
+
+Overview
+--------
+
+The Pulp 3 Ansible Installer supports obtaining TLS/SSL Certificates via Let's Encrypt (or other
+ACME compatible CAs), using your choice of 3rd-party Ansible role.
+
+The pulp_webserver role supports HTTP-01 verification for Let's Encrypt (the most common
+verification method), but must be called in a particular manner, as shown in the example playbook
+below.
+
+DNS-01 verification is also supported, and guidance is offered below.
+
+Let's Encrypt HTTP-01 Requirements
+----------------------------------
+
+Let's Encrypt HTTP-01 verification requires that:
+
+1. The server be accessible over the internet on both ports 80, and 443
+  (and 443 per pulp_installer's design.) The Pulp 3 Ansible Installer will configure the OS's firewall, but any
+  firewall/router in front of it (such as a security group on a cloud provider) must allow them.
+
+2. The server has a DNS name it can be reached at, such as pulp.example.com . This is what must be
+   filled in at `<< domain name >>` in the example playbook below.  Note that many
+   auto-generated DNS names by cloud providers are blocked per Let's Encrypt policy.
+
+These requirements must be satisfied before running The Pulp 3 Ansible Installer.
+
+Let's Encrypt HTTP-01 Example Playbook
+--------------------------------------
+As an example, we are going to write a playbook for installing `pulp_file`, with Let's Encrypt and
+HTTP 01 verification.
+
+The 3rd-party role listed below,
+[lexa-uw.letsencrypt](https://galaxy.ansible.com/lexa-uw/letsencrypt), is an example. The variables listed below are meant for it, and can serve as a guide for other roles.
+
+You can learn more about the variables on the [roles section](https://pulp-installer.readthedocs.io/en/latest/roles/pulp/#role-variables)
+
+1 -  Install the `pulp_installer` collection:
+```
+ansible-galaxy collection install pulp.pulp_installer
+```
+
+2 -  Install the `geerlingguy.postgresql` role:
+```
+ansible-galaxy install geerlingguy.postgresql
+```
+
+3 - Install your preferred 3rd-party role from [Ansible
+Galaxy](https://galaxy.ansible.com/search?deprecated=false&keywords=acme&order_by=-relevance&page=1).
+
+For the example of the role in the playbook below:
+```
+ansible-galaxy install lexa-uw.letsencrypt
+```
+
+4 - Write the following playbook:
+```
+vim install.yml
+```
+
+```yaml
+---
+- hosts: << domain name >>
+  vars:
+    pulp_webserver_httpd_servername: "{{ inventory_hostname }}"
+    lets_encrypt_hostname: "{{ inventory_hostname }}"
+    lets_encrypt_directories_certs: "/etc/letsencrypt"
+    lets_encrypt_directories_data: "/var/lib/pulp/pulpcore_static"
+    pulp_default_admin_password: << YOUR PASSWORD HERE >>
+    pulp_install_plugins:
+      # galaxy-ng: {}
+      # pulp-ansible: {}
+      # pulp-certguard: {}
+      # pulp-container: {}
+      # pulp-cookbook: {}
+      # pulp-deb: {}
+      pulp-file: {}
+      # pulp-gem: {}
+      # pulp-maven: {}
+      # pulp-npm: {}
+      # pulp-python: {}
+      # pulp-rpm: {}
+    pulp_settings:
+      secret_key: << YOUR SECRET HERE >>
+      content_origin: "https://{{ inventory_hostname }}"
+  roles:
+    # Includes running pulp_webserver. letsencrypt depends on a webserver
+    # that can host the .well-known directory.
+    - pulp.pulp_installer.pulp_all_services
+    - role: lexa-uw.letsencrypt
+      become: true
+  tasks:
+    # Must be run via a task so that it can be run more than once.
+    - name: Run pulp_webserver a 2nd time to import the key
+      include_role:
+        name: pulp.pulp_installer.pulp_webserver
+      vars:
+        pulp_webserver_tls_key: "/etc/letsencrypt/private_key.pem"
+        pulp_webserver_tls_cert: "/etc/letsencrypt/fullchain.pem"
+        pulp_webserver_tls_files_remote: true
+  environment:
+    DJANGO_SETTINGS_MODULE: pulpcore.app.settings
+```
+4 - Run the playbook:
+
+```
+ansible-playbook install.yml -u <managed_node_username> --ask-become-pass
+```
+<script id="asciicast-335829" src="https://asciinema.org/a/335829.js" async data-autoplay="true" data-speed="2"></script>
+
+Let's Encrypt DNS-01 Verification
+---------------------------------
+This is supported as well.
+
+The main differences from the above example are:
+1. The dropping of the internet accessible requirement, and DNS requirements instead.
+2. The 3rd party role for Let's Encrypt is run before `pulp_all_services`/`pulp_webserver`, and
+needs a different set of variables.
+3. pulp_webserver does not need to be run a 2nd time.
+4. When `pulp_all_services`/`pulp_webserver` is run the 1st & only time, specify the
+  pulp_webserver_tls variables that point to the certificate and key received in the global `vars`
+  section at the top of the playbook.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,10 +4,6 @@ Getting started
 The Pulp 3 Ansible installer is a collection of roles to install or upgrade Pulp 3 hosted on galaxy:
 [https://galaxy.ansible.com/pulp/pulp_installer](https://galaxy.ansible.com/pulp/pulp_installer)
 
-Some plugins require a prerequisite role. You can find information about prerequisite roles that you require in the **Roles** area of the Pulp page on Ansible Galaxy:
-[https://galaxy.ansible.com/pulp](https://galaxy.ansible.com/pulp)
-
-
 Installation
 ------------
 The recommended installation is from ansible-galaxy:
@@ -33,7 +29,7 @@ they can be set in the playbook. See the Ansible docs for more flexible idiomati
 
 
 Example Playbook for Installing Plugins
------------------
+---------------------------------------
 As an example, we are going to write a playbook for installing `pulp_container` and `pulp_rpm`.
 You can learn more about the variables on the [roles section](https://pulp-installer.readthedocs.io/en/latest/roles/pulp/#role-variables)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - Home: index.md
   - Getting started: quickstart.md
   - contributing.md
+  - Let's Encrypt: letsencrypt.md
   - Changelog: CHANGES.md
   - Roles:
       - Pulp Common: roles/pulp_common.md

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -68,6 +68,13 @@
     - name: Reset ssh conn to allow user changes to affect when ssh user and pulp user are the same
       meta: reset_connection
 
+    # Needed for ngingx/apache to serve content at pulp_webserver_static_dir,
+    # which is the subdir pulpcore_static by default.
+    - name: Make {{ pulp_user_home }} world executable
+      file:
+        path: '{{ pulp_user_home }}'
+        mode: 'o+x'
+
     - name: Create cache dir for Pulp
       file:
         path: '{{ pulp_cache_dir }}'

--- a/roles/pulp_webserver/README.md
+++ b/roles/pulp_webserver/README.md
@@ -20,12 +20,20 @@ Role Variables
 * `pulp_webserver_disable_https`: Whether or not HTTPS should be disabled. Defaults to `false`.
 * `pulp_webserver_tls_folder`: Path where to generate or drop the certificates. Defaults to
   `pulp_config_dir`.
+* `pulp_webserver_tls_cert`: Relative or absolute path to the TLS (SSL) certificate
+   one wants to import.
+* `pulp_webserver_tls_key`: Relative or absolute path to the TLS (SSL) key
+   one wants to import.
+* `pulp_webserver_tls_custom_ca_cert` A custom CA certificate to import on the server.
+* `pulp_webserver_tls_files_remote`: Whether or not `pulp_webserver_tls_cert`,
+  `pulp_webserver_tls_key` & `pulp_webserver_tls_custom_ca_cert` are on the webserver (`true`)
+   or on the ansible management node (`false`). Defaults to `false`.
 * `pulp_webserver_httpd_servername`: Servername to use when deploying httpd. Defaults to
   `ansible_fqdn`.
-* `pulp_webserver_ssl_cert`: Relative or absolute path to the TLS certificate one wants to
-   import.
-* `pulp_webserver_ssl_key`: Relative or absolute path to the TLS key one wants to
-   import.
+- `pulp_webserver_static_dir` absolute path where to place static files, such as for the .well-known
+   directory for ACME (letsencrypt) files or SSL certs. This is not to be confused with the Pulp
+   application's setting `STATIC_ROOT`, which is a function of Pulp itself (not the webserver) and servces
+   a different set of files.
 
 Plugin Webserver Configs
 ------------------------

--- a/roles/pulp_webserver/defaults/main.yml
+++ b/roles/pulp_webserver/defaults/main.yml
@@ -7,3 +7,7 @@ pulp_configure_firewall: auto
 pulp_webserver_disable_https: false
 pulp_webserver_tls_folder: '{{ pulp_config_dir }}'
 pulp_webserver_httpd_servername: '{{ ansible_fqdn }}'
+# The "static" dir is used by Pulp 2, and has conflicting SELinux policies.
+# https://pulp.plan.io/issues/5995
+pulp_webserver_static_dir: "{{ pulp_user_home | regex_replace('\\/$', '') }}/pulpcore_static"
+pulp_webserver_tls_files_remote: false

--- a/roles/pulp_webserver/tasks/import_certificates.yml
+++ b/roles/pulp_webserver/tasks/import_certificates.yml
@@ -1,18 +1,20 @@
 ---
 - name: Import specified TLS certificate
   copy:
-    src: "{{ pulp_webserver_ssl_cert }}"
+    src: "{{ pulp_webserver_tls_cert }}"
     dest: "{{ pulp_webserver_tls_folder }}/pulp_webserver.crt"
     owner: root
     group: "{{ pulp_group }}"
     mode: 0600
+    remote_src: "{{ pulp_webserver_tls_files_remote }}"
   notify: reload {{ pulp_webserver_server }}
 
 - name: Import specified TLS private key
   copy:
-    src: "{{ pulp_webserver_ssl_key }}"
+    src: "{{ pulp_webserver_tls_key }}"
     dest: "{{ pulp_webserver_tls_folder }}/pulp_webserver.key"
     owner: root
     group: "{{ pulp_group }}"
     mode: 0600
+    remote_src: "{{ pulp_webserver_tls_files_remote }}"
   notify: reload {{ pulp_webserver_server }}

--- a/roles/pulp_webserver/tasks/main.yml
+++ b/roles/pulp_webserver/tasks/main.yml
@@ -15,10 +15,10 @@
 
 - name: Ensure that if we have web cert, we also have key
   fail:
-    msg: "If you give one of pulp_webserver_ssl_cert and pulp_webserver_ssl_key, you must also give the other."
+    msg: "If you give one of pulp_webserver_tls_cert and pulp_webserver_tls_key, you must also give the other."
   when:
-    - "pulp_webserver_ssl_cert is defined or pulp_webserver_ssl_key is defined"
-    - "pulp_webserver_ssl_cert is not defined or pulp_webserver_ssl_key is not defined"
+    - "pulp_webserver_tls_cert is defined or pulp_webserver_tls_key is defined"
+    - "pulp_webserver_tls_cert is not defined or pulp_webserver_tls_key is not defined"
 
 - debug:
     msg: >
@@ -37,31 +37,45 @@
   changed_when: false
   check_mode: false
 
-- import_tasks: generate_tls_certificates.yml
-  become: true
+- include_tasks: generate_tls_certificates.yml
+  args:
+    apply:
+      become: true
   when:
-    - pulp_webserver_ssl_cert is undefined
-    - pulp_webserver_ssl_key is undefined
+    - pulp_webserver_tls_cert is undefined
+    - pulp_webserver_tls_key is undefined
 
-- import_tasks: import_certificates.yml
-  become: true
+- include_tasks: import_certificates.yml
+  args:
+    apply:
+      become: true
   when:
-    - pulp_webserver_ssl_cert is defined
-    - pulp_webserver_ssl_key is defined
+    - pulp_webserver_tls_cert is defined
+    - pulp_webserver_tls_key is defined
 
 - name: Copy custom CA cert
   copy:
-    src: "{{ pulp_websserver_custom_ca_cert }}"
+    src: "{{ pulp_webserver_tls_custom_ca_cert }}"
     dest: "{{ pulp_webserver_trusted_root_certificates_path }}/pulp-custom-ca-cert.crt"
     mode: '0644'
     owner: root
     group: root
-  when: pulp_websserver_custom_ca_cert is defined
+    remote_src: "{{ pulp_webserver_tls_files_remote }}"
+  when: pulp_webserver_tls_custom_ca_cert is defined
   become: true
   notify: update ca trust
 
-- import_tasks: nginx.yml
-  when: pulp_webserver_server == 'nginx'
+- name: Create ACME dirs
+  file:
+    path: "{{ item }}"
+    state: directory
+    mode: 0755
+    owner: "{{ pulp_user }}"
+    group: "{{ pulp_group }}"
+  become: true
+  with_items:
+    - "{{ pulp_webserver_static_dir }}"
+    - "{{ pulp_webserver_static_dir }}/.well-known"
 
 - include_tasks: "{{ pulp_webserver_server }}.yml"
 
@@ -86,3 +100,6 @@
 
 - include_tasks: firewalld.yml
   when: pulp_configure_firewall in ['firewalld', 'auto']
+
+# In case an ACME role relies on a change made in pulp_webserver.
+- meta: flush_handlers

--- a/roles/pulp_webserver/templates/nginx.conf.j2
+++ b/roles/pulp_webserver/templates/nginx.conf.j2
@@ -49,7 +49,7 @@ http {
         ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
         ssl_prefer_server_ciphers on;
 
-        {% if pulp_webserver_ssl_cert is defined %}
+        {% if pulp_webserver_tls_cert is defined %}
         # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
         add_header Strict-Transport-Security max-age=15768000;
         {% endif %}
@@ -62,6 +62,10 @@ http {
 
         # Gunicorn docs suggest this value.
         keepalive_timeout 5;
+
+        # static files that can change dynamically, or are needed for TLS
+        # purposes are served through the webserver.
+        root {{ pulp_webserver_static_dir }};
 
         location /pulp/content/ {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -103,8 +107,15 @@ http {
             # redirects, we set the Host: header above already.
             proxy_redirect off;
             proxy_pass http://pulp-api;
-            # static files are served through whitenoise - http://whitenoise.evans.io/en/stable/
+            # most pulp static files are served through whitenoise
+            # http://whitenoise.evans.io/en/stable/
         }
+
+        # ACME http-01 tokens, i.e, for Let's Encrypt
+        location /.well-known/ {
+            try_files $uri $uri/ =404;
+        }
+
     }
 
 {% if not pulp_webserver_disable_https | bool %}

--- a/roles/pulp_webserver/templates/pulp-vhost.conf.j2
+++ b/roles/pulp_webserver/templates/pulp-vhost.conf.j2
@@ -39,6 +39,10 @@ Define pulp-api {{ pulp_api_bind }}
 <VirtualHost *:443>
   ServerName {{ pulp_webserver_httpd_servername }}
 
+  # static files that can change dynamically, or are needed for TLS
+  # purposes are served through the webserver.
+  DocumentRoot {{ pulp_webserver_static_dir }}
+
   ## TLS Configuration
   SSLEngine On
   SSLCertificateFile {{ pulp_webserver_tls_folder }}/pulp_webserver.crt
@@ -47,7 +51,7 @@ Define pulp-api {{ pulp_api_bind }}
   SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
   SSLHonorCipherOrder on
 
-{% if pulp_webserver_ssl_cert is defined %}
+{% if pulp_webserver_tls_cert is defined %}
   # HSTS (15768000 seconds = 6 months)
   Header always set Strict-Transport-Security "max-age=15768000;; includeSubDomains; preload"
 {% endif %}
@@ -72,8 +76,18 @@ Define pulp-api {{ pulp_api_bind }}
 
   IncludeOptional pulp/*.conf
 
-  # static files are served through whitenoise - http://whitenoise.evans.io/en/stable/
+  # most pulp static files are served through whitenoise
+  # http://whitenoise.evans.io/en/stable/
   ProxyPass / http://${pulp-api}/
   ProxyPassReverse / http://${pulp-api}/
+
+  # ACME http-01 tokens, i.e, for Let's Encrypt
+  <Location "/.well-known">
+    AllowOverride None
+    ProxyPass "!"
+    ProxyPassReverse "!"
+    Require all granted
+  </Location>
+
 </VirtualHost>
 {% endif %}


### PR DESCRIPTION
As an installer user, I can configure Pulp to run with TLS enabled to install/renew using letsencrypt certificates

fixes: #6846
https://pulp.plan.io/issues/6846