### PR TITLE
remove installation psycopg python package

### DIFF
--- a/CHANGES/6752.misc
+++ b/CHANGES/6752.misc
@@ -1,0 +1,1 @@
+Remove python3-psycopg2 dependency as installed automatically when needed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,18 +18,13 @@ must have Python 3 and Ansible (>= 2.9) installed.
 The [managed node](https://docs.ansible.com/ansible/2.5/network/getting_started/basic_concepts.html#managed-nodes)
 must be one of these currently supported operating systems:
 
-* CentOS 7
-* Debian Buster (needs `allow_world_readable_tmpfiles = True` in ansible.cfg)
-* Fedora 30 or later
+- CentOS 7
+- Debian Buster (needs `allow_world_readable_tmpfiles = True` in ansible.cfg)
+- Fedora 30 or later
 
 The managed node cannot provide any other service on the same hostname as Pulp's API. The only
 exception is Pulp 2. The RESP APIs for Pulp 2 and Pulp 3 can be served on the same hostname as
 long as the `apache` webserver is deployed for both.
-
-Ansibles Python interpreter must have the package installed:
-
-* psycopg2
-* firewall (if firewalld should be configured; you can disable that with `pulp_configure_firewall=false`)
 
 The Ansible collection requires [geerlingguy.postgresql](https://galaxy.ansible.com/geerlingguy/postgresql) role,
 which should be installed from ansible-galaxy.

--- a/roles/pulp_database/vars/Debian.yml
+++ b/roles/pulp_database/vars/Debian.yml
@@ -1,2 +1,1 @@
 ---
-postgresql_python_library: python3-psycopg2

--- a/roles/pulp_database/vars/Ubuntu.yml
+++ b/roles/pulp_database/vars/Ubuntu.yml
@@ -1,2 +1,1 @@
 ---
-postgresql_python_library: python3-psycopg2


### PR DESCRIPTION
python*-psycopg2 is installed by geerlingguy role so removed from docs as prerequisite

closes: #6752
https://pulp.plan.io/issues/6752