### PR TITLE
Problem: pulp_installer installs TLS certs in /etc/pulp

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,4 +5,5 @@ skip_list:
 exclude_paths:
   - ./roles/geerlingguy.postgresql/
   - ../../.ansible/roles/geerlingguy.postgresql/
+  - ../../.ansible/roles/lexa-uw.letsencrypt/
   - ./.github/

--- a/CHANGES/7328.removal
+++ b/CHANGES/7328.removal
@@ -1,0 +1,6 @@
+The default location for Pulp Webserver's TLS certificates was changed from /etc/pulp to /etc/pulp/certs/ .
+Users that wish to continue using their current certificate and key must run
+`sudo mv -t /etc/pulp/certs/ /etc/pulp/pulp_webserver.{key,crt}` before upgrading / running
+the new pulp_installer version. Alternatively, users can control the directory with the variable
+`pulp_certs_dir`, which was renamed from `pulp_webserver_tls_folder`. `pulp_certs_dir` now also
+controls where the keys for API authentication tokens are installed as well.

--- a/roles/pulp_api/README.md
+++ b/roles/pulp_api/README.md
@@ -23,6 +23,8 @@ Shared variables
 This role **is tightly coupled** to the required `pulp_common` role, and inherits
 some of its variables.
 
+* `pulp_certs_dir`: Path where to generate or drop the keys for authentication tokens. Defaults to
+  '{{ pulp_config_dir }}/certs' .
 * `pulp_config_dir`
 * `pulp_group`
 * `pulp_install_dir`

--- a/roles/pulp_api/tasks/generate_token_auth_key.yml
+++ b/roles/pulp_api/tasks/generate_token_auth_key.yml
@@ -1,7 +1,7 @@
 ---
 - name: Look for token authentication key
   stat:
-    path: "{{ __pulp_common_pulp_pki_dir }}/token_private_key.pem"
+    path: "{{ pulp_certs_dir }}/token_private_key.pem"
     get_attributes: false
     get_checksum: false
     get_mime: false
@@ -11,7 +11,7 @@
 
 - name: Generate token authentication private key
   openssl_privatekey:
-    path: "{{ __pulp_common_pulp_pki_dir }}/token_private_key.pem"
+    path: "{{ pulp_certs_dir }}/token_private_key.pem"
     type: ECC
     curve: secp256r1
     owner: "{{ pulp_user }}"

--- a/roles/pulp_api/tasks/import_token_auth_key.yml
+++ b/roles/pulp_api/tasks/import_token_auth_key.yml
@@ -2,7 +2,7 @@
 - name: Import specified token authentication key
   copy:
     src: "{{ pulp_token_auth_key }}"
-    dest: "{{ __pulp_common_pulp_pki_dir }}/token_private_key.pem"
+    dest: "{{ pulp_certs_dir }}/token_private_key.pem"
     owner: "{{ pulp_user }}"
     group: "{{ pulp_group }}"
     mode: 0600

--- a/roles/pulp_api/tasks/main.yml
+++ b/roles/pulp_api/tasks/main.yml
@@ -27,7 +27,7 @@
 
     - name: Create cert directory to hold token authentication key
       file:
-        path: "{{ __pulp_common_pulp_pki_dir }}"
+        path: "{{ pulp_certs_dir }}"
         state: directory
         owner: "{{ pulp_user }}"
         group: "{{ pulp_group }}"
@@ -42,8 +42,8 @@
 
     - name: Extract token authentication public key
       openssl_publickey:
-        path: "{{ __pulp_common_pulp_pki_dir }}/token_public_key.pem"
-        privatekey_path: "{{ __pulp_common_pulp_pki_dir }}/token_private_key.pem"
+        path: "{{ pulp_certs_dir }}/token_public_key.pem"
+        privatekey_path: "{{ pulp_certs_dir }}/token_private_key.pem"
         owner: "{{ pulp_user }}"
         group: "{{ pulp_group }}"
       become: true
@@ -53,8 +53,8 @@
 
     - name: Extract token authentication public key (ansible 2.8 workaround)
       command:
-        cmd: "openssl ec -in {{ __pulp_common_pulp_pki_dir }}/token_private_key.pem -pubout -out {{ __pulp_common_pulp_pki_dir }}/token_public_key.pem"
-        creates: "{{ __pulp_common_pulp_pki_dir }}/token_public_key.pem"
+        cmd: "openssl ec -in {{ pulp_certs_dir }}/token_private_key.pem -pubout -out {{ pulp_certs_dir }}/token_public_key.pem"
+        creates: "{{ pulp_certs_dir }}/token_public_key.pem"
       become: true
       become_user: "{{ pulp_user }}"
       when:

