### PR TITLE
Fix pclean to clean up media

### DIFF
--- a/roles/pulp_devel/templates/alias.bashrc.j2
+++ b/roles/pulp_devel/templates/alias.bashrc.j2
@@ -44,7 +44,7 @@ _pdbreset_help="$_dbreset_help - `setterm -foreground red -bold on`THIS DESTROYS
 
 pclean() {
     pdbreset
-    sudo rm -rf {{ pulp_user_home }}/artifact
+    sudo rm -rf {{ pulp_media_root }}/*
     {{ pulp_django_admin_path }} collectstatic --noinput --link
 }
 _pclean_help="Restore pulp to a clean-installed state"


### PR DESCRIPTION
It attempts to rm /var/lib/pulp/artifact/ which is now at
/var/lib/pulp/media/artifact.

[noissue]