### PR TITLE
Privilege escalation

### DIFF
--- a/CHANGES/8186.bugfix
+++ b/CHANGES/8186.bugfix
@@ -1,0 +1,1 @@
+On some environments we need to escalate privilege for Enumerate default system PATH.

--- a/roles/pulp_common/tasks/main.yml
+++ b/roles/pulp_common/tasks/main.yml
@@ -87,6 +87,8 @@
   changed_when: false
   register: systemd_show_env_path
   check_mode: false
+  # This task typically doesn't need root, but on some user systems it does.
+  become: yes
 
 - name: systemd_show_env_path
   debug:


### PR DESCRIPTION
for some CentOS envs we need escalate privileges for ``systemctl show-environment``

closes: #8186
https://pulp.plan.io/issues/8186