### PR TITLE
fix redis in getting started guide

### DIFF
--- a/CHANGES/7773.doc
+++ b/CHANGES/7773.doc
@@ -1,0 +1,1 @@
+Add workaround to install redis correctly

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -71,6 +71,12 @@ vim install.yml
       # pulp-npm: {}
       # pulp-python: {}
       pulp-rpm: {}
+  # can be removed once this is resolved: https://pulp.plan.io/issues/7773
+  pre_tasks:
+    - name: install EPEL
+      yum:
+        name: epel-release
+      become: yes
   roles:
     - pulp.pulp_installer.pulp_all_services
   environment:


### PR DESCRIPTION
Installing on a fresh CentOS 7 box is currently broken, because EPEL is missing. This adds a temporary fix until the role itself is fixed, so users can actually install pulp.

ref #7773
https://pulp.plan.io/issues/7773