### PR TITLE
Add become to symlink deletion

### DIFF
--- a/roles/pulp_common/handlers/restart_all_pulp.yml
+++ b/roles/pulp_common/handlers/restart_all_pulp.yml
@@ -30,3 +30,4 @@
   file:
     path: '{{ __pulp_old_artifact_dir }}'
     state: absent
+  become: true


### PR DESCRIPTION
While upgrading with ansible not running as root, you can get a
permission denied.

[noissue]