### PR TITLE
Update playbook.yml: Ansible version bump

### DIFF
--- a/playbooks/example-use/playbook.yml
+++ b/playbooks/example-use/playbook.yml
@@ -5,9 +5,9 @@
     # "min_ansible_version". It needs to be kept manually up-to-date.
     - name: Verify Ansible meets min required version
       assert:
-        that: "ansible_version.full is version_compare('2.8', '>=')"
+        that: "ansible_version.full is version_compare('2.9', '>=')"
         msg: >
-          "You must update Ansible to at least 2.8 to use this version of Pulp 3 Installer."
+          "You must update Ansible to at least 2.9 to use this version of Pulp 3 Installer."
   roles:
     - pulp_all_services
   environment:


### PR DESCRIPTION
The pulp_installer set of Ansible playbooks now require at least Ansible version
2.9. Bumping the version here to reflect that requirement.
[noissue]