--- a/roles/pulp_common/README.md
+++ b/roles/pulp_common/README.md
@@ -99,6 +99,9 @@ Role Variables
   subscription-manager/katello.
   Also accepts a single string or empty string.
   Only affects RHEL7 (RHEL8 no longer has an optional repo.)
+* `pulp_certs_dir`: Path where to generate or drop the TLS certificates & keys for authentication
+  tokens. Not used directly by pulp_common, but by roles that depend on it. Defaults to
+  '{{ pulp_config_dir }}/certs' .
 
 Role Variables if installing from RPMs
 --------------------------------------

--- a/roles/pulp_common/vars/main.yml
+++ b/roles/pulp_common/vars/main.yml
@@ -10,7 +10,7 @@ pulp_install_plugins_normalized_yml: |-
 # A pulp_install_plugins but with the plugin names corrected:
 # pip/PyPI only uses dashes, not underscores.
 pulp_install_plugins_normalized: "{{ pulp_install_plugins_normalized_yml | from_yaml }}"
-__pulp_common_pulp_pki_dir: "{{ pulp_config_dir }}/certs"
+pulp_certs_dir: "{{ pulp_config_dir }}/certs"
 # Users should not set this variable, instead using `pulp_settings`
 __pulp_common_pulp_settings_defaults:
   databases:
@@ -20,8 +20,8 @@ __pulp_common_pulp_settings_defaults:
       NAME: pulp
       USER: pulp
       PASSWORD: pulp
-  private_key_path: "{{ __pulp_common_pulp_pki_dir }}/token_private_key.pem"
-  public_key_path: "{{ __pulp_common_pulp_pki_dir }}/token_public_key.pem"
+  private_key_path: "{{ pulp_certs_dir }}/token_private_key.pem"
+  public_key_path: "{{ pulp_certs_dir }}/token_public_key.pem"
   token_server: "https://{{ ansible_facts.fqdn }}/token"
   token_signature_algorithm: ES256
 __pulp_common_merged_pulp_settings: "{{ __pulp_common_pulp_settings_defaults|combine(pulp_settings, recursive=True) }}"

--- a/roles/pulp_webserver/README.md
+++ b/roles/pulp_webserver/README.md
@@ -18,8 +18,6 @@ Role Variables
 * `pulp_configure_firewall` Install and configure a firewall. Valid values are 'auto', 'firewalld',
   and 'none'. Defaults to 'auto' (which is the same as 'firewalld', but may change in the future).
 * `pulp_webserver_disable_https`: Whether or not HTTPS should be disabled. Defaults to `false`.
-* `pulp_webserver_tls_folder`: Path where to generate or drop the certificates. Defaults to
-  `pulp_config_dir`.
 * `pulp_webserver_tls_cert`: Relative or absolute path to the TLS (SSL) certificate
    one wants to import.
 * `pulp_webserver_tls_key`: Relative or absolute path to the TLS (SSL) key
@@ -76,6 +74,8 @@ Shared variables
 This role **is tightly coupled** to the required `pulp_common` role, and inherits
 some of its variables.
 
+* `pulp_certs_dir`: Path where to generate or drop the TLS certificates. Defaults to
+  '{{ pulp_config_dir }}/certs' .
 * `pulp_install_dir`: Location of a virtual environment for Pulp and its Python
   dependencies.
 * `pulp_install_plugins` (technically `pulp_install_plugins_normalized`). The list

--- a/roles/pulp_webserver/defaults/main.yml
+++ b/roles/pulp_webserver/defaults/main.yml
@@ -5,7 +5,7 @@ pulp_api_bind: '127.0.0.1:24817'
 pulp_configure_firewall: auto
 
 pulp_webserver_disable_https: false
-pulp_webserver_tls_folder: '{{ pulp_config_dir }}'
+pulp_certs_dir: '{{ pulp_config_dir }}/certs'
 pulp_webserver_httpd_servername: '{{ ansible_facts.fqdn }}'
 # The "static" dir is used by Pulp 2, and has conflicting SELinux policies.
 # https://pulp.plan.io/issues/5995

--- a/roles/pulp_webserver/tasks/generate_tls_certificates.yml
+++ b/roles/pulp_webserver/tasks/generate_tls_certificates.yml
@@ -1,12 +1,12 @@
 ---
 - name: Ensure python-cryptography is installed
   package:
-    name: '{{ pulp_webserver_python_cryptography }}'
+    name: '{{ pulp_python_cryptography }}'
   become: true
 
 - name: Look for CA certificate
   stat:
-    path: '{{ pulp_webserver_tls_folder }}/root.crt'
+    path: '{{ pulp_certs_dir }}/root.crt'
     get_attributes: false
     get_checksum: false
     get_mime: false
