### PR TITLE
TLS: Reload nginx upon new self-cert generation

### DIFF
--- a/roles/pulp_webserver/tasks/generate_tls_certificates.yml
+++ b/roles/pulp_webserver/tasks/generate_tls_certificates.yml
@@ -76,6 +76,7 @@
         ownca_not_after: '+824d'
         owner: root
         group: "{{ pulp_group }}"
+      notify: reload {{ pulp_webserver_server }}
   when: not __pulp_webserver_cert.stat.exists
 
 - name: Cleanup CSR files


### PR DESCRIPTION
On first install everything runs smoothly. But if one then decide to
remove the certs in `/etc/pulp/certs/pulp_webserver.{key,crt}` in order
for them to be regenerated at next run, the webserver is not reloaded
leading to the new certificate not to be used immediately.

[noissue]