### PR TITLE
Update pulpcore-selinux to 1.2.4.

### DIFF
--- a/CHANGES/8210.misc
+++ b/CHANGES/8210.misc
@@ -1,0 +1,1 @@
+Update pulpcore-selinux (SELinux policies) to 1.2.4 for the future feature of systemd socket activation.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -59,7 +59,7 @@ __pulp_selinux_policy_pkgs:
   - pulpcore
   - pulpcore_rhsmcertd
 __pulp_selinux_repo: 'https://github.com/pulp/pulpcore-selinux.git'
-__pulp_selinux_version: '1.2.3'
+__pulp_selinux_version: '1.2.4'
 __pulp_selinux_label_dirs:
   - "{{ pulp_install_dir }}"
   - "{{ pulp_config_dir }}"


### PR DESCRIPTION
The fixes are required by foreman-installer, and will be
required by pulp-installer when it implements #7689:
(systemd socket activation):
* Allow systemd Type=notify
* Label /var/run/pulpcore-(api|content).sock as server

fixes: #8210
SELinux policy updates for systemd socket activation
https://pulp.plan.io/issues/8210

re: #7689
As a user I want my socket to be backed up by a systemd implementation
https://pulp.plan.io/issues/7689