### PR TITLE
Problem: pulplift dev environment is failing to build

### DIFF
--- a/CHANGES/7359.bugfix
+++ b/CHANGES/7359.bugfix
@@ -1,0 +1,4 @@
+Fix failure on task "pulp_common: Make /var/lib/pulp world executable" by creating the directory
+(and giving it owner user permissions as well). Occurs when specifying an existing user account
+as pulp_user but not having /var/lib/pulp (`pulp_user_home`) already present. pulplift would
+trigger this.

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -68,12 +68,18 @@
     - name: Reset ssh conn to allow user changes to affect when ssh user and pulp user are the same
       meta: reset_connection
 
-    # Needed for ngingx/apache to serve content at pulp_webserver_static_dir,
-    # which is the subdir pulpcore_static by default.
-    - name: Make {{ pulp_user_home }} world executable
+    # World executable is needed for ngingx/apache to serve content at
+    # pulp_webserver_static_dir, which is the subdir pulpcore_static by default.
+    #
+    # We need to create it in case the pulp_user already exists
+    # and has a different home dir. Like "vagrant" for pulplift.
+    - name: Make sure {{ pulp_user_home }} is world executable, and exists
       file:
         path: '{{ pulp_user_home }}'
-        mode: 'o+x'
+        state: directory
+        mode: 'u+rwx,o+x'
+        owner: '{{ pulp_user }}'
+        group: '{{ pulp_group }}'
 
     - name: Create cache dir for Pulp
       file:


### PR DESCRIPTION
Solution: Always create pulp_user_home . And give it owner user rwx
permissions also.

fixes: #7359
https://pulp.plan.io/issues/7359