### PR TITLE
Allow auth migrations to work when installing galaxy_ng plugin

### DIFF
--- a/CHANGES/7493.bugfix
+++ b/CHANGES/7493.bugfix
@@ -1,0 +1,1 @@
+Allow auth migrations to work for galaxy_ng

--- a/roles/pulp_database_config/tasks/main.yml
+++ b/roles/pulp_database_config/tasks/main.yml
@@ -20,11 +20,13 @@
 - meta: flush_handlers
 
 - block:
-
     - name: Run database auth migrations
       command: '{{ pulp_django_admin_path }} migrate auth --no-input'
       register: migrate_auth
       changed_when: "'No migrations to apply' not in migrate_auth.stdout"
+      environment:
+        # Stops django-guardian from creating an anonymous user
+        PULP_ANONYMOUS_USER_NAME: '@none None'
 
     - name: Run database migrations
       command: '{{ pulp_django_admin_path }} migrate --no-input'


### PR DESCRIPTION
Set environment variable `PULP_ANONYMOUS_USER_NAME` to prevent `django-guardian` from attempting to create an anonymous user during Auth migrations. Without this environment variable Auth migrations fail when installing the [galaxy_ng plugin](https://github.com/ansible/galaxy_ng).

fixes: #7493