### PR TITLE
Fix collectstatic and pulp's restart not happening

### DIFF
--- a/roles/pulp_common/tasks/install_packages.yml
+++ b/roles/pulp_common/tasks/install_packages.yml
@@ -19,6 +19,9 @@
       yum:
         name: "{{ updates.results | map(attribute='name')|list }}"
         state: latest # noqa 403
+      notify:
+        - Collect static content
+        - Restart all Pulp services
 
   become: true
   when:


### PR DESCRIPTION
during packages upgrades.

Fixes a regression introduced by: #7646
https://pulp.plan.io/issues/7646
(during this 3.7.2 / 3.8.0 development cycle, so no change message)

[noissue]