### PR TITLE
Problem: pulp_installer fails to enable the "powertools"

### DIFF
--- a/CHANGES/7996.bugfix
+++ b/CHANGES/7996.bugfix
@@ -1,0 +1,2 @@
+Fixed inability to install on CentOS 8.3 or CentOS Stream due to the newly renamed "powertools" repo
+(formerly "PowerTools") not being enabled by the installer.

--- a/roles/pulp_common/tasks/repos.yml
+++ b/roles/pulp_common/tasks/repos.yml
@@ -88,7 +88,7 @@
 - name: Enable the CentOS PowerTools repo
   block:
 
-    - name: Determine which file in /etc/yum.repos.d/ has the CentOS PowerTools repo
+    - name: Determine which file in /etc/yum.repos.d/ has the CentOS 8.0 to 8.2 PowerTools repo
       shell: grep -l -E "^\[PowerTools\]" /etc/yum.repos.d/*.repo
       register: repo_file
       changed_when: false
@@ -105,20 +105,17 @@
       when: repo_file.rc == 0
       become: true
 
-    # Note: We can safely assume there will be no file with it if we are not on
-    # CentOS Stream. The RPM centos-release-stream adds several .repo files like:
-    # CentOS-Stream-PowerTools.repo
-    - name: Determine which file in /etc/yum.repos.d/ has the CentOS Stream-PowerTools repo
-      shell: grep -l -E "^\[Stream-PowerTools\]" /etc/yum.repos.d/*.repo
+    - name: Determine which file in /etc/yum.repos.d/ has the CentOS 8.3+ or Stream powertools repo
+      shell: grep -l -E "^\[powertools\]" /etc/yum.repos.d/*.repo
       register: repo_file
       changed_when: false
       failed_when: false
       check_mode: False
 
-    - name: Enable the CentOS Stream-PowerTools PowerTools repo
+    - name: Enable the CentOS powertools repo
       ini_file:
         path: "{{ repo_file.stdout }}"
-        section: "Stream-PowerTools"
+        section: "powertools"
         option: enabled
         value: 1
         no_extra_spaces: true


### PR DESCRIPTION
repo on CentOS 8.3 or the new CentOS Stream

Solution: Enable it or "PowerTools".
Replacing the "Stream-PowerTools" repo.

fixes: #7996