### PR TITLE
fix list formatting in docs index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,7 @@ must have Python 3 and Ansible (>= 2.9) installed.
 
 The [managed node](https://docs.ansible.com/ansible/2.5/network/getting_started/basic_concepts.html#managed-nodes)
 must be one of these currently supported operating systems:
+
 * CentOS 7
 * Debian Buster (needs `allow_world_readable_tmpfiles = True` in ansible.cfg)
 * Fedora 30 or later
@@ -26,6 +27,7 @@ exception is Pulp 2. The RESP APIs for Pulp 2 and Pulp 3 can be served on the sa
 long as the `apache` webserver is deployed for both.
 
 Ansibles Python interpreter must have the package installed:
+
 * psycopg2
 * firewall (if firewalld should be configured; you can disable that with `pulp_configure_firewall=false`)
 


### PR DESCRIPTION
this is needed when a not-github markdown parser tries to parse the file