### PR TITLE
pulp_installer should compile & install the pulpcore-selinux policy

### DIFF
--- a/CHANGES/7573.removal
+++ b/CHANGES/7573.removal
@@ -1,0 +1,1 @@
+pulp_installer will no longer set SELinux to enabled, permissive and enforcing (casually referred to as "disabled") on CentOS/RHEL/Fedora.

--- a/CHANGES/7574.feature
+++ b/CHANGES/7574.feature
@@ -1,0 +1,1 @@
+Compile and install the pulpcore-selinux policy on CentOS/RHEL/Fedora.

--- a/roles/pulp_api/tasks/main.yml
+++ b/roles/pulp_api/tasks/main.yml
@@ -2,6 +2,18 @@
 # tasks file for pulp_api
 - block:
 
+    - name: Apply the SELinux type to the TCP port that pulpcore-api listens on
+      seport:
+        ports: '{{ pulp_api_bind.split(":")[1] }}'
+        proto: tcp
+        setype: pulpcore_port_t
+      become: true
+      when:
+        - not (pulp_api_bind.startswith('unix:'))
+        - ansible_facts.os_family == 'RedHat'
+        # We can also try using seport's ignore_selinux_state variable
+        - ansible_facts.selinux.status == "enabled"
+
     - name: Install pulpcore-api service files
       template:
         src: pulpcore-api.service.j2

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -52,3 +52,20 @@ pulp_pkg_undeclared_deps:
   - python3-djangorestframework-queryfields
 pulp_pkg_upgrade_all: false
 pulp_upgraded_manually: false
+
+# The order is significant; linear order to handle the dependency tree
+__pulp_selinux_policy_pkgs:
+  - pulpcore_port
+  - pulpcore
+  - pulpcore_rhsmcertd
+__pulp_selinux_repo: 'https://github.com/pulp/pulpcore-selinux.git'
+__pulp_selinux_version: 'master'
+__pulp_selinux_label_dirs:
+  - "{{ pulp_install_dir }}"
+  - "{{ pulp_config_dir }}"
+  - "{{ pulp_user_home }}"
+__pulp_selinux_label_dirs_optional:
+  # Depending on the roles applied yet whether or not Pulp is running, these may
+  # not exist, throwing error code 255 when a called command realizes nothing
+  # is present.
+  - "/var/run/pulpcore*"

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -59,7 +59,7 @@ __pulp_selinux_policy_pkgs:
   - pulpcore
   - pulpcore_rhsmcertd
 __pulp_selinux_repo: 'https://github.com/pulp/pulpcore-selinux.git'
-__pulp_selinux_version: 'master'
+__pulp_selinux_version: '1.1.1'
 __pulp_selinux_label_dirs:
   - "{{ pulp_install_dir }}"
   - "{{ pulp_config_dir }}"

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -52,8 +52,3 @@ pulp_pkg_undeclared_deps:
   - python3-djangorestframework-queryfields
 pulp_pkg_upgrade_all: false
 pulp_upgraded_manually: false
-
-# Unadvertised because we do not want to maintain this feature anymore after
-# the installer adds support for installing the SElinux policies.
-# Useful for testing the policies in the meantime.
-pulp_disable_selinux: true

--- a/roles/pulp_common/handlers/main.yml
+++ b/roles/pulp_common/handlers/main.yml
@@ -1,9 +1,25 @@
 ---
-# Workaround https://github.com/ansible/ansible/issues/34505
-# by not using include_tasks
-- name: Restart all Pulp services
-  include: handlers/restart_all_pulp.yml
-  static: no
+# These SELinux handlers are listed up top so that they are run 1st, before
+# Pulp is restarted.
+- name: Load the SELinux policy packages
+  command: 'semodule -i /usr/local/share/selinux/{{ ansible_facts.selinux.type }}/{{ item }}.pp'
+  loop: '{{ __pulp_selinux_policy_pkgs }}'
+
+# Note: we cannot flush handlers until after these are created later on in the
+# Pulp role, after the SELinux policies are installed.
+# Installing them earlier should mean the files are created with the context to
+# begin with.
+- name: Restore SELinux contexts on Pulp dirs that must exist
+  command: '/sbin/fixfiles restore {{ __pulp_selinux_label_dirs | join(" ") }}'
+  # We need the when condition on this particular SELinux handler because it
+  # gets triggered by "Collect static content".
+
+# shell for handling '*' in the dir name
+- name: Restore SELinux contexts on Pulp dirs that may exist
+  shell: '/sbin/fixfiles restore {{ __pulp_selinux_label_dirs_optional | join(" ") }}' # noqa 305
+  register: result
+  changed_when: result.rc == 0
+  failed_when: result.rc not in [0,255]
 
 - name: Collect static content
   command: "{{ pulp_django_admin_path }} collectstatic --noinput --link"
