### PR TITLE
Disable fips jobs in PR and release builds

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -145,10 +145,6 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - test_type: pulp3-source-centos7-fips
-          - test_type: pulp3-source-centos8-fips
     steps:
       - uses: actions/checkout@v2.3.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,10 +106,6 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - test_type: pulp3-source-centos7-fips
-          - test_type: pulp3-source-centos8-fips
     steps:
       - uses: actions/checkout@v2.3.1
         with:


### PR DESCRIPTION
Looking for some feedback.

The pulp org is limited to 20 concurrent jobs in Github Actions and
we're starting to see queue times of 15+ minutes. These fips jobs start
every time a change is pushed to a PR. I think it might make sense to
disable them for PRs and releases and just rely on them running nightly

[noissue]