### PR TITLE
Problem: pulp_installer should use the new libexec SELinux wrappers

### DIFF
--- a/CHANGES/7667.feature
+++ b/CHANGES/7667.feature
@@ -1,0 +1,1 @@
+Start rq & gunicorn from the bash wrapper scripts provided by newer pulpcore 3.7 RPM packages, `/usr/libexec/pulpcore/{rq,gunicorn}`. These scripts enable pulp processes to transitioning to the Pulp SELinux context, rather than the generic rq/gunicorn context.

--- a/CHANGES/7667.removal
+++ b/CHANGES/7667.removal
@@ -1,0 +1,1 @@
+pulp_installer no longer supports installing from older RPM packages that lack the wrapper scripts `/usr/libexec/pulpcore/{rq,gunicorn}`.

--- a/roles/pulp_api/templates/pulpcore-api.service.j2
+++ b/roles/pulp_api/templates/pulpcore-api.service.j2
@@ -14,7 +14,7 @@ User={{ pulp_user }}
 Group={{ pulp_group }}
 PIDFile=/run/pulpcore-api.pid
 RuntimeDirectory=pulpcore-api
-ExecStart={{ pulp_install_dir }}/bin/gunicorn pulpcore.app.wsgi:application \
+ExecStart={{ __pulp_daemons_dir }}/gunicorn pulpcore.app.wsgi:application \
           --bind '{{ pulp_api_bind }}' \
           --workers {{ pulp_api_workers }} \
           --access-logfile -

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -7,6 +7,7 @@ pulp_config_dir: '/etc/pulp'
 pulp_settings_file: '{{ pulp_config_dir }}/settings.py'
 pulp_install_source: pip
 pulp_install_dir: '{{ (pulp_install_source == "packages") | ternary("/usr", "/usr/local/lib/pulp") }}'
+__pulp_daemons_dir: '{{ (pulp_install_source == "packages") | ternary("/usr/libexec/pulpcore", pulp_install_dir ~ "/bin") }}'
 pulp_install_api_service: true
 # Deprecated unused. Variables for dependency upgrades are TBD
 pulp_upgrade: false

--- a/roles/pulp_content/templates/pulpcore-content.service.j2
+++ b/roles/pulp_content/templates/pulpcore-content.service.j2
@@ -14,7 +14,7 @@ User={{ pulp_user }}
 Group={{ pulp_group }}
 WorkingDirectory=/var/run/pulpcore-content/
 RuntimeDirectory=pulpcore-content
-ExecStart={{ pulp_install_dir }}/bin/gunicorn pulpcore.content:server \
+ExecStart={{ __pulp_daemons_dir }}/gunicorn pulpcore.content:server \
           --bind '{{ pulp_content_bind }}' \
           --worker-class 'aiohttp.GunicornWebWorker' \
           -w 2 \

--- a/roles/pulp_resource_manager/templates/pulpcore-resource-manager.service.j2
+++ b/roles/pulp_resource_manager/templates/pulpcore-resource-manager.service.j2
@@ -14,7 +14,7 @@ User={{ pulp_user }}
 Group={{ pulp_group }}
 WorkingDirectory=/var/run/pulpcore-resource-manager/
 RuntimeDirectory=pulpcore-resource-manager
-ExecStart={{ pulp_install_dir }}/bin/rq worker \
+ExecStart={{ __pulp_daemons_dir }}/rq worker \
           -w pulpcore.tasking.worker.PulpWorker -n resource-manager \
           --pid=/var/run/pulpcore-resource-manager/resource-manager.pid \
           -c 'pulpcore.rqconfig' \

--- a/roles/pulp_workers/templates/pulpcore-worker@.service.j2
+++ b/roles/pulp_workers/templates/pulpcore-worker@.service.j2
@@ -16,7 +16,7 @@ User={{ pulp_user }}
 Group={{ pulp_group }}
 WorkingDirectory=/var/run/pulpcore-worker-%i/
 RuntimeDirectory=pulpcore-worker-%i
-ExecStart={{ pulp_install_dir }}/bin/rq worker \
+ExecStart={{ __pulp_daemons_dir }}/rq worker \
           -w pulpcore.tasking.worker.PulpWorker \
           --pid=/var/run/pulpcore-worker-%i/reserved-resource-worker-%i.pid \
           -c 'pulpcore.rqconfig' \


### PR DESCRIPTION
from the RPM packages

Solution: Use the private variable __pulp_daemons_dir between pulp_common
and the pulp service roles. It has different default paths depending on
pulp_install_source .

fixes: #7667
https://pulp.plan.io/issues/7667
pulp_installer should use the new libexec SELinux wrappers from the RPM packages

**NOTE**: Our package tests will fail until https://github.com/theforeman/pulpcore-packaging/pull/38/files is merged, and the repo built/updated with it. It should not be merged until then.