@@ -14,6 +30,24 @@
   # Restarting pulpcore-api is necessary for collectstatic to
   # work; whitenoise cannot see the files unless pulpcore-api is restarted.
   #
-  notify: Restart all Pulp services
+  notify:
+    # the pulpcore-manager command does not run in the context of the daemon
+    - Restore SELinux contexts on Pulp asset dirs
+    - Restart all Pulp services
   environment:
     PULP_SETTINGS: "{{ pulp_settings_file }}"
+
+- name: Restore SELinux contexts on Pulp asset dirs
+  command: '/sbin/fixfiles restore {{ pulp_user_home }}/assets'
+  # We need the when condition on this particular SELinux handler because it
+  # gets triggered by "Collect static content".
+  when:
+    - ansible_facts.os_family == 'RedHat'
+    # when permissive or enforcing. That would be stored in .mode & .config_mode
+    - ansible_facts.selinux.status == "enabled"
+
+# Workaround https://github.com/ansible/ansible/issues/34505
+# by not using include_tasks
+- name: Restart all Pulp services
+  include: handlers/restart_all_pulp.yml
+  static: no

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -135,14 +135,6 @@
         recurse: true
         follow: false
 
-    - name: Install packages needed for source install
-      package:
-        name:
-          - git
-        state: present
-      register: result
-      until: result is succeeded
-
   become: true
 
 - name: install pulp from {{ pulp_install_source }}

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -14,12 +14,6 @@
         name: '{{ pulp_preq_packages }}'
         state: present
 
-    - name: Disable SELinux
-      selinux:
-        policy: targeted
-        state: permissive
-      when: ansible_facts.os_family == 'RedHat' and pulp_disable_selinux | bool
-
     # Become root so as to search paths like /usr/sbin.
     - name: Find the nologin executable
       command: which nologin

--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -1,4 +1,67 @@
 ---
+# Dependency package was installed earlier via pulp_preq_packages
+- name: Check if SELinux is enabled
+  setup:
+    gather_subset: selinux
+
+- name: Compile & install the pulpcore SELinux policy
+  block:
+
+    - name: Install SELinux policy build dependencies
+      yum:
+        name:
+          - selinux-policy-devel
+          - policycoreutils
+          # Needed for seport technically, used by pulp_api & pulp_content
+          - "{{ (ansible_facts.distribution_major_version | int == 7) | ternary('policycoreutils-python','python3-policycoreutils') }}"
+
+    - name: 'Ensure that /usr/local/share/selinux/{{ ansible_facts.selinux.type }} exists'
+      file:
+        path: '/usr/local/share/selinux/{{ ansible_facts.selinux.type }}'
+        state: directory
+        recurse: true
+        mode: 0755
+        owner: root
+        group: root
+
+    - name: Clone SELinux policy from Git
+      git:
+        # TEMP: Temporary repo and branch for el8 and related set of features.
+        repo: '{{ __pulp_selinux_repo }}'
+        version: '{{ __pulp_selinux_version }}'
+        dest: '{{ pulp_user_home }}/pulpcore-selinux'
+      become: true
+      become_user: '{{ pulp_user }}'
+
+    - name: Compile the SELinux policies
+      make:
+        file: /usr/share/selinux/devel/Makefile
+        chdir: '{{ pulp_user_home }}/pulpcore-selinux'
+        target: '{{ item }}.pp'
+      loop: '{{ __pulp_selinux_policy_pkgs }}'
+      become: true
+      become_user: '{{ pulp_user }}'
+
+    - name: Install the SELinux policy packages on disk
+      copy:
+        src: '{{ pulp_user_home }}/pulpcore-selinux/{{ item }}.pp'
+        dest: '/usr/local/share/selinux/{{ ansible_facts.selinux.type }}/{{ item }}.pp'
+        remote_src: true
+        mode: 0644
+        owner: root
+        group: root
+      loop: '{{ __pulp_selinux_policy_pkgs }}'
+      notify:
+        - Load the SELinux policy packages
+        - Restore SELinux contexts on Pulp dirs that must exist
+        - Restore SELinux contexts on Pulp dirs that may exist
+
+  become: true
+  when:
+    - ansible_facts.os_family == 'RedHat'
+    # when permissive or enforcing. That would be stored in .mode & .config_mode
+    - ansible_facts.selinux.status == "enabled"
+
 - name: Create pulp install dir
   file:
     path: '{{ pulp_install_dir }}'

