### PR TITLE
Molecule dep broken

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ deps =
     py36: molecule-docker
     py37: molecule-docker
     py38: molecule-docker
+    py36,py37,py38: rich==9.4.0
     # molecule dep that is incompatible with python 2 as of 1.13.0 & 1.13.1
     sh < 1.13 ; python_version < "3"
 setenv =


### PR DESCRIPTION
new version of molecule dep 'rich' 9.5.0 cause molecule won't run

[noissue]