### PR TITLE
Update molecule package tests from pulpcore 3.6 to 3.7

### DIFF
--- a/CHANGES/7646.feature
+++ b/CHANGES/7646.feature
@@ -1,0 +1,1 @@
+When installing from distro packages (`pulp_install_source==packages`), from a repo (`pulp_pkg_repo`), and upgrading them (`pulp_pkg_upgrade_all==true`), pulp_installer will now upgrade all the packages from the repo. This addresses any incorrect dependency declarations in the repo, which would cause pulp_installer to fail on collectstatic.

--- a/molecule/packages-dynamic/group_vars/all
+++ b/molecule/packages-dynamic/group_vars/all
@@ -8,4 +8,4 @@ pulp_install_plugins:
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
-pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.6/el{{ ansible_distribution_major_version }}/$basearch/"
+pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.7/el{{ ansible_distribution_major_version }}/$basearch/"

--- a/molecule/packages-dynamic/group_vars/all
+++ b/molecule/packages-dynamic/group_vars/all
@@ -9,3 +9,6 @@ pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
 pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.7/el{{ ansible_distribution_major_version }}/$basearch/"
+# Setting this not because it should have any effect, but to test that it
+# doesn't:
+pulp_pkg_upgrade_all: true

--- a/molecule/packages-static/group_vars/all
+++ b/molecule/packages-static/group_vars/all
@@ -10,4 +10,4 @@ pulp_install_plugins:
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
-pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.6/el{{ ansible_distribution_major_version }}/$basearch/"
+pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.7/el{{ ansible_distribution_major_version }}/$basearch/"

--- a/molecule/packages-upgrade/group_vars/all
+++ b/molecule/packages-upgrade/group_vars/all
@@ -8,5 +8,5 @@ pulp_install_plugins:
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
-pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.6/el{{ ansible_distribution_major_version }}/$basearch/"
+pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.7/el{{ ansible_distribution_major_version }}/$basearch/"
 pulp_pkg_upgrade_all: true

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -51,6 +51,7 @@ pulp_pkg_undeclared_deps:
   - python3-djangorestframework
   - python3-djangorestframework-queryfields
 pulp_pkg_upgrade_all: false
+__pulp_pkg_repo_name: "pulpcore"
 pulp_upgraded_manually: false
 
 # The order is significant; linear order to handle the dependency tree

--- a/roles/pulp_common/tasks/install_packages.yml
+++ b/roles/pulp_common/tasks/install_packages.yml
@@ -1,5 +1,32 @@
 ---
 - block:
+    - name: "Enumerate the list of updates from the {{ __pulp_pkg_repo_name }} repo"
+      yum:
+        list: updates
+        disablerepo: "*"
+        enablerepo:  "{{ __pulp_pkg_repo_name }}"
+      register: updates
+
+    - name: List packages to be upgraded
+      debug:
+        # We do not use json_query because it requires jmespath on the control
+        # node. We should not introduce an addtl control node dependency
+        # unless there is a very compelling reason.
+        # msg: "{{ updates | json_query('results[*].name') }}"
+        msg: "{{ updates.results | map(attribute='name')|list }}"
+
+    - name: Upgrade all existing installed Pulp packages
+      yum:
+        name: "{{ updates.results | map(attribute='name')|list }}"
+        state: latest # noqa 403
+
+  become: true
+  when:
+    - ansible_facts.os_family == "RedHat"
+    - pulp_pkg_repo is not none
+    - pulp_pkg_upgrade_all
+
+- block:
 
     - name: "Install the Pulp undeclared {{ ansible_facts.pkg_mgr }} package dependencies"
       package:
@@ -34,7 +61,7 @@
     - name: "Install Pulp plugins (with overriden names) via {{ ansible_facts.pkg_mgr }}"
       package:
         name: '{{ item.value.pkg_name }}'
-        state: present
+        state: "{{ pulp_pkg_upgrade_all | ternary('latest','present') }}"
       with_dict: '{{ pulp_install_plugins }}'
       when:
         - item.value.pkg_name is defined

--- a/roles/pulp_common/tasks/repos.yml
+++ b/roles/pulp_common/tasks/repos.yml
@@ -113,10 +113,10 @@
     - ansible_facts.distribution == "CentOS"
     - ansible_facts.distribution_major_version|int >= 8
 
-- name: Add pulpcore RPM repositories
+- name: "Add {{ __pulp_pkg_repo_name }} RPM repository"
   yum_repository:
-    name: pulpcore
-    description: pulpcore
+    name: "{{ __pulp_pkg_repo_name }}"
+    description: "{{ __pulp_pkg_repo_name }}"
     baseurl: "{{ pulp_pkg_repo }}"
     gpgcheck: false
     enabled: true


### PR DESCRIPTION
(Because the new yum.theforeman.org repo now exists.)

[noissue]

Also implement a change to the upgrade logic to workaround any incorrect dependencies in the repo during upgrade:

https://pulp.plan.io/issues/7646

As a pulp_installer user, upgrading Pulp from RPM packages will upgrade all packages in the pulp repo I specify