### PR TITLE
As a pulp_installer user, gpg will be installed

### DIFF
--- a/CHANGES/8163.feature
+++ b/CHANGES/8163.feature
@@ -1,0 +1,1 @@
+Install the Linux distro's `gpg` binary command for the new SigningService functionality in pulpcore.

--- a/roles/pulp_common/vars/CentOS-7.yml
+++ b/roles/pulp_common/vars/CentOS-7.yml
@@ -10,6 +10,7 @@ pulp_preq_packages:
   - make               # For make docs, and SELinux policy install
   - git                # For source install, and SELinux policy install
   - sudo
+  - gnupg2             # For the signing service via the gpg python module
 
 pulp_python_interpreter: /usr/bin/python3.6
 pulp_python_cryptography:

--- a/roles/pulp_common/vars/Debian.yml
+++ b/roles/pulp_common/vars/Debian.yml
@@ -7,6 +7,7 @@ pulp_preq_packages:
   - gcc              # For psycopg2
   - git              # For source install
   - sudo
+  - gpg              # For the signing service via the gpg python module
 
 # Pulp requires Python 3.6+.
 pulp_python_interpreter: /usr/bin/python3

--- a/roles/pulp_common/vars/Fedora.yml
+++ b/roles/pulp_common/vars/Fedora.yml
@@ -9,6 +9,7 @@ pulp_preq_packages:
   - libpq-devel         # Renamed/Split version of postgresql-devel
   - git                 # For source install, and SELinux policy install
   - sudo
+  - gnupg2              # For the signing service via the gpg python module
 
 # Pulp requires Python 3.6+.
 pulp_python_interpreter: /usr/bin/python3

--- a/roles/pulp_common/vars/Ubuntu.yml
+++ b/roles/pulp_common/vars/Ubuntu.yml
@@ -7,6 +7,7 @@ pulp_preq_packages:
   - gcc                 # For psycopg2
   - git                 # For source install
   - sudo
+  - gpg                 # For the signing service via the gpg python module
 
 # Pulp requires Python 3.6+.
 pulp_python_interpreter: /usr/bin/python3


### PR DESCRIPTION
for the new signing service functionality (in pulpcore)

re: #7700
Add public_key to the SigningService model itself
https://pulp.plan.io/issues/7700

fixes: #8163
https://pulp.plan.io/issues/8163