### PR TITLE
Revert "Problem: psycopg2 2.9 is causing pulp_installer"

### DIFF
--- a/CHANGES/8925.bugfix
+++ b/CHANGES/8925.bugfix
@@ -1,1 +1,0 @@
-Fix pulp_installer being unable to install pulpcore from source ("AssertionError: database connection isn't set to UTC" during "pulp_database_config : Run database migrations") by preventing the pulpcore dependency psycopg2 from being either version 2.9 or 2.9.1.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -24,7 +24,6 @@ pulp_use_system_wide_pkgs: false
 prereq_pip_packages:
   - Jinja2
   - pygments
-  - "psycopg2!=2.9,!=2.9.1"
 pulp_rhel_codeready_repo:
   - codeready-builder-for-rhel-8-x86_64-rpms
   - rhui-codeready-builder-for-rhel-8-rhui-rpms


### PR DESCRIPTION
This reverts commit 3f1b084f050975f42213fb0074d2f1fbd106a485.

Due to #8926 being merged to master, and 3.13 / 3.11 not
needing it due to their requirements.txt having psycopg2<2.9

[noissue]