### PR TITLE
ansible lint rule to find lack of mode: usage

### DIFF
--- a/scripts/ansible_lint_rules/FileTypeModuleHasMode.py
+++ b/scripts/ansible_lint_rules/FileTypeModuleHasMode.py
@@ -1,0 +1,21 @@
+# Chris Meyers
+
+from ansiblelint import AnsibleLintRule
+
+
+class FileTypeModuleHasMode(AnsibleLintRule):
+    """ test it """
+
+    id = 'ANSIBLE921'
+    shortdesc = "Ensure mode is explicitly set"
+    description = "Ensure mode is explicitly set when a new file COULD potentially be created"
+    tags = ['mode', 'file']
+
+    _commands = ['acl', 'archive', 'assemble', 'copy', 'fetch', 'file', 'ini_file', 'iso_extract', 'lineinfile', 'patch', 'tempfile', 'template', 'unarchive', 'xattr']
+
+    def matchtask(self, file, task):
+        if task["action"]["__ansible_module__"] in self._commands:
+            if task["action"].get("state", "present") == "absent":
+                return False
+            return not bool(task["action"].get('mode', False))
+        return False

--- a/scripts/lint_mode.py
+++ b/scripts/lint_mode.py
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+function run_ansible_lint {
+    base_dir=$(dirname "$(readlink -f "$0")")
+    cd $base_dir/../
+    roles_dirs=($(find . -maxdepth 1 -name roles -not -path "*ansible_collections*" -not -path "./tar-build/*"))
+    role_dirs=( )
+
+    for i in "${roles_dirs[@]}"
+    do
+        role_dirs+=($(find $i -maxdepth 1))
+    done
+
+    ansible-lint -t file -r $base_dir/ansible_lint_rules "${role_dirs[@]}"
+}
+
+run_ansible_lint


### PR DESCRIPTION
* Recent Ansible CVE required Ansible to change the default behavior of
file type modes such that if mode is node specified explicitly, newly
created files would default to mode '0600'. Before this CVE fix the
default mode was '0644`. This can cause problems.
* pip install ansible-lint
* Run scripts/lint_mode.sh

### 3.6.0 Results
```
ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_common/tasks/ambiguously-named-repo.yml:9
Task/Handler: Enable the {{ item }} repo

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_common/tasks/install_pip.yml:2
Task/Handler: Create pulp install dir

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_common/tasks/install_pip.yml:35
Task/Handler: Update any existing venv to allow system-wide packages

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_common/tasks/install_pip.yml:53
Task/Handler: Create requirements.in file to check pulpcore/plugin compatibility

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_common/tasks/install_pip.yml:180
Task/Handler: Create constraints file to lock the pulpcore version when plugins are installed

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_common/tasks/preflight_function.yml:25
Task/Handler: Backup currently installed packages for any potential troubleshooting purposes

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_common/tasks/repos.yml:82
Task/Handler: Enable the CentOS PowerTools repo

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_common/tasks/repos.yml:102
Task/Handler: Enable the CentOS Stream-PowerTools PowerTools repo

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_database/tasks/install_postgres.yml:19
Task/Handler: Enable PostgreSQL SCL

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_devel/tasks/bashrc.yml:3
Task/Handler: Create ~/.bashrc.d/

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_devel/tasks/bashrc.yml:8
Task/Handler: Define developer aliases in ~/.bashrc.d/

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_devel/tasks/bashrc.yml:25
Task/Handler: Add Django supplemental bashrc

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_devel/tasks/bashrc.yml:30
Task/Handler: Add virtualenv supplemental bashrc

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_devel/tasks/bashrc.yml:45
Task/Handler: Add fzf bashrc

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_devel/tasks/config_files.yml:2
Task/Handler: Create ~/.vimrc if not already present

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_devel/tasks/config_files.yml:15
Task/Handler: Create pulp-smash config directory if not already present

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_devel/tasks/config_files.yml:21
Task/Handler: Create pulp-smash config if not already present

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_devel/tasks/install_basic_packages.yml:66
Task/Handler: Create virtualenvwrapper symlink

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_devel/tasks/main.yml:34
Task/Handler: Set the message of the day

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_redis/tasks/configure_tcp.yml:2
Task/Handler: Ensure Redis will listen on the specified TCP socket

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_redis/tasks/configure_uds.yml:8
Task/Handler: Ensure Redis will not listen on a TCP socket

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_redis/tasks/main.yml:23
Task/Handler: Enable Redis SCL

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_webserver/tasks/apache.yml:9
Task/Handler: Install Apache vhost file

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_webserver/tasks/apache.yml:15
Task/Handler: Enable Apache vhost files and mod files

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_webserver/tasks/apache.yml:28
Task/Handler: Create directory for Pulp Apache snippets

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_webserver/tasks/apache.yml:36
Task/Handler: Symlink Apache snippets

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_webserver/tasks/nginx.yml:17
Task/Handler: Install Nginx configuration file

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_webserver/tasks/nginx.yml:38
Task/Handler: Create directory for Pulp Nginx snippets

ANSIBLE921 Ensure mode is explicitly set
/home/meyers/ansible/pulp_installer/roles/pulp_webserver/tasks/nginx.yml:46
Task/Handler: Symlink nginx snippets

```