### PR TITLE
Install crun

### DIFF
--- a/roles/pulp_devel/vars/Fedora-34.yml
+++ b/roles/pulp_devel/vars/Fedora-34.yml
@@ -11,3 +11,4 @@ pulp_devel_distro_pkgs:
   - ripgrep
   - vim-enhanced
   - ruby-devel
+  - crun


### PR DESCRIPTION
Hiting error when generating bindings:
```
Error: container_linux.go:380: starting container process caused: error adding seccomp filter rule for syscall bdflush: permission denied: OCI permission denied
```
Installing crun fixed the problem

[noissue]