### PR TITLE
Update pip installs' pulpcore-selinux to 1.2.2

### DIFF
--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -62,7 +62,7 @@ __pulp_selinux_policy_pkgs:
   - pulpcore
   - pulpcore_rhsmcertd
 __pulp_selinux_repo: 'https://github.com/pulp/pulpcore-selinux.git'
-__pulp_selinux_version: '1.2.0'
+__pulp_selinux_version: '1.2.2'
 __pulp_selinux_label_dirs:
   - "{{ pulp_install_dir }}"
   - "{{ pulp_config_dir }}"


### PR DESCRIPTION
Sets the SELinux context on /var/lib/pulp/pulpcore_static correctly
to httpd_sys_content_t so that webservers can read it.

[noissue]