### PR TITLE
Problem: pulp_installer refuses to install in

### DIFF
--- a/CHANGES/8834.bugfix
+++ b/CHANGES/8834.bugfix
@@ -1,0 +1,1 @@
+Enable installing in FIPS mode whenever installing from RPM packages (pulp_install_source == "packages"), which may be patched for FIPS mode.

--- a/roles/pulp_common/tasks/main.yml
+++ b/roles/pulp_common/tasks/main.yml
@@ -38,7 +38,7 @@
 - name: Check required roles if FIPS detected
   assert:
     that:
-      - "'pulp_devel' in role_names"
+      - ('pulp_devel' in role_names) or (pulp_install_source == 'packages')
     fail_msg: >
       Pulp cannot run in a FIPS environment because Django (a dependency) is not FIPS
       compatible


### PR DESCRIPTION
packages mode and non-devel mode when FIPS is enabled

Solution: Check for either devel mode (with pip) or packages mode.
(#8258 checked for devel mode only)

fixes: #8834
https://pulp.plan.io/issues/8834

EDIT: I tested this locally by dropping the "when" line, and running the 2 molecule tests that should pass (as well as 1 that shouldn't.)