### PR TITLE
Minor fixes and improvements to Fernet key

### DIFF
--- a/roles/pulp_api/README.md
+++ b/roles/pulp_api/README.md
@@ -14,7 +14,7 @@ Role Variables
 * `pulp_token_auth_key`: Location of the openssl private key (in pem format) to use for token
   authentication. If not specified, a new key wil be generated. (Only generated if one doesn't
   exist.)
-* `pulp_db_fields_key`: Relative or absolute path to the Ferret symmetric encryption key
+* `pulp_db_fields_key`: Relative or absolute path to the Fernet symmetric encryption key
    one wants to import. It is used to encrypt certain fields in the database (such as credentials.)
    If not specified, a new key will be generated. (Only generated if one doesn't exist.)
 * `pulp_db_fields_key_remote`: Whether or not the `pulp_database_fields_key`

--- a/roles/pulp_api/tasks/generate_database_fields_key.yml
+++ b/roles/pulp_api/tasks/generate_database_fields_key.yml
@@ -28,7 +28,8 @@
   shell: >-
     set -o pipefail &&
     umask 0077 &&
-    openssl rand -base64 32 > {{ __pulp_db_fields_key_path }}
+    openssl rand -base64 32
+    | tr '+/' '-_' > {{ __pulp_db_fields_key_path }}
   args:
     # Debian defaults to bourne, but it doesn't understand pipefail.
     executable: /bin/bash

--- a/roles/pulp_api/tasks/generate_database_fields_key.yml
+++ b/roles/pulp_api/tasks/generate_database_fields_key.yml
@@ -41,7 +41,7 @@
 - name: Ensure correct permissions on new Pulp Database Encryption Key
   file:
     path: '{{ __pulp_db_fields_key_path }}'
-    owner: "{{ pulp_user }}"
+    owner: 'root'
     group: "{{ pulp_group }}"
-    mode: 0600
+    mode: 0640
   become: true

--- a/roles/pulp_api/tasks/main.yml
+++ b/roles/pulp_api/tasks/main.yml
@@ -66,9 +66,9 @@
   copy:
     src: "{{ pulp_db_fields_key }}"
     dest: "{{ __pulp_db_fields_key_path }}"
-    owner: "{{ pulp_user }}"
+    owner: 'root'
     group: "{{ pulp_group }}"
-    mode: 0600
+    mode: 0640
     remote_src: "{{ pulp_db_fields_key_remote }}"
   notify: Restart all Pulp services
   when: pulp_db_fields_key | length


### PR DESCRIPTION
This PR contains three commits of minor fixes and improvements to the database fields encryption key

1. Use url-safe base64 alphabet for pulp_db_fields_key
2. Fix typo in pulp_db_fields_key documentation
3. Use 0640 filemode for keyfile (pulp user does not require write permissions)

refs: #8704
Create a key for pulp to use when encrypting sensitive db fields
https://pulp.plan.io/issues/8704