### PR TITLE
Problem: psycopg2 2.9 is causing pulp_installer

### DIFF
--- a/CHANGES/8925.bugfix
+++ b/CHANGES/8925.bugfix
@@ -1,0 +1,1 @@
+Fix pulp_installer being unable to install pulpcore from source ("AssertionError: database connection isn't set to UTC" during "pulp_database_config : Run database migrations") by preventing the pulpcore dependency psycopg2 from being either version 2.9 or 2.9.1.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -24,6 +24,7 @@ pulp_use_system_wide_pkgs: false
 prereq_pip_packages:
   - Jinja2
   - pygments
+  - "psycopg2!=2.9,!=2.9.1"
 pulp_rhel_codeready_repo:
   - codeready-builder-for-rhel-8-x86_64-rpms
   - rhui-codeready-builder-for-rhel-8-rhui-rpms


### PR DESCRIPTION
source installs to fail

Solution: Fix pulp_installer being unable to install pulpcore from source
("AssertionError: database connection isn't set to UTC" during
"pulp_database_config : Run database migrations")
by preventing the pulpcore dependency psycopg2 from being either
version 2.9 or 2.9.1.

fixes: #8925