### PR TITLE
Fix auth migrations being run for galaxy_ng.

### DIFF
--- a/CHANGES/7493.bugfix
+++ b/CHANGES/7493.bugfix
@@ -1,1 +1,0 @@
-Allow auth migrations to work for galaxy_ng

--- a/CHANGES/7493.bugfix
+++ b/CHANGES/7493.bugfix
@@ -1,0 +1,3 @@
+Fix auth migrations being run for galaxy_ng. Due to code removal, the
+pulp_default_admin_password is now set whenever pulpcore is 1st installed, updated/upgraded,
+or when `pulp_upgraded_manually==true`.

--- a/roles/pulp_common/tasks/install_packages.yml
+++ b/roles/pulp_common/tasks/install_packages.yml
@@ -1,17 +1,21 @@
 ---
 - block:
 
-    - name: "Install the Pulp undeclared {{ ansible_facts.pkg_mgr }} package dependencies"
+    - name: "Install pulpcore via {{ ansible_facts.pkg_mgr }} packages"
       package:
-        name: "{{ pulp_pkg_undeclared_deps }}"
+        name: "{{ pulp_pkg_pulpcore_name }}"
         state: "{{ pulp_pkg_upgrade_all | ternary('latest','present') }}"
+      register: pulpcore_install_pkgs
       notify:
         - Collect static content
         - Restart all Pulp services
 
-    - name: "Install pulpcore via {{ ansible_facts.pkg_mgr }} packages"
+    # This includes the SELinux package, which actually depends on pulpcore.
+    # So we install these after installing pulpcore, to ensure that
+    # pulpcore_install_pkgs.changed is correctly determined.
+    - name: "Install the Pulp undeclared {{ ansible_facts.pkg_mgr }} package dependencies"
       package:
-        name: "{{ pulp_pkg_pulpcore_name }}"
+        name: "{{ pulp_pkg_undeclared_deps }}"
         state: "{{ pulp_pkg_upgrade_all | ternary('latest','present') }}"
       notify:
         - Collect static content

--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -147,6 +147,7 @@
       when: pulp_source_dir is undefined
       environment:
         SETUPTOOLS_USE_DISTUTILS: stdlib
+      register: pulpcore_install_pypi
       notify:
         - Collect static content
         - Restart all Pulp services
@@ -163,14 +164,14 @@
       when: pulp_source_dir is defined
       environment:
         SETUPTOOLS_USE_DISTUTILS: stdlib
-      register: result
-      # This is a hack. Editable pip installs are always changed, which fails molecule's
-      # idempotence test.
-      # Unfortunately, this will prevent the handlers from being notified.
-      changed_when: result.changed and not pulp_pip_editable
+      register: pulpcore_install_src
       notify:
         - Collect static content
         - Restart all Pulp services
+      # Editable pip installs are always changed, which fails molecule's idempotence test.
+      # Unfortunately, this will prevent the handlers from being notified.
+      tags:
+        - molecule-idempotence-notest
 
     # We have to do this separate task, even though the pip module should
     # register the installed version, because when tested (Ansible 2.9, with no
@@ -230,14 +231,13 @@
       when: item.value.source_dir is defined
       environment:
         SETUPTOOLS_USE_DISTUTILS: stdlib
-      register: result
-      # This is a hack. Editable pip installs are always changed, which fails molecule's
-      # idempotence test.
-      # Unfortunately, this will prevent the handlers from being notified.
-      changed_when: result.changed and not pulp_pip_editable
       notify:
         - Collect static content
         - Restart all Pulp services
+      # Editable pip installs are always changed, which fails molecule's idempotence test.
+      # Unfortunately, this will prevent the handlers from being notified.
+      tags:
+        - molecule-idempotence-notest
 
     - name: Install gunicorn via PyPI
       pip:

--- a/roles/pulp_database_config/README.md
+++ b/roles/pulp_database_config/README.md
@@ -11,7 +11,8 @@ More specifically, this role does the following via `django-admin`:
 Role Variables
 --------------
 
-`pulp_default_admin_password`: Initial password for the Pulp admin. **Required**.
+`pulp_default_admin_password`: Initial password for the Pulp admin. Is set whenever
+pulp is installed, updated/upgraded, or `pulp_upgraded_manually==true`. **Required**
 
 Shared Variables
 ----------------
@@ -26,6 +27,7 @@ variables which are documented in that role:
 * `pulp_django_admin_paths`
 * `pulp_settings_file`
 * `pulp_user`
+* `pulp_upgraded_manually`
 
 This role understands how to talk to the database server via `pulp_settings_file`,
 which is written to disk in the `pulp_common` role, and whose relevant

--- a/roles/pulp_database_config/tasks/main.yml
+++ b/roles/pulp_database_config/tasks/main.yml
@@ -20,13 +20,11 @@
 - meta: flush_handlers
 
 - block:
+
     - name: Run database auth migrations
       command: '{{ pulp_django_admin_path }} migrate auth --no-input'
       register: migrate_auth
       changed_when: "'No migrations to apply' not in migrate_auth.stdout"
-      environment:
-        # Stops django-guardian from creating an anonymous user
-        PULP_ANONYMOUS_USER_NAME: '@none None'
 
     - name: Run database migrations
       command: '{{ pulp_django_admin_path }} migrate --no-input'

--- a/roles/pulp_database_config/tasks/main.yml
+++ b/roles/pulp_database_config/tasks/main.yml
@@ -21,11 +21,6 @@
 
 - block:
 
-    - name: Run database auth migrations
-      command: '{{ pulp_django_admin_path }} migrate auth --no-input'
-      register: migrate_auth
-      changed_when: "'No migrations to apply' not in migrate_auth.stdout"
-
     - name: Run database migrations
       command: '{{ pulp_django_admin_path }} migrate --no-input'
       register: result
@@ -34,7 +29,14 @@
     - name: Set the Pulp admin user's password
       command: '{{ pulp_django_admin_path }} reset-admin-password --password {{ pulp_default_admin_password }}'
       no_log: true
-      when: pulp_default_admin_password is defined and migrate_auth.changed
+      # Only gets run when pulpcore gets installed or updated/upgraded.
+      # Using 1 combined variable for all 3 types of install seemed to always be
+      # false when it was skipped later, so let's use separate vars.
+      when: >
+        pulpcore_install_pypi.changed | default(false) or
+        pulpcore_install_src.changed | default(false) or
+        pulpcore_install_pkgs.changed | default(false) or
+        pulp_upgraded_manually
 
   run_once: "{{ __pulp_database_config_run_once }}"
   become: true


### PR DESCRIPTION
Due to code removal, the pulp_default_admin_password is now set
whenever pulpcore is 1st installed, updated/upgraded,
or when `pulp_upgraded_manually==true`.

By letting the anonymous user get created, we help keep Pulp consistent pulp_installer 3.6.0 through 3.6.3 was run or whether future versions of it get run.

fixes: #7493