### PR TITLE
Galaxy Importer Post Install role.

### DIFF
--- a/example.dev-config.yml
+++ b/example.dev-config.yml
@@ -32,13 +32,16 @@ pulp_install_plugins:
   # pulp-rpm:
   #   source_dir: "/home/vagrant/devel/pulp_rpm"
 
+# # Optional galaxy-importer settings
+# galaxy_importer_settings: {}
+
 # Vagrant source install Required
 pulp_user: "vagrant"
 developer_user: "vagrant"
 developer_user_home: "/home/vagrant"
 pulp_source_dir: "/home/vagrant/devel/pulpcore"
 
-# Optional git specific branch
+# # Optional git specific branch
 # pulp_git_url: "https://github.com/pulp/pulpcore"
 # pulp_git_revision: "3.11"  # branch/tag/commit
 

--- a/roles/galaxy_post_install/README.md
+++ b/roles/galaxy_post_install/README.md
@@ -1,0 +1,14 @@
+# Galaxy Post Install
+
+This roles runs galaxy post install configuration
+It runs by default when `galaxy-ng` is part of `pulp_install_plugins` variable.
+
+## Tasks
+
+### Galaxy Importer Settings
+
+Creates config file for galaxy-importer
+
+#### Variables
+
+`galaxy_importer_settings`: Key value dictionnary that contains the content of galaxy-importer.cfg to be overwritten.

--- a/roles/galaxy_post_install/defaults/main.yml
+++ b/roles/galaxy_post_install/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+galaxy_importer_settings: {}

--- a/roles/galaxy_post_install/handlers/main.yml
+++ b/roles/galaxy_post_install/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers for galaxy post install

--- a/roles/galaxy_post_install/meta/main.yml
+++ b/roles/galaxy_post_install/meta/main.yml
@@ -1,0 +1,27 @@
+---
+galaxy_info:
+  author: Galaxy Team
+  description: A role to setup galaxy_ng & galaxy_importer post install tasks
+  issue_tracker_url: https://issues.redhat.com/projects/AAH
+  license: GPL-2.0-or-later
+  company: Red Hat
+  min_ansible_version: 2.9
+  platforms:
+    - name: Debian
+      versions:
+        - buster
+    - name: Fedora
+      versions:
+        - 32
+        - 33
+        - 34
+    - name: EL
+      versions:
+        - 7
+        - 8
+  galaxy_tags:
+    - pulp
+    - pulpcore
+    - galaxy
+    - galaxyng
+  dependencies: []

--- a/roles/galaxy_post_install/tasks/galaxy_importer.yml
+++ b/roles/galaxy_post_install/tasks/galaxy_importer.yml
@@ -1,0 +1,20 @@
+---
+- block:
+  - name: Ensure tar is available for galaxy-importer
+    package:
+      name: tar
+      state: present
+
+  - name: Create galaxy-importer directory
+    file:
+      path: "/etc/galaxy-importer/"
+      state: directory
+      mode: '0755'
+
+  - name: Write galaxy-importer config
+    template:
+      src: galaxy-importer.cfg.j2
+      dest: /etc/galaxy-importer/galaxy-importer.cfg
+      mode: '0644'
+
+  become: true

--- a/roles/galaxy_post_install/tasks/main.yml
+++ b/roles/galaxy_post_install/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- import_tasks: galaxy_importer.yml

--- a/roles/galaxy_post_install/templates/galaxy-importer.cfg.j2
+++ b/roles/galaxy_post_install/templates/galaxy-importer.cfg.j2
@@ -1,0 +1,4 @@
+[galaxy-importer]
+{% for key, value in galaxy_importer_settings.items() %}
+{{ key | upper }} = {{ value }}
+{% endfor %}

--- a/roles/galaxy_post_install/vars/main.yml
+++ b/roles/galaxy_post_install/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars for galaxy post install

--- a/roles/pulp_common/tasks/configure.yml
+++ b/roles/pulp_common/tasks/configure.yml
@@ -36,4 +36,9 @@
         group: root
         mode: "0440"
 
+    - name: Include galaxy_ng post install role
+      include_role:
+        name: galaxy_post_install
+      when: pulp_install_plugins_normalized['galaxy-ng'] is defined
+
   become: true


### PR DESCRIPTION
For configuring galaxy importer, when galaxy_ng is present on plugins
list this new role will be included to the pulp_common/configure task.

https://issues.redhat.com/browse/AAH-686

[noissue]