### PR TITLE
Problem: SELinux denials on symlinking when galaxy-importer

### DIFF
--- a/CHANGES/7780.bugfix
+++ b/CHANGES/7780.bugfix
@@ -1,0 +1,1 @@
+Fix SELinux denials on symlinking by the galaxy_ng content plugin by updating pulpcore-selinux (SELinux policies) to 1.2.3.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -62,7 +62,7 @@ __pulp_selinux_policy_pkgs:
   - pulpcore
   - pulpcore_rhsmcertd
 __pulp_selinux_repo: 'https://github.com/pulp/pulpcore-selinux.git'
-__pulp_selinux_version: '1.2.2'
+__pulp_selinux_version: '1.2.3'
 __pulp_selinux_label_dirs:
   - "{{ pulp_install_dir }}"
   - "{{ pulp_config_dir }}"


### PR DESCRIPTION
is run (by galaxy_ng content plugin)

Solution: Update pulpcore-selinux to 1.2.3, which includes
the fix.

fixes: #7780