### PR TITLE
Remove The loop variable 'item' is already in use. warning

### DIFF
--- a/roles/pulp_common/tasks/ambiguously-named-repo.yml
+++ b/roles/pulp_common/tasks/ambiguously-named-repo.yml
@@ -1,15 +1,15 @@
 ---
-- name: "Determine which file in /etc/yum.repos.d/ has the {{ item }} repo"
-  shell: grep -l -E "^\[{{ item }}\]" /etc/yum.repos.d/*.repo
+- name: "Determine which file in /etc/yum.repos.d/ has the {{ __pulp_common_repo }} repo"
+  shell: grep -l -E "^\[{{ __pulp_common_repo }}\]" /etc/yum.repos.d/*.repo
   register: repo_file
   changed_when: false
   failed_when: false
   check_mode: False
 
-- name: "Enable the {{ item }} repo"
+- name: "Enable the {{ __pulp_common_repo }} repo"
   ini_file:
     path: "{{ repo_file.stdout }}"
-    section: "{{ item }}"
+    section: "{{ __pulp_common_repo }}"
     option: enabled
     value: "1"
     no_extra_spaces: true

--- a/roles/pulp_common/tasks/install_packages.yml
+++ b/roles/pulp_common/tasks/install_packages.yml
@@ -49,25 +49,29 @@
 
     - name: "Install Pulp plugins via {{ ansible_facts.pkg_mgr }} packages"
       package:
-        name: '{{ pulp_pkg_name_prefix }}{{ item.key }}'
+        name: '{{ pulp_pkg_name_prefix }}{{ __pulp_common_package.key }}'
         state: "{{ pulp_pkg_upgrade_all | ternary('latest','present') }}"
       # We use pulp_install_plugins rather than pulp_install_plugins_normalized
       # so that users can specify package names with underscores if distros
       # require it.
-      with_dict: '{{ pulp_install_plugins }}'
+      loop: '{{ pulp_install_plugins | dict2items }}'
+      loop_control:
+        loop_var: __pulp_common_package
       when:
-        - item.value.pkg_name is undefined
+        - __pulp_common_package.value.pkg_name is undefined
       notify:
         - Collect static content
         - Restart all Pulp services
 
     - name: "Install Pulp plugins (with overriden names) via {{ ansible_facts.pkg_mgr }}"
       package:
-        name: '{{ item.value.pkg_name }}'
+        name: '{{ __pulp_common_package.value.pkg_name }}'
         state: "{{ pulp_pkg_upgrade_all | ternary('latest','present') }}"
-      with_dict: '{{ pulp_install_plugins }}'
+      loop: '{{ pulp_install_plugins | dict2items }}'
+      loop_control:
+        loop_var: __pulp_common_package
       when:
-        - item.value.pkg_name is defined
+        - __pulp_common_package.value.pkg_name is defined
       notify:
         - Collect static content
         - Restart all Pulp services

--- a/roles/pulp_common/tasks/main.yml
+++ b/roles/pulp_common/tasks/main.yml
@@ -17,9 +17,9 @@
       # "that:" (like when:), and then the {{ }}
       # It converts from item, to the string like pulp_default_admin_password ,
       # to the value of pulp_default_admin_password .
-      - "{{ item }} | default('', true) | length > 0"
+      - "{{ __pulp_common_req_var }} | default('', true) | length > 0"
     fail_msg: >
-      {{ item }} is undefined, null, an empty string, or an empty dictionary "{}" . Please
+      {{ __pulp_common_req_var }} is undefined, null, an empty string, or an empty dictionary "{}" . Please
       set it in your variables
       (e.g. pulp_installer/playbooks/example-use/group_vars/all)
       and run pulp_installer again.
@@ -29,6 +29,8 @@
     - pulp_settings.content_origin
     - pulp_settings.secret_key
     - pulp_install_plugins
+  loop_control:
+    loop_var: __pulp_common_req_var
 
 - name: Load OS specific variables
   include_vars: "{{ lookup('first_found', params) }}"

--- a/roles/pulp_common/tasks/repos.yml
+++ b/roles/pulp_common/tasks/repos.yml
@@ -47,7 +47,9 @@
 # The query ensures that a single string rather than a list of strings is valid.
 - name: Find and enable the first found name of the RHEL7 Optional repo
   include_tasks: ambiguously-named-repo.yml
-  with_items: "{{ rhel7_optional_repo }}"
+  loop: "{{ rhel7_optional_repo }}"
+  loop_control:
+    loop_var: __pulp_common_repo
   when:
     - ansible_facts.distribution == "RedHat"
     - ansible_facts.distribution_major_version|int == 7
@@ -69,7 +71,9 @@
 # The query ensures that a single string rather than a list of strings is valid.
 - name: Find and enable the first found name of the RHEL CodeReady Builder repo
   include_tasks: ambiguously-named-repo.yml
-  with_items: "{{ pulp_rhel_codeready_repo }}"
+  loop: "{{ pulp_rhel_codeready_repo }}"
+  loop_control:
+    loop_var: __pulp_common_repo
   when:
     - ansible_facts.distribution == "RedHat"
     - ansible_facts.distribution_major_version|int >= 8

--- a/roles/pulp_database_config/tasks/main.yml
+++ b/roles/pulp_database_config/tasks/main.yml
@@ -6,9 +6,9 @@
       # "that:" (like when:), and then the {{ }}
       # It converts from item, to the string like pulp_default_admin_password ,
       # to the value of pulp_default_admin_password .
-      - "{{ item }} | default('', true) | length > 0"
+      - "{{ __pulp_database_config_req_variable }} | default('', true) | length > 0"
     fail_msg: >
-      {{ item }} is undefined, null, or an empty string. Please
+      {{ __pulp_database_config_req_variable }} is undefined, null, or an empty string. Please
       set it in your variables
       (e.g. pulp_installer/playbooks/example-use/group_vars/all)
       and run pulp_installer again.
@@ -16,6 +16,8 @@
       pulp_installer/roles/pulp/README.md for more info.
   loop:
     - pulp_default_admin_password
+  loop_control:
+    loop_var: __pulp_database_config_req_variable
 
 - meta: flush_handlers
 

--- a/roles/pulp_redis/tasks/configure_uds.yml
+++ b/roles/pulp_redis/tasks/configure_uds.yml
@@ -8,8 +8,8 @@
 - name: Ensure Redis will not listen on a TCP socket
   lineinfile:
     path: '{{ pulp_redis_conf_file | default(_pulp_redis_conf_file) }}'
-    regexp: '{{ item.regexp }}'
-    line: '{{ item.line }}'
+    regexp: '{{ __pulp_redis_setting.regexp }}'
+    line: '{{ __pulp_redis_setting.line }}'
   loop:
     - regexp: '^port '
       line: 'port 0'
@@ -17,4 +17,6 @@
       line: 'unixsocket {{ pulp_redis_bind | replace("unix:", "") }}'
     - regexp: '^unixsocketperm '
       line: 'unixsocketperm 775'
+  loop_control:
+    loop_var: __pulp_redis_setting
   notify: restart redis

--- a/roles/pulp_webserver/tasks/generate_tls_certificates.yml
+++ b/roles/pulp_webserver/tasks/generate_tls_certificates.yml
@@ -81,8 +81,10 @@
 
 - name: Cleanup CSR files
   file:
-    path: '{{ pulp_certs_dir }}/{{ item }}'
+    path: '{{ pulp_certs_dir }}/{{ __pulp_webserver_csr_path }}'
     state: absent
   loop:
     - root.csr
     - pulp_webserver.csr
+  loop_control:
+    loop_var: __pulp_webserver_csr_path

--- a/roles/pulp_webserver/tasks/main.yml
+++ b/roles/pulp_webserver/tasks/main.yml
@@ -27,11 +27,13 @@
 
 - name: "Check installed plugins for {{ pulp_webserver_server }} snippets"
   script:
-    cmd: check_snippet.py {{ item.key | regex_replace("-", "_") | quote }} {{ pulp_webserver_server }}.conf
+    cmd: check_snippet.py {{ __pulp_webserver_plugin.key | regex_replace("-", "_") | quote }} {{ pulp_webserver_server }}.conf
   args:
     executable: '{{ (pulp_install_source == "packages") | ternary(pulp_python_interpreter, pulp_install_dir ~ "/bin/python") }}'
   register: snippets
-  with_dict: '{{ pulp_install_plugins_normalized }}'
+  loop: '{{ pulp_install_plugins_normalized | dict2items }}'
+  loop_control:
+    loop_var: __pulp_webserver_plugin
   failed_when: >
     snippets.stderr is search("env: 'python': No such file or directory")
   changed_when: false
@@ -76,15 +78,17 @@
 
 - name: Create ACME dirs
   file:
-    path: "{{ item }}"
+    path: "{{ __pulp_webserver_acme_path }}"
     state: directory
     mode: 0755
     owner: "{{ pulp_user }}"
     group: "{{ pulp_group }}"
   become: true
-  with_items:
+  loop:
     - "{{ pulp_webserver_static_dir }}"
     - "{{ pulp_webserver_static_dir }}/.well-known"
+  loop_control:
+    loop_var: __pulp_webserver_acme_path
 
 - include_tasks: "{{ pulp_webserver_server }}.yml"
 

--- a/roles/pulp_webserver/tasks/nginx.yml
+++ b/roles/pulp_webserver/tasks/nginx.yml
@@ -45,12 +45,14 @@
     # above and/or create a temporary data structure.
     - name: Symlink nginx snippets
       file:
-        src: "{{ item.stdout_lines | last }}"
+        src: "{{ __pulp_webserver_snippet.stdout_lines | last }}"
         # Note: item.item is pulp_install_plugins_normalized
-        dest: "/etc/nginx/pulp/{{ item.item.key | regex_replace('-', '_') }}.conf"
+        dest: "/etc/nginx/pulp/{{ __pulp_webserver_snippet.__pulp_webserver_plugin.key | regex_replace('-', '_') }}.conf"
         state: link
       loop: '{{ snippets.results }}'
-      when: item.rc == 0
+      loop_control:
+        loop_var: __pulp_webserver_snippet
+      when: __pulp_webserver_snippet.rc == 0
       notify: reload nginx
 
     - name: Start and enable Nginx

--- a/roles/pulp_workers/handlers/main.yml
+++ b/roles/pulp_workers/handlers/main.yml
@@ -2,7 +2,9 @@
 - name: Reload systemd and restart pulp workers
   systemd:
     daemon_reload: true
-    name: pulpcore-worker@{{ item }}.service
+    name: pulpcore-worker@{{ __pulp_workers_worker_index }}.service
     state: restarted
-  with_sequence: 'start=1 count={{ pulp_workers }}'
+  loop: "{{ range(1, pulp_workers + 1) | list }}"
+  loop_control:
+    loop_var: __pulp_workers_worker_index
   become: true

--- a/roles/pulp_workers/tasks/main.yml
+++ b/roles/pulp_workers/tasks/main.yml
@@ -12,8 +12,10 @@
 - name: Set states of pulp workers
   systemd:
     daemon_reload: true
-    name: pulpcore-worker@{{ item }}.service
+    name: pulpcore-worker@{{ __pulp_workers_worker_index }}.service
     state: started
     enabled: true
-  with_sequence: 'start=1 count={{ pulp_workers }}'
+  loop: "{{ range(1, pulp_workers + 1) | list }}"
+  loop_control:
+    loop_var: __pulp_workers_worker_index
   become: true

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,9 @@ deps =
     ansible-lint
     docker
     molecule
+    py36: molecule-docker
+    py37: molecule-docker
+    py38: molecule-docker
     # molecule dep that is incompatible with python 2 as of 1.13.0 & 1.13.1
     sh < 1.13 ; python_version < "3"
 setenv =


### PR DESCRIPTION
Removing the following warning

```
[WARNING]: The loop variable 'item' is already in use. You should set
the `loop_var` value in the `loop_control` option for the task to
something else to avoid variable collisions and[184/611]
unexpected behavior.
```

[noissue]