### PR TITLE
Adopt a new pattern to specify defined/undefined for tls variables

### DIFF
--- a/roles/pulp_webserver/defaults/main.yml
+++ b/roles/pulp_webserver/defaults/main.yml
@@ -11,3 +11,19 @@ pulp_webserver_httpd_servername: '{{ ansible_facts.fqdn }}'
 # https://pulp.plan.io/issues/5995
 pulp_webserver_static_dir: "{{ pulp_user_home | regex_replace('\\/$', '') }}/pulpcore_static"
 pulp_webserver_tls_files_remote: false
+
+# To fit nicely with other roles calling pulp_installer.pulp_webserver it is a
+# good idea to handle the case when wrapper call the role with value defined
+# but set to '' - to act as undefined. Without the following the following
+# statement will be evaluated to truthy (because it ends up being defined)
+# when really it should be falsy:
+#
+# - name: Include role
+#   include_role
+#     name: pulp_webserver
+#   vars:
+#     pulp_webserver_tls_key: '{{ myundefvar | default("") }}'
+#
+pulp_webserver_tls_key: ''
+pulp_webserver_tls_cert: ''
+pulp_webserver_tls_custom_ca_cert: ''

--- a/roles/pulp_webserver/tasks/main.yml
+++ b/roles/pulp_webserver/tasks/main.yml
@@ -17,8 +17,8 @@
   fail:
     msg: "If you give one of pulp_webserver_tls_cert and pulp_webserver_tls_key, you must also give the other."
   when:
-    - "pulp_webserver_tls_cert is defined or pulp_webserver_tls_key is defined"
-    - "pulp_webserver_tls_cert is not defined or pulp_webserver_tls_key is not defined"
+    - pulp_webserver_tls_cert | length or pulp_webserver_tls_key | length
+    - not pulp_webserver_tls_cert | length or not pulp_webserver_tls_key | length
 
 - debug:
     msg: >
@@ -51,16 +51,16 @@
     apply:
       become: true
   when:
-    - pulp_webserver_tls_cert is undefined
-    - pulp_webserver_tls_key is undefined
+    - not pulp_webserver_tls_cert | length
+    - not pulp_webserver_tls_key | length
 
 - include_tasks: import_certificates.yml
   args:
     apply:
       become: true
   when:
-    - pulp_webserver_tls_cert is defined
-    - pulp_webserver_tls_key is defined
+    - pulp_webserver_tls_cert | length
+    - pulp_webserver_tls_key | length
 
 - name: Copy custom CA cert
   copy:
@@ -70,7 +70,7 @@
     owner: root
     group: root
     remote_src: "{{ pulp_webserver_tls_files_remote }}"
-  when: pulp_webserver_tls_custom_ca_cert is defined
+  when: pulp_webserver_tls_custom_ca_cert | length
   become: true
   notify: update ca trust
 

--- a/roles/pulp_webserver/templates/nginx.conf.j2
+++ b/roles/pulp_webserver/templates/nginx.conf.j2
@@ -49,7 +49,7 @@ http {
         ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
         ssl_prefer_server_ciphers on;
 
-        {% if pulp_webserver_tls_cert is defined %}
+        {% if pulp_webserver_tls_cert | length %}
         # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
         add_header Strict-Transport-Security max-age=15768000;
         {% endif %}

--- a/roles/pulp_webserver/templates/pulp-vhost.conf.j2
+++ b/roles/pulp_webserver/templates/pulp-vhost.conf.j2
@@ -51,7 +51,7 @@ Define pulp-api {{ pulp_api_bind }}
   SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
   SSLHonorCipherOrder on
 
-{% if pulp_webserver_tls_cert is defined %}
+{% if pulp_webserver_tls_cert | length %}
   # HSTS (15768000 seconds = 6 months)
   Header always set Strict-Transport-Security "max-age=15768000;; includeSubDomains; preload"
 {% endif %}


### PR DESCRIPTION
The goal of this commit is to adopt a new pattern for TLS related
variables so it can be easily embedded within another playbook.

Current Issue:

```
- name: Install Automation Hub via Pulp Installer
  include_role:
    name: "{{ item  }}"
  vars:
    pulp_webserver_tls_cert: "{{ mycert | default('') }}"
    pulp_webserver_tls_key: "{{ mykey | default('') }}"
  with_items:
    - "pulp.pulp_installer.pulp_redis"
    - "pulp.pulp_installer.pulp_services"
    - "pulp.pulp_installer.pulp_webserver"
```

That would be an ideal approach, but this would fail currently because
the variable itself - within the pulp webserver role scope - ends up
being defined (but empty) - so the play ends with `src (or content) is
required`.

With the approach suggested in this PR - This would easily allow people
to have a layer on top of the Pulp installer, and if they wish to
specify the value they can, else by default it would be considered
"undefine"

[noissue]