### PR TITLE
common: Allow one to ignore collectstatic for specific plugins

### DIFF
--- a/roles/pulp_common/README.md
+++ b/roles/pulp_common/README.md
@@ -32,6 +32,8 @@ Role Variables
     immediately before the venv is created. You will need to download it 1st (with
     ansible-galaxy.) Needed because many plugins will have OS dependencies in C.
     See `prereq_pip_packages` also.
+    * `collectstatic`: Optional. Boolean that specifies if the static for a plugin should be collected.
+    If set to false the plugin name will be passed as `--ignore` at collectstatic time.
     * **Example**:
     ```yaml
     pulp_install_source: pip
@@ -45,6 +47,8 @@ Role Variables
         source_dir: "/var/lib/pulp/pulp_three" # path to the plugin source code
       pulp-four:
         prereq_role: "pulp.pulp_four_role" # role to run immediately before the venv is created
+      pulp-five:
+        collectstatic: false
     ```
 * `pulp_cache_dir`: Location of Pulp cache. Defaults to "/var/lib/pulp/tmp".
 * `pulp_config_dir`: Directory which will contain Pulp configuration files.

--- a/roles/pulp_common/handlers/main.yml
+++ b/roles/pulp_common/handlers/main.yml
@@ -22,7 +22,7 @@
   failed_when: result.rc not in [0,255]
 
 - name: Collect static content
-  command: "{{ pulp_django_admin_path }} collectstatic --noinput --link"
+  command: "{{ pulp_django_admin_path }} collectstatic --noinput --link {{ pulp_collectstatic_ignore_list }}"
   register: staticresult
   changed_when: "staticresult.stdout is not search('\n0 static files')"
   become: true

--- a/roles/pulp_common/vars/main.yml
+++ b/roles/pulp_common/vars/main.yml
@@ -7,6 +7,15 @@ pulp_install_plugins_normalized_yml: |-
   {% for key, value in pulp_install_plugins.items() %}
   {{ key.replace('_', '-') }}: {{ value | to_json }}
   {% endfor %}
+# List of plugin to ignore when collecting static files
+pulp_collectstatic_ignore_list: |-
+  {{ pulp_install_plugins | dict2items |
+      selectattr('value.collectstatic', "defined") |
+      selectattr('value.collectstatic', "sameas", False) |
+      map(attribute='key') |
+      map('regex_replace', "-", "_") |
+      map('regex_replace', "^", "--ignore ") |
+      list | join(" ") }}
 # A pulp_install_plugins but with the plugin names corrected:
 # pip/PyPI only uses dashes, not underscores.
 pulp_install_plugins_normalized: "{{ pulp_install_plugins_normalized_yml | from_yaml }}"


### PR DESCRIPTION
As a user, I don't want static to be collected for some of the plugins I
install. I will be providing them by another mean.

```
pulp_install_plugins:
  pulp-ansible:
  pulp-container:
  my-plugin:
    collectstatic: false
  my-plugin2:
    collectstatic: false
```

Will lead to this command[1] looking like:

```
PULP_SETTINGS=/etc/pulp/settings.py /usr/bin/pulpcore-manager collectstatic --noinput --link --ignore my_plugin --ignore my_plugin2
```

[1]
https://github.com/pulp/pulp_installer/blob/2c71d92257ade7ad57cbb96e85b77b6c0eb49f5a/roles/pulp_common/handlers/main.yml#L25

[noissue]