### PR TITLE
Problem: pulp_installer restores SELinux contexts every time it is run

### DIFF
--- a/CHANGES/8281.bugfix
+++ b/CHANGES/8281.bugfix
@@ -1,0 +1,1 @@
+Fix pulp_installer, on SELinux-enabled systems, not being idemopotent and always restoring SELinux contexts.

--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -14,12 +14,14 @@
 
     - name: 'Ensure that /usr/local/share/selinux/{{ ansible_facts.selinux.type }} exists'
       file:
-        path: '/usr/local/share/selinux/{{ ansible_facts.selinux.type }}'
+        path: "{{ item }}"
         state: directory
-        recurse: true
         mode: 0755
         owner: root
         group: root
+      with_items:
+        - '/usr/local/share/selinux'
+        - '/usr/local/share/selinux/{{ ansible_facts.selinux.type }}'
 
     - name: Clone SELinux policy from Git
       git:


### PR DESCRIPTION
Solution: Fix an idempotency error.

Fixes: 8281
pulp_installer restores SELinux contexts every time it is run
https://pulp.plan.io/issues/8281