### PR TITLE
3.11 backport: CI: Modify tag jobs to only run release tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,20 +17,12 @@ jobs:
             ansible: "2.9"
             python: "2.7"
             toxpy: "27"
-          - test_type: source-static
-            ansible: "2.9"
-            python: "3.6"
-            toxpy: "36"
           - test_type: packages-static
             ansible: "2.10"
             python: "3.7"
             toxpy: "37"
           - test_type: release-dynamic
             ansible: "2.10"
-            python: "3.8"
-            toxpy: "38"
-          - test_type: source-dynamic
-            ansible: "2.9"
             python: "3.8"
             toxpy: "38"
           - test_type: packages-dynamic
@@ -41,10 +33,6 @@ jobs:
             ansible: "2.9"
             python: "2.7"
             toxpy: "27"
-          - test_type: source-upgrade
-            ansible: "2.10"
-            python: "3.6"
-            toxpy: "36"
           - test_type: packages-upgrade
             ansible: "2.10"
             python: "3.6"

--- a/CHANGES/6550.dev
+++ b/CHANGES/6550.dev
@@ -1,0 +1,1 @@
+When CI runs for a tag (release), only run pip release and package tests, not source (devel) tests.


### PR DESCRIPTION
and package tests

fixes: #6550
https://pulp.plan.io/issues/6550
pulp_installer CI: Modify tag jobs to only run release tests