### PR TITLE
3.11 backport: Problem: pulp_installer CI upgrade tests are

### DIFF
--- a/CHANGES/8887.dev
+++ b/CHANGES/8887.dev
@@ -1,0 +1,1 @@
+Fix upgrade CI tests failing on Debian 10 & CentOS 8 during verification by upgrading systemd.

--- a/molecule/scenario_resources/verify.yml
+++ b/molecule/scenario_resources/verify.yml
@@ -59,6 +59,13 @@
         state: present
       when: ansible_facts.distribution == 'Fedora'
 
+    - name: Update systemd to resolve inspec being unable to inspect it
+      package:
+        name: systemd
+        state: latest  # noqa 403
+      when: (ansible_facts.distribution == 'Debian' and ansible_facts.distribution_major_version == '10') or
+            (ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version == '8')
+
     # Undeclared by the package, and not documented:
     # https://docs.chef.io/inspec/resources/port/
     - name: Install netstat dependency for inspec's port listening tests


### PR DESCRIPTION
failing on debian 10 & CentOS 8

During the verify phase, with the inspec command.

Solution: Upgrade the systemd package on said distros during the
verify phase.

fixes: #8887