### PR TITLE
Use apache webserver in tests

### DIFF
--- a/CHANGES/4968.misc
+++ b/CHANGES/4968.misc
@@ -1,0 +1,1 @@
+Added 'apache' webserver to tests on.

--- a/CHANGES/7524.bugfix
+++ b/CHANGES/7524.bugfix
@@ -1,0 +1,1 @@
+Fixed apache config to handle unix sockets.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -121,6 +121,14 @@ There are other (intentional) differences between tests:
 1. `dynamic` - Due to a limitation of Ansible 2.8 with collections, these are not tested with
    Ansible 2.8.
 
+To test both webserver solutions we testing `apache` as webserver with
+
+* package-dynamic
+* source-dynamic
+* release-static
+
+All others scenarios use `nginx` as a webserver.
+
 Docs Testing
 ------------
 

--- a/molecule/packages-dynamic/group_vars/all
+++ b/molecule/packages-dynamic/group_vars/all
@@ -12,3 +12,4 @@ pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.7/el{{ ansible_distributio
 # Setting this not because it should have any effect, but to test that it
 # doesn't:
 pulp_pkg_upgrade_all: true
+pulp_webserver_server: apache

--- a/molecule/release-static/group_vars/all
+++ b/molecule/release-static/group_vars/all
@@ -18,3 +18,4 @@ pulp_install_plugins:
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
+pulp_webserver_server: apache

--- a/molecule/source-dynamic/group_vars/all
+++ b/molecule/source-dynamic/group_vars/all
@@ -31,3 +31,4 @@ developer_user: pulp
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
+pulp_webserver_server: apache

--- a/roles/pulp_webserver/README.md
+++ b/roles/pulp_webserver/README.md
@@ -14,9 +14,9 @@ Role Variables
 --------------
 
 * `pulp_webserver_server` Set the webserver Pulp should use to reverse proxy with. Defaults to
-  'nginx'.
-* `pulp_configure_firewall` Install and configure a firewall. Valid values are 'auto', 'firewalld',
-  and 'none'. Defaults to 'auto' (which is the same as 'firewalld', but may change in the future).
+  `nginx`. The other valid value is `apache`.
+* `pulp_configure_firewall` Install and configure a firewall. Valid values are `auto`, `firewalld`,
+  and `none`. Defaults to `auto` (which is the same as `firewalld`, but may change in the future).
 * `pulp_webserver_http_port`: Define the HTTP port to listen on. Defaults to `80`.
 * `pulp_webserver_https_port`: Define the HTTPS port to listen on. Defaults to `443`.
 * `pulp_webserver_disable_https`: Whether or not HTTPS should be disabled. Defaults to `false`.

--- a/roles/pulp_webserver/tasks/apache.yml
+++ b/roles/pulp_webserver/tasks/apache.yml
@@ -12,7 +12,19 @@
         dest: "{{ pulp_webserver_apache_vhost_dir }}/pulp-vhost.conf"
       notify: reload apache
 
-    - name: Enable Apache vhost files and mod files
+    - name: Enable Apache mod files
+      apache2_module:
+        state: present
+        name: "{{ item }}"
+      loop:
+        - headers
+        - proxy
+        - proxy_http
+        - ssl
+      when: ansible_facts.os_family == "Debian"
+      notify: reload apache
+
+    - name: Enable Apache vhost files
       file:
         src: "{{ item.src }}"
         dest: "{{ item.dest }}"
@@ -20,8 +32,13 @@
       loop:
         - src: ../sites-available/pulp-vhost.conf
           dest: /etc/apache2/sites-enabled/pulp-vhost.conf
-        - src: ../mods-available/proxy.load
-          dest: /etc/apache2/mods-enabled/proxy.load
+      when: ansible_facts.os_family == "Debian"
+      notify: reload apache
+
+    - name: Remove default apache vhost file
+      file:
+        state: absent
+        path: /etc/apache2/sites-enabled/000-default.conf
       when: ansible_facts.os_family == "Debian"
       notify: reload apache
 

--- a/roles/pulp_webserver/templates/pulp-vhost.conf.j2
+++ b/roles/pulp_webserver/templates/pulp-vhost.conf.j2
@@ -1,5 +1,5 @@
-Define pulp-content {{ pulp_content_bind }}
-Define pulp-api {{ pulp_api_bind }}
+Define pulp-content {{ __pulp_webserver_apache_content_bind }}
+Define pulp-api {{ __pulp_webserver_apache_api_bind }}
 
 {% if pulp_webserver_disable_https | bool %}
 <VirtualHost *:{{ pulp_webserver_http_port }}>
@@ -14,22 +14,22 @@ Define pulp-api {{ pulp_api_bind }}
   ProxyRequests Off
   ProxyPreserveHost Off
 
-  ProxyPass /pulp/api/v3 http://${pulp-api}/pulp/api/v3
-  ProxyPassReverse /pulp/api/3 http://${pulp-api}/pulp/api/v3
+  ProxyPass /pulp/api/v3 ${pulp-api}/pulp/api/v3
+  ProxyPassReverse /pulp/api/3 ${pulp-api}/pulp/api/v3
 
-  ProxyPass /auth/login/ http://${pulp-api}/auth/login/
-  ProxyPassReverse /auth/login/ http://${pulp-api}/auth/login/
+  ProxyPass /auth/login/ ${pulp-api}/auth/login/
+  ProxyPassReverse /auth/login/ ${pulp-api}/auth/login/
 
-  ProxyPass /pulp/content http://${pulp-content}/pulp/content
-  ProxyPassReverse /pulp/content http://${pulp-content}/pulp/content
+  ProxyPass /pulp/content ${pulp-content}/pulp/content
+  ProxyPassReverse /pulp/content ${pulp-content}/pulp/content
 
   IncludeOptional pulp/*.conf
 
   # static files are served through whitenoise - http://whitenoise.evans.io/en/stable/
   # exclude all pulp v2 api calls
   ProxyPassMatch ^/pulp/api/v2 !
-  ProxyPass / http://${pulp-api}/
-  ProxyPassReverse / http://${pulp-api}/
+  ProxyPass / ${pulp-api}/
+  ProxyPassReverse / ${pulp-api}/
 
 </VirtualHost>
 {% else %}
@@ -67,14 +67,14 @@ Define pulp-api {{ pulp_api_bind }}
   ProxyRequests Off
   ProxyPreserveHost Off
 
-  ProxyPass /pulp/api/v3 http://${pulp-api}/pulp/api/v3
-  ProxyPassReverse /pulp/api/v3 http://${pulp-api}/pulp/api/v3
+  ProxyPass /pulp/api/v3 ${pulp-api}/pulp/api/v3
+  ProxyPassReverse /pulp/api/v3 ${pulp-api}/pulp/api/v3
 
-  ProxyPass /auth/login/ http://${pulp-api}/auth/login/
-  ProxyPassReverse /auth/login/ http://${pulp-api}/auth/login/
+  ProxyPass /auth/login/ ${pulp-api}/auth/login/
+  ProxyPassReverse /auth/login/ ${pulp-api}/auth/login/
 
-  ProxyPass /pulp/content http://${pulp-content}/pulp/content
-  ProxyPassReverse /pulp/content http://${pulp-content}/pulp/content
+  ProxyPass /pulp/content ${pulp-content}/pulp/content
+  ProxyPassReverse /pulp/content ${pulp-content}/pulp/content
 
   IncludeOptional pulp/*.conf
 
@@ -82,8 +82,8 @@ Define pulp-api {{ pulp_api_bind }}
   # http://whitenoise.evans.io/en/stable/
   # exclude all pulp v2 api calls
   ProxyPassMatch ^/pulp/api/v2 !
-  ProxyPass / http://${pulp-api}/
-  ProxyPassReverse / http://${pulp-api}/
+  ProxyPass / ${pulp-api}/
+  ProxyPassReverse / ${pulp-api}/
 
   # ACME http-01 tokens, i.e, for Let's Encrypt
   <Location "/.well-known">

--- a/roles/pulp_webserver/vars/main.yml
+++ b/roles/pulp_webserver/vars/main.yml
@@ -1,0 +1,4 @@
+---
+__pulp_apache_url: 'localhost'
+__pulp_webserver_apache_api_bind: "{{ pulp_api_bind.startswith('unix') | ternary(pulp_api_bind + '|http://' + __pulp_apache_url, 'http://' + pulp_api_bind ) }}"
+__pulp_webserver_apache_content_bind: "{{ pulp_content_bind.startswith('unix') | ternary(pulp_content_bind + '|http://' + __pulp_apache_url, 'http://' + pulp_content_bind ) }}"


### PR DESCRIPTION
Change 2 dynamic and 1 static test to use apache instead of nginx.

Add install mods for apache and removing default vhost for Debian host.

closes: #4968
https://pulp.plan.io/issues/4968
closes: #7524
https://pulp.plan.io/issues/7524