### PR TITLE
Recommended UNIX socket paths for the api, content & redis roles docs

### DIFF
--- a/roles/pulp_api/README.md
+++ b/roles/pulp_api/README.md
@@ -6,9 +6,10 @@ Install, configure, and set the state of the pulp API service.
 Role Variables
 --------------
 
-* `pulp_api_bind`: Interface and Port where Pulp Content `gunicorn` service will listen. Defaults to
-  '127.0.0.1:24817'. This variable is the value used to render the `pulpcore-api.service.j2` template
-  passing to the `--bind` parameter of the `gunicorn` service.
+* `pulp_api_bind`: Interface and Port where Pulp Content [`gunicorn` service will
+  listen.](https://docs.gunicorn.org/en/stable/settings.html#bind)
+  One can specify a unix socket path instead (recommended value is `'unix:/var/run/pulpcore-api/pulpcore-api.sock'`).
+  Defaults to `'127.0.0.1:24817'`.
 * `pulp_api_workers`: Number of Pulp Content `gunicorn` processes for handling requests. Defaults to 1.
   Used to render the `pulpcore-api.service.j2` template, passing to the `--workers` parameter of the
   gunicorn service.

--- a/roles/pulp_content/README.md
+++ b/roles/pulp_content/README.md
@@ -6,12 +6,13 @@ Install, configure, and set the state of pulp content app.
 Role Variables
 --------------
 
-* `pulp_content_bind`: Interface and Port where Pulp Content `gunicorn` service will listen.
+* `pulp_content_bind`: Interface and Port where Pulp Content [`gunicorn` service will
+  listen.](https://docs.gunicorn.org/en/stable/settings.html#bind)
 
-This variable is the value used to render the `pulpcore-content.service.j2` template passing
-to the `--bind` parameter of the gunicorn service.
+One can specify a unix socket path instead
+(recommended value is `'unix:/var/run/pulpcore-content/pulpcore-content.sock'`).
 
-Defaults to `127.0.0.1:24816`
+Defaults to `'127.0.0.1:24816'`.
 
 Shared variables
 ----------------

--- a/roles/pulp_redis/README.md
+++ b/roles/pulp_redis/README.md
@@ -7,7 +7,7 @@ Role Variables
 --------------
 
 * `pulp_redis_bind`: Interface and Port where Redis service will listen. One can specify a unix
-   path (ie. 'unix:/var/run/redis/redis.sock'). Defaults to `127.0.0.1:6379`
+   socket path instead (recommended value is `'unix:/var/run/redis/redis.sock'`). Defaults to `'127.0.0.1:6379'`.
 * `pulp_redis_package_name`: Name of the redis package server to install. Defaults to: `redis`
 * `pulp_redis_server_name`: Name of the redis server service to run. Defaults to: OS specific
 * `pulp_redis_conf_file`: Path to the redis server configuration file. Defaults to: os specific


### PR DESCRIPTION
These are based on the systemd WorkingDirectory for each service.

[noissue]