### PR TITLE
Use pulp patched django

### DIFF
--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -197,7 +197,7 @@
     - name: Install patched versions of dependencies (FIPS only)
       pip:
         name:
-          - git+https://github.com/mdellweg/django.git@fips
+          - git+https://github.com/pulp/django.git@fips
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
       when: ansible_fips


### PR DESCRIPTION
I'll spend more time fixing https://github.com/pulp/pulp_installer/pull/528
but it fixes our nightly CI, and I need this for the tests I'm doing with https://github.com/pulp/plugin_template/pull/345