### PR TITLE
Update CentOS 8 / 8 Stream images

### DIFF
--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -14,9 +14,7 @@ centos7-fips:
   pty: true
 
 centos8:
-  box_name:   'centos/82'
-  # vagrantcloud still has 8.1. We've asked CentOS to register this URL with it.
-  box_url:    'https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-Vagrant-8.2.2004-20200611.2.x86_64.vagrant-libvirt.box'
+  box_name:   'centos/8'
   pty:        true
 
 centos8-fips:
@@ -24,6 +22,5 @@ centos8-fips:
   pty:        true
 
 centos8-stream:
-  box_name:   'centos/8-stream'
-  box_url:    'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20200113.0.x86_64.vagrant-libvirt.box'
+  box_name:   'centos/stream8'
   pty:        true

--- a/vagrant/boxes.d/20-sandbox.yaml
+++ b/vagrant/boxes.d/20-sandbox.yaml
@@ -34,8 +34,7 @@ pulp3-sandbox-centos7-fips:
     galaxy_role_file: "requirements.yml"
 
 pulp3-sandbox-centos8:
-  box_name: 'centos/82'
-  box_url: 'https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-Vagrant-8.2.2004-20200611.2.x86_64.vagrant-libvirt.box'
+  box_name: 'centos/8'
   memory: 4096
   ansible:
     playbook: "vagrant/playbooks/user-sandbox.yml"
@@ -49,8 +48,7 @@ pulp3-sandbox-centos8-fips:
     galaxy_role_file: "requirements.yml"
 
 pulp3-sandbox-centos8-stream:
-  box_name: 'centos/8-stream'
-  box_url: 'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20200113.0.x86_64.vagrant-libvirt.box'
+  box_name: 'centos/stream8'
   memory: 4096
   ansible:
     playbook: "vagrant/playbooks/user-sandbox.yml"

--- a/vagrant/boxes.d/30-source.yaml
+++ b/vagrant/boxes.d/30-source.yaml
@@ -160,8 +160,7 @@ pulp3-source-centos7-fips:
     galaxy_role_file: "requirements.yml"
 
 pulp3-source-centos8:
-  box_name: 'centos/82'
-  box_url: 'https://cloud.centos.org/centos/8/x86_64/images/CentOS-8-Vagrant-8.2.2004-20200611.2.x86_64.vagrant-libvirt.box'
+  box_name: 'centos/8'
   sshfs:
     host_path: '..'
     guest_path: '/home/vagrant/devel'
@@ -185,8 +184,7 @@ pulp3-source-centos8-fips:
     galaxy_role_file: "requirements.yml"
 
 pulp3-source-centos8-stream:
-  box_name: 'centos/8-stream'
-  box_url: 'https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-Vagrant-8-20200113.0.x86_64.vagrant-libvirt.box'
+  box_name: 'centos/stream8'
   sshfs:
     host_path: '..'
     guest_path: '/home/vagrant/devel'


### PR DESCRIPTION
to newer versions, registered with vagrantcloud.

Because they're registered with vagrantcloud, avoids need for
workaround on VirtualBox (Macs).

[noissue]