### PR TITLE
Create or import a key for pulp-api to use when

### DIFF
--- a/CHANGES/8704.feature
+++ b/CHANGES/8704.feature
@@ -1,0 +1,1 @@
+Create or import a key for pulp-api to use when encrypting sensitive db fields. Introduces new variables `pulp_db_fields` & `pulp_db_fields_key_remote`.

--- a/roles/pulp_api/README.md
+++ b/roles/pulp_api/README.md
@@ -12,7 +12,14 @@ Role Variables
   Defaults to `'127.0.0.1:24817'`.
 * `pulp_api_workers`: Number of `gunicorn` processes for handling Pulp API requests. Defaults to 1.
 * `pulp_token_auth_key`: Location of the openssl private key (in pem format) to use for token
-  authentication. If not specified, a new key wil be generated.
+  authentication. If not specified, a new key wil be generated. (Only generated if one doesn't
+  exist.)
+* `pulp_db_fields_key`: Relative or absolute path to the Ferret symmetric encryption key
+   one wants to import. It is used to encrypt certain fields in the database (such as credentials.)
+   If not specified, a new key will be generated. (Only generated if one doesn't exist.)
+* `pulp_db_fields_key_remote`: Whether or not the `pulp_database_fields_key`
+  are on the pulp-api system (`true`) or on the ansible management node (`false`).
+  Defaults to `false`.
 
 Shared variables
 ----------------
@@ -22,7 +29,7 @@ Shared variables
 This role **is tightly coupled** to the required `pulp_common` role, and inherits
 some of its variables.
 
-* `pulp_certs_dir`: Path where to generate or drop the keys for authentication tokens. Defaults to
+* `pulp_certs_dir`: Path where to generate or drop the keys for authentication token and database fields. Defaults to
   '{{ pulp_config_dir }}/certs' .
 * `pulp_config_dir`
 * `pulp_group`

--- a/roles/pulp_api/defaults/main.yml
+++ b/roles/pulp_api/defaults/main.yml
@@ -2,3 +2,5 @@
 # defaults file for pulp_api
 pulp_api_bind: '127.0.0.1:24817'
 pulp_api_workers: 1
+pulp_db_fields_key: ''
+pulp_db_fields_key_remote: false

--- a/roles/pulp_api/tasks/generate_database_fields_key.yml
+++ b/roles/pulp_api/tasks/generate_database_fields_key.yml
@@ -1,0 +1,47 @@
+---
+- name: Check for existing Pulp Database Encryption Key
+  stat:
+    path: '{{ __pulp_db_fields_key_path }}'
+    get_attributes: false
+    get_checksum: false
+    get_mime: false
+  register: __pulp_db_fields_key_file
+
+# A theoretically better approach would be to use the jinja2 filter
+# `b64encode` and not have to install `openssl`.
+# However, then the bytes to be encoded would have to be put
+# into a temporary ansible variable on the ansible management node, and the
+# templated file may be placed elsewhere on disk temporarily. It seems
+# more secure to just do it this way.
+
+# Fortunately every single distro we support uses this package name
+# for /usr/bin/openssl
+# https://pkgs.org/search/?q=%2Fusr%2Fbin%2Fopenssl
+- name: Install the openssl command
+  package:
+    name: openssl
+    state: present
+  become: true
+  when: not __pulp_db_fields_key_file.stat.exists
+
+- name: Generate Pulp Database Encryption Key
+  shell: >-
+    set -o pipefail &&
+    umask 0077 &&
+    dd if=/dev/urandom bs=32 count=1 2>/dev/null
+    | openssl base64 > {{ __pulp_db_fields_key_path }}
+  args:
+    # Debian defaults to bourne, but it doesn't understand pipefail.
+    executable: /bin/bash
+  notify: Restart all Pulp services
+  become: true
+  become_user: "{{ pulp_user }}"
+  when: not __pulp_db_fields_key_file.stat.exists
+
+- name: Ensure correct permissions on new Pulp Database Encryption Key
+  file:
+    path: '{{ __pulp_db_fields_key_path }}'
+    owner: "{{ pulp_user }}"
+    group: "{{ pulp_group }}"
+    mode: 0600
+  become: true

--- a/roles/pulp_api/tasks/main.yml
+++ b/roles/pulp_api/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 # tasks file for pulp_api
-- block:
+
+- name: Non-key-related pulp-api install tasks
+  block:
 
     - name: Apply the SELinux type to the TCP port that pulpcore-api listens on
       seport:
@@ -59,3 +61,18 @@
   become_user: "{{ pulp_user }}"
   when:
     - (ansible_version.major > 2) or (ansible_version.major == 2 and ansible_version.minor >= 9)
+
+- name: Import Pulp Database Encryption Key
+  copy:
+    src: "{{ pulp_db_fields_key }}"
+    dest: "{{ __pulp_db_fields_key_path }}"
+    owner: "{{ pulp_user }}"
+    group: "{{ pulp_group }}"
+    mode: 0600
+    remote_src: "{{ pulp_db_fields_key_remote }}"
+  notify: Restart all Pulp services
+  when: pulp_db_fields_key | length
+
+- import_tasks: generate_database_fields_key.yml
+  when:
+    - not pulp_db_fields_key | length

--- a/roles/pulp_api/vars/main.yml
+++ b/roles/pulp_api/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for pulp_api
+__pulp_db_fields_key_path: '{{ pulp_certs_dir }}/database_fields.symmetric.key'


### PR DESCRIPTION
encrypting sensitive db fields.

Introduces new variables `pulp_db_fields_key` & `pulp_db_fields_key_remote`.

fixes: #8704
Create a key for pulp to use when encrypting sensitive db fields
https://pulp.plan.io/issues/8704