### PR TITLE
always install policycoreutils python bindings

### DIFF
--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -11,9 +11,6 @@
       yum:
         name:
           - selinux-policy-devel
-          - policycoreutils
-          # Needed for seport technically, used by pulp_api & pulp_content
-          - "{{ (ansible_facts.distribution_major_version | int == 7) | ternary('policycoreutils-python','python3-policycoreutils') }}"
 
     - name: 'Ensure that /usr/local/share/selinux/{{ ansible_facts.selinux.type }} exists'
       file:

--- a/roles/pulp_common/vars/CentOS-7.yml
+++ b/roles/pulp_common/vars/CentOS-7.yml
@@ -4,6 +4,7 @@ pulp_preq_packages:
   - python36-devel
   - python-setuptools
   - libselinux-python  # For ansible itself
+  - policycoreutils-python # For ansible itself
   - postgresql-devel
   - gcc                # For psycopg2
   - make               # For make docs, and SELinux policy install

--- a/roles/pulp_common/vars/Fedora.yml
+++ b/roles/pulp_common/vars/Fedora.yml
@@ -3,6 +3,7 @@ pulp_preq_packages:
   - python3
   - python3-devel
   - python3-libselinux  # For ansible itself
+  - python3-policycoreutils # For ansible itself
   - gcc                 # For psycopg2
   - make                # For make docs, and SELinux policy install
   - libpq-devel         # Renamed/Split version of postgresql-devel


### PR DESCRIPTION
seport is used by pulp_api and pulp_content on PIP *and* RPM installs,
so let's install the bindings needed for it to work by default.