@@ -16,12 +16,12 @@
   block:
     - name: Generate CA key
       openssl_privatekey:
-        path: '{{ pulp_webserver_tls_folder }}/root.key'
+        path: '{{ pulp_certs_dir }}/root.key'
 
     - name: Generate CA CSR
       openssl_csr:
-        path: '{{ pulp_webserver_tls_folder }}/root.csr'
-        privatekey_path: '{{ pulp_webserver_tls_folder }}/root.key'
+        path: '{{ pulp_certs_dir }}/root.csr'
+        privatekey_path: '{{ pulp_certs_dir }}/root.key'
         common_name: '{{ pulp_webserver_httpd_servername }}'
         organization_name: Pulp
         country_name: US
@@ -29,15 +29,15 @@
 
     - name: Generate CA certificate
       openssl_certificate:
-        path: '{{ pulp_webserver_tls_folder }}/root.crt'
-        csr_path: '{{ pulp_webserver_tls_folder }}/root.csr'
-        privatekey_path: '{{ pulp_webserver_tls_folder }}/root.key'
+        path: '{{ pulp_certs_dir }}/root.crt'
+        csr_path: '{{ pulp_certs_dir }}/root.csr'
+        privatekey_path: '{{ pulp_certs_dir }}/root.key'
         provider: selfsigned
   when: not __pulp_webserver_ca_cert.stat.exists
 
 - name: Look for webserver certificate
   stat:
-    path: '{{ pulp_webserver_tls_folder }}/pulp_webserver.crt'
+    path: '{{ pulp_certs_dir }}/pulp_webserver.crt'
     get_attributes: false
     get_checksum: false
     get_mime: false
@@ -47,14 +47,14 @@
   block:
     - name: Generate private keys
       openssl_privatekey:
-        path: '{{ pulp_webserver_tls_folder }}/pulp_webserver.key'
+        path: '{{ pulp_certs_dir }}/pulp_webserver.key'
         owner: root
         group: "{{ pulp_group }}"
 
     - name: Generate CSRs standalone
       openssl_csr:
-        path: '{{ pulp_webserver_tls_folder }}/pulp_webserver.csr'
-        privatekey_path: '{{ pulp_webserver_tls_folder }}/pulp_webserver.key'
+        path: '{{ pulp_certs_dir }}/pulp_webserver.csr'
+        privatekey_path: '{{ pulp_certs_dir }}/pulp_webserver.key'
         common_name: '{{ pulp_webserver_httpd_servername }}'
         subject_alt_name: 'DNS:{{ pulp_webserver_httpd_servername }}'
         key_usage:
@@ -67,12 +67,12 @@
 
     - name: Generate certificates
       openssl_certificate:
-        path: '{{ pulp_webserver_tls_folder }}/pulp_webserver.crt'
-        csr_path: '{{ pulp_webserver_tls_folder }}/pulp_webserver.csr'
-        privatekey_path: '{{ pulp_webserver_tls_folder }}/pulp_webserver.key'
+        path: '{{ pulp_certs_dir }}/pulp_webserver.crt'
+        csr_path: '{{ pulp_certs_dir }}/pulp_webserver.csr'
+        privatekey_path: '{{ pulp_certs_dir }}/pulp_webserver.key'
         provider: ownca
-        ownca_path: '{{ pulp_webserver_tls_folder }}/root.crt'
-        ownca_privatekey_path: '{{ pulp_webserver_tls_folder }}/root.key'
+        ownca_path: '{{ pulp_certs_dir }}/root.crt'
+        ownca_privatekey_path: '{{ pulp_certs_dir }}/root.key'
         ownca_not_after: '+824d'
         owner: root
         group: "{{ pulp_group }}"
@@ -80,7 +80,7 @@
 
 - name: Cleanup CSR files
   file:
-    path: '{{ pulp_webserver_tls_folder }}/{{ item }}'
+    path: '{{ pulp_certs_dir }}/{{ item }}'
     state: absent
   loop:
     - root.csr

--- a/roles/pulp_webserver/tasks/import_certificates.yml
+++ b/roles/pulp_webserver/tasks/import_certificates.yml
@@ -2,7 +2,7 @@
 - name: Import specified TLS certificate
   copy:
     src: "{{ pulp_webserver_tls_cert }}"
-    dest: "{{ pulp_webserver_tls_folder }}/pulp_webserver.crt"
+    dest: "{{ pulp_certs_dir }}/pulp_webserver.crt"
     owner: root
     group: "{{ pulp_group }}"
     mode: 0600
@@ -12,7 +12,7 @@
 - name: Import specified TLS private key
   copy:
     src: "{{ pulp_webserver_tls_key }}"
