### PR TITLE
Fix failure when checking for db key

### DIFF
--- a/CHANGES/9004.bugfix
+++ b/CHANGES/9004.bugfix
@@ -1,0 +1,1 @@
+Fix failure on task `pulp_api : Check for existing Pulp Database Encryption Key` when connecting to the ansible-managed system as a user account other than root.

--- a/roles/pulp_api/tasks/generate_database_fields_key.yml
+++ b/roles/pulp_api/tasks/generate_database_fields_key.yml
@@ -6,6 +6,7 @@
     get_checksum: false
     get_mime: false
   register: __pulp_db_fields_key_file
+  become: true
 
 # A theoretically better approach would be to use the jinja2 filter
 # `b64encode` and not have to install `openssl`.


### PR DESCRIPTION
when running the installer as non-root.

'pulp-api : Check for existing Pulp Database Encryption Key'

fixes: #9004