### PR TITLE
module_hotfixes: Ensure compatibility with both dnf and yum

### DIFF
--- a/roles/pulp_common/tasks/repos.yml
+++ b/roles/pulp_common/tasks/repos.yml
@@ -127,26 +127,10 @@
     - ansible_facts.distribution_major_version|int >= 8
 
 - name: "Configure {{ __pulp_pkg_repo_name }} RPM repository"
-  block:
-    # Set module_hotfixes=1 so that dnf allows to override packages that are part
-    # of modular repositories (like CentOS-8 - AppStream).
-    # Use a dedicated config file and include it later, as yum_repository doesn't
-    # support setting the module_hotfixes parameter yet.
-    - name: "Create module_hotfixes config file"
-      copy:
-        dest: /etc/yum/pulpcore.conf
-        content: |
-          module_hotfixes=1
+  template:
+    src: pulpcore.repo.j2
+    dest: /etc/yum.repos.d/pulpcore.repo
 
-    - name: "Add {{ __pulp_pkg_repo_name }} RPM repository"
-      yum_repository:
-        name: "{{ __pulp_pkg_repo_name }}"
-        description: "{{ __pulp_pkg_repo_name }}"
-        baseurl: "{{ pulp_pkg_repo }}"
-        gpgcheck: "{{ pulp_pkg_repo_gpgcheck }}"
-        gpgkey: "{{ __pulp_pkg_repo_gpgkey }}"
-        enabled: true
-        include: /etc/yum/pulpcore.conf
   when:
     - ansible_facts.os_family == "RedHat"
     - pulp_pkg_repo is not none

--- a/roles/pulp_common/templates/pulpcore.repo.j2
+++ b/roles/pulp_common/templates/pulpcore.repo.j2
@@ -1,0 +1,12 @@
+# Set module_hotfixes=1 so that dnf allows to override packages that are part
+# of modular repositories (like CentOS-8 - AppStream).
+# Use a dedicated config file and include it later, as yum_repository doesn't
+# support setting the module_hotfixes parameter yet.
+[{{ __pulp_pkg_repo_name }}]
+name = {{__pulp_pkg_repo_name}}
+description = {{ __pulp_pkg_repo_name }}
+baseurl = {{ pulp_pkg_repo }}
+gpgcheck = {{ pulp_pkg_repo_gpgcheck }}
+gpgkey = {{ __pulp_pkg_repo_gpgkey }}
+enabled = 1
+module_hotfixes = 1


### PR DESCRIPTION
The way the module_hotfixes is currently set works only with yum.conf(5)
but not dnf.conf(5).

With dnf.conf(5) the `include=` instruction is not understood and simply
ignored.

The new approach works with both.

[noissue]