-    dest: "{{ pulp_webserver_tls_folder }}/pulp_webserver.key"
+    dest: "{{ pulp_certs_dir }}/pulp_webserver.key"
     owner: root
     group: "{{ pulp_group }}"
     mode: 0600

--- a/roles/pulp_webserver/tasks/main.yml
+++ b/roles/pulp_webserver/tasks/main.yml
@@ -37,6 +37,15 @@
   changed_when: false
   check_mode: false
 
+- name: Create cert directory to hold SSL certificates
+  file:
+    path: "{{ pulp_certs_dir }}"
+    state: directory
+    owner: "{{ pulp_user }}"
+    group: "{{ pulp_group }}"
+    mode: 0700
+  become: true
+
 - include_tasks: generate_tls_certificates.yml
   args:
     apply:

--- a/roles/pulp_webserver/templates/nginx.conf.j2
+++ b/roles/pulp_webserver/templates/nginx.conf.j2
@@ -38,8 +38,8 @@ http {
         listen 443 default_server deferred ssl;
         listen [::]:443 default_server deferred ssl;
 
-        ssl_certificate {{ pulp_webserver_tls_folder }}/pulp_webserver.crt;
-        ssl_certificate_key {{ pulp_webserver_tls_folder }}/pulp_webserver.key;
+        ssl_certificate {{ pulp_certs_dir }}/pulp_webserver.crt;
+        ssl_certificate_key {{ pulp_certs_dir }}/pulp_webserver.key;
         ssl_session_cache shared:SSL:50m;
         ssl_session_timeout 1d;
         ssl_session_tickets off;

--- a/roles/pulp_webserver/templates/pulp-vhost.conf.j2
+++ b/roles/pulp_webserver/templates/pulp-vhost.conf.j2
@@ -45,8 +45,8 @@ Define pulp-api {{ pulp_api_bind }}
 
   ## TLS Configuration
   SSLEngine On
-  SSLCertificateFile {{ pulp_webserver_tls_folder }}/pulp_webserver.crt
-  SSLCertificateKeyFile {{ pulp_webserver_tls_folder }}/pulp_webserver.key
+  SSLCertificateFile {{ pulp_certs_dir }}/pulp_webserver.crt
+  SSLCertificateKeyFile {{ pulp_certs_dir }}/pulp_webserver.key
   SSLProtocol TLSv1.2
   SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
   SSLHonorCipherOrder on

--- a/roles/pulp_webserver/vars/CentOS-7.yml
+++ b/roles/pulp_webserver/vars/CentOS-7.yml
@@ -11,4 +11,3 @@ pulp_webserver_apache_snippets_dir: /etc/httpd/pulp
 pulp_webserver_apache_log_dir: /var/log/httpd
 pulp_webserver_trusted_root_certificates_path: /etc/pki/ca-trust/source/anchors/
 pulp_webserver_trusted_root_certificates_update_bin: update-ca-trust
-pulp_webserver_python_cryptography: python-cryptography

--- a/roles/pulp_webserver/vars/Debian.yml
+++ b/roles/pulp_webserver/vars/Debian.yml
@@ -6,4 +6,3 @@ pulp_webserver_apache_snippets_dir: /etc/apache2/pulp
 pulp_webserver_apache_log_dir: /var/log/apache2
 pulp_webserver_trusted_root_certificates_path: /usr/local/share/ca-certificates/
 pulp_webserver_trusted_root_certificates_update_bin: update-ca-certificates
-pulp_webserver_python_cryptography: python3-cryptography

--- a/roles/pulp_webserver/vars/Fedora.yml
+++ b/roles/pulp_webserver/vars/Fedora.yml
@@ -11,4 +11,3 @@ pulp_webserver_apache_snippets_dir: /etc/httpd/pulp
 pulp_webserver_apache_log_dir: /var/log/httpd
 pulp_webserver_trusted_root_certificates_path: /etc/pki/ca-trust/source/anchors/
 pulp_webserver_trusted_root_certificates_update_bin: update-ca-trust
-pulp_webserver_python_cryptography: python3-cryptography


### PR DESCRIPTION
rather than /etc/pulp/certs/ like we decided it would, and the
pulpcore docs say it defaults to.

Solution: Set the new location to /etc/pulp/certs.

And deduplicate the variables for installing python's crypto library
and the dir to use for API authentication tokens, which already was
/etc/pulp/certs .

No automated solution will be provided to move the keys, we will simply
release ASAP before too many user installs get the wrong location.
And tell users to move their keys.

fixes: #7328
pulp_installer and ssl docs disagree
https://pulp.plan.io/issues/7328