### PR TITLE
Allow one to inherits from another package

### DIFF
--- a/roles/pulp_common/vars/main.yml
+++ b/roles/pulp_common/vars/main.yml
@@ -5,7 +5,11 @@
 # https://stackoverflow.com/questions/41521138/ansible-template-adds-u-to-array-in-template
 pulp_install_plugins_normalized_yml: |-
   {% for key, value in pulp_install_plugins.items() %}
-  {{ key.replace('_', '-') }}: {{ value | to_json }}
+  {% if value.get('inherits') %}
+  {{ value.get('inherits').replace('_', '-')  }}: {{ value | to_json  }}
+  {% else %}
+  {{ key.replace('_', '-')  }}: {{ value | to_json  }}
+  {% endif %}
   {% endfor %}
 # A pulp_install_plugins but with the plugin names corrected:
 # pip/PyPI only uses dashes, not underscores.


### PR DESCRIPTION
The scenario is the following. I provide to the public a plugin that
pulls another plugin and add some feature on top of it. Both my plugin
and the plugin I pull conflicts (from a package definition standpoint)
so I can declare just one of them. Yet I'd like to leverage the content
of my inherited plugin like snippets.

This would work like the following:

```
pulp_install_plugins:
  automation-hub:
    inherits: galaxy-ng
```

This would led to `python3-automation-hub` plugin to be installed
(as expected) and also apply the snippet from `galaxy-ng` plugin which
my plugin rely upon,

[noissue]