### PR TITLE
Early pulling the f33 upgrade image

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -86,7 +86,7 @@ jobs:
         if: matrix.test_type == 'release-upgrade' || matrix.test_type == 'source-upgrade'
         run: |
           docker pull quay.io/pulp/pulp-ci-dbuster:3.0.0
-          docker pull quay.io/pulp/pulp_rpm-ci-f31:3.1.0
+          docker pull quay.io/pulp/pulp_rpm-ci-f33:3.9.0
           docker pull quay.io/pulp/pulp_rpm-ci-c7:3.1.0
       - name: Pulling images for distro packages upgrades
         if: matrix.test_type == 'packages-upgrade'


### PR DESCRIPTION
because we now use it rather than the 31 upgrade image

[noissue]