### PR TITLE
3.11 backport: Revert "Problem: psycopg2 2.9 is causing pulp_installer"

### DIFF
--- a/CHANGES/8925.bugfix
+++ b/CHANGES/8925.bugfix
@@ -1,1 +1,0 @@
-Fix pulp_installer being unable to install pulpcore from source ("AssertionError: database connection isn't set to UTC" during "pulp_database_config : Run database migrations") by preventing the pulpcore dependency psycopg2 from being either version 2.9 or 2.9.1.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -21,7 +21,6 @@ pulp_pip_editable: yes
 pulp_use_system_wide_pkgs: false
 prereq_pip_packages:
   - Jinja2
-  - "psycopg2!=2.9,!=2.9.1"
 pulp_rhel_codeready_repo:
   - codeready-builder-for-rhel-8-x86_64-rpms
   - rhui-codeready-builder-for-rhel-8-rhui-rpms


### PR DESCRIPTION
This reverts commit 173fa9d220e5b67efebf20a80b324bdf5bcfdec2.

Upon further investigation, it was only ever needed for the master
branch, not for 3.11 or 3.13.