### PR TITLE
configure module_hotfixes=1 for the pulpcore rpm repository

### DIFF
--- a/roles/pulp_common/tasks/repos.yml
+++ b/roles/pulp_common/tasks/repos.yml
@@ -126,14 +126,27 @@
     - ansible_facts.distribution == "CentOS"
     - ansible_facts.distribution_major_version|int >= 8
 
-- name: "Add {{ __pulp_pkg_repo_name }} RPM repository"
-  yum_repository:
-    name: "{{ __pulp_pkg_repo_name }}"
-    description: "{{ __pulp_pkg_repo_name }}"
-    baseurl: "{{ pulp_pkg_repo }}"
-    gpgcheck: "{{ pulp_pkg_repo_gpgcheck }}"
-    gpgkey: "{{ __pulp_pkg_repo_gpgkey }}"
-    enabled: true
+- name: "Configure {{ __pulp_pkg_repo_name }} RPM repository"
+  block:
+    # Set module_hotfixes=1 so that dnf allows to override packages that are part
+    # of modular repositories (like CentOS-8 - AppStream).
+    # Use a dedicated config file and include it later, as yum_repository doesn't
+    # support setting the module_hotfixes parameter yet.
+    - name: "Create module_hotfixes config file"
+      copy:
+        dest: /etc/yum/pulpcore.conf
+        content: |
+          module_hotfixes=1
+
+    - name: "Add {{ __pulp_pkg_repo_name }} RPM repository"
+      yum_repository:
+        name: "{{ __pulp_pkg_repo_name }}"
+        description: "{{ __pulp_pkg_repo_name }}"
+        baseurl: "{{ pulp_pkg_repo }}"
+        gpgcheck: "{{ pulp_pkg_repo_gpgcheck }}"
+        gpgkey: "{{ __pulp_pkg_repo_gpgkey }}"
+        enabled: true
+        include: /etc/yum/pulpcore.conf
   when:
     - ansible_facts.os_family == "RedHat"
     - pulp_pkg_repo is not none


### PR DESCRIPTION
our RPM repository ships packages that are *also* available as modules.
to make dnf prefer our packages over the modules, we need to configure
the repository with module_hotfixes=1, as otherwise dnf would ignore
those packages.

[noissue]