--- a/roles/pulp_common/vars/CentOS-7.yml
+++ b/roles/pulp_common/vars/CentOS-7.yml
@@ -6,7 +6,9 @@ pulp_preq_packages:
   - libselinux-python  # For ansible itself
   - postgresql-devel
   - gcc                # For psycopg2
-  - make               # For make docs
+  - make               # For make docs, and SELinux policy install
+  - git                # For source install, and SELinux policy install
+
 pulp_python_interpreter: /usr/bin/python3.6
 pulp_python_cryptography:
   - python-cryptography

--- a/roles/pulp_common/vars/Debian.yml
+++ b/roles/pulp_common/vars/Debian.yml
@@ -5,6 +5,7 @@ pulp_preq_packages:
   - python3-venv
   - libpq-dev
   - gcc              # For psycopg2
+  - git              # For source install
 
 # Pulp requires Python 3.6+.
 pulp_python_interpreter: /usr/bin/python3

--- a/roles/pulp_common/vars/Fedora.yml
+++ b/roles/pulp_common/vars/Fedora.yml
@@ -4,8 +4,9 @@ pulp_preq_packages:
   - python3-devel
   - python3-libselinux  # For ansible itself
   - gcc                 # For psycopg2
-  - make                # For make docs
+  - make                # For make docs, and SELinux policy install
   - libpq-devel         # Renamed/Split version of postgresql-devel
+  - git                 # For source install, and SELinux policy install
 
 # Pulp requires Python 3.6+.
 pulp_python_interpreter: /usr/bin/python3

--- a/roles/pulp_common/vars/Ubuntu.yml
+++ b/roles/pulp_common/vars/Ubuntu.yml
@@ -5,6 +5,7 @@ pulp_preq_packages:
   - python3-venv
   - libpq-dev
   - gcc                 # For psycopg2
+  - git                 # For source install
 
 # Pulp requires Python 3.6+.
 pulp_python_interpreter: /usr/bin/python3

--- a/roles/pulp_content/tasks/main.yml
+++ b/roles/pulp_content/tasks/main.yml
@@ -1,5 +1,17 @@
 ---
 - block:
+
+  - name: Apply the SELinux type to the TCP port that pulpcore-content listens on
+    seport:
+      ports: '{{ pulp_content_bind.split(":")[1] }}'
+      proto: tcp
+      setype: pulpcore_port_t
+    when:
+      - not (pulp_content_bind.startswith('unix:'))
+      - ansible_facts.os_family == 'RedHat'
+      # We can also try using seport's ignore_selinux_state variable
+      - ansible_facts.selinux.status == "enabled"
+
   - name: Install pulpcore-content service file
     template:
       src: pulpcore-content.service.j2


### PR DESCRIPTION
Applies to RedHat only.

Does not support for users overrding the folderpaths yet.

Implementation includes:
1. Use make with the Makefile from the repo.2
2. __pulp_selinux_policy_pkgs tracks the 3 policy package names from
pulpcore-selinux.
3. Install the compiled policy packages to /usr/local/share/selinux/ .
4. Apply the SELinux type to the ports, read from pulp_api_bind
and pulp_content_bind .
5. Clone from github pulp org via https. Currently master branch.
This can be overriden via __pulp_selinux_repo & +__pulp_selinux_version.
6. Thorough handler logic on when to relabel the files on disk.

fixes: #7574

How to test:
https://github.com/pulp/pulplift/pull/108
Have pulp_installer be this PR/commit (I usually replace the submodule with a symlink temporarily.)
local.user-config.yml
```
pulp_default_admin_password: password
pulp_install_plugins:
  pulp-ansible: {}
  pulp-certguard: {}
  pulp-container: {}
  pulp-file: {}
  pulp-rpm: {}

pulp_settings:
  secret_key: "unsafe_default"
  content_origin: "http://{{ ansible_fqdn }}"

# Needed for https://github.com/pulp/pulpcore-selinux/pull/16 , possibly more over the next week
__pulp_selinux_repo: 'https://github.com/mikedep333/pulpcore-selinux.git'
__pulp_selinux_version: 'el8-fixes'

```
`vagrant up pulp3-sandbox-centos8`
`vagrant ssh pulp3-sandbox-centos8`
curl the status page
`ausearch -m AVC,USER_AVC`