### PR TITLE
Bump pulpcore-selinux to 1.1.3 for pip installs

### DIFF
--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -60,7 +60,7 @@ __pulp_selinux_policy_pkgs:
   - pulpcore
   - pulpcore_rhsmcertd
 __pulp_selinux_repo: 'https://github.com/pulp/pulpcore-selinux.git'
-__pulp_selinux_version: '1.1.1'
+__pulp_selinux_version: '1.1.3'
 __pulp_selinux_label_dirs:
   - "{{ pulp_install_dir }}"
   - "{{ pulp_config_dir }}"


### PR DESCRIPTION
Its changes should have no effect on pip installs,
but we want to test it anyway.

[noissue]