### PR TITLE
support per pulp_install_plugins source_dir vcs

### DIFF
--- a/CHANGES/7382.bugfix
+++ b/CHANGES/7382.bugfix
@@ -1,0 +1,1 @@
+Fixed bug where pulp_install_plugins source_dir vcs was being used when checking depdencies via pip-compile

--- a/roles/pulp_common/templates/requirements.in.j2
+++ b/roles/pulp_common/templates/requirements.in.j2
@@ -1,6 +1,10 @@
 pulpcore=={{ pulp_version }}
 {% for plugin, value in pulp_install_plugins_normalized.items() %}
+{% if value['source_dir'] is defined -%}
+-e {{ value['source_dir'] }}
+{% else -%}
 {{ plugin }}{% if value['version'] is defined and value['version']|length %}=={{ value['version'] }}{% endif %}
+{% endif %}
 
 {% endfor %}
 # Any plugins listed below were already installed but not specified in


### PR DESCRIPTION
Problem: The requirements.in file that pip-compile consumes only
includes the package name and not the source_dir

Solution: Per pulp_install_plugins source_dir entries that are vcs are
added to the pip-compile requirements.in so that the pip-compile line
will have all the information available to decide if requirements and
dependencies are met.

fixes: #7382
https://pulp.plan.io/issues/7382
