### PR TITLE
Simplify DATABASE engine name

### DIFF
--- a/roles/pulp_common/vars/main.yml
+++ b/roles/pulp_common/vars/main.yml
@@ -25,7 +25,7 @@ __pulp_common_pulp_settings_defaults:
   databases:
     default:
       HOST: localhost
-      ENGINE: django.db.backends.postgresql_psycopg2
+      ENGINE: django.db.backends.postgresql
       NAME: pulp
       USER: pulp
       PASSWORD: pulp

--- a/roles/pulp_database/vars/main.yml
+++ b/roles/pulp_database/vars/main.yml
@@ -15,7 +15,7 @@ __pulp_database_pulp_settings_defaults:
   databases:
     default:
       HOST: localhost
-      ENGINE: django.db.backends.postgresql_psycopg2
+      ENGINE: django.db.backends.postgresql
       NAME: pulp
       USER: pulp
       PASSWORD: pulp

--- a/roles/pulp_services/README.md
+++ b/roles/pulp_services/README.md
@@ -56,7 +56,7 @@ Here's an example playbook for using pulp_services in pulp_installer. It assumes
           databases:
             default:
               HOST: postgres1
-              ENGINE: django.db.backends.postgresql_psycopg2
+              ENGINE: django.db.backends.postgresql
               NAME: pulp
               USER: pulp
               PASSWORD: << YOUR DATABASE PASSWORD HERE >>


### PR DESCRIPTION
As of Django 1.9 there is no need to add the _pycopg2 postfix as the
backend was renamed.

See: https://docs.djangoproject.com/en/3.1/releases/1.9/

[noissue]