### PR TITLE
Problem: CI is failing because ruamel.yaml.clib no

### DIFF
--- a/CHANGES/8977.bugfix
+++ b/CHANGES/8977.bugfix
@@ -1,0 +1,1 @@
+Fix installation of molecule on python 2 by limiting the python 2 version of ruamel.yaml.clib to 0.2.2.

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ deps =
     # molecule dep that is incompatible with python 2 as of 1.13.0 & 1.13.1
     sh < 1.13 ; python_version < "3"
     ruamel.yaml < 0.17 ; python_version < "3"
+    ruamel.yaml.clib < 0.2.3 ; python_version < "3"
 setenv =
     release: TEST_1 = release
     source: TEST_1 = source


### PR DESCRIPTION
longer supports Python 2

Solution: limit the python 2 version of ruamel.yaml.clib to 0.2.2.