### PR TITLE
Removing FIPS sandbox tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,8 +82,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - test_type: pulp3-sandbox-centos7-fips
-          - test_type: pulp3-sandbox-centos8-fips
           - test_type: pulp3-source-centos8-fips
           - test_type: pulp3-source-centos7-fips
           - test_type: pulp3-source-fedora32

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,8 +82,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - test_type: pulp3-sandbox-centos7-fips
-          - test_type: pulp3-sandbox-centos8-fips
+          - test_type: pulp3-source-centos7-fips
+          - test_type: pulp3-source-centos8-fips
     steps:
       - uses: actions/checkout@v2.3.1
         with:


### PR DESCRIPTION
Pulp cannot run in a FIPS environment because Django (a dependency) is not FIPS compatible

[noissue]