### PR TITLE
Problem: pulp_installer preflight check fails on

### DIFF
--- a/CHANGES/9093.bugfix
+++ b/CHANGES/9093.bugfix
@@ -1,0 +1,1 @@
+Fixed the pre-flight check accidentally producing an error (and accidentally enforcing) on EL7 when not installing pulp-rpm. This bug was introduced in 3.11.0.

--- a/roles/pulp_common/tasks/preflight_function.yml
+++ b/roles/pulp_common/tasks/preflight_function.yml
@@ -43,6 +43,8 @@
   environment:
     LC_ALL: en_US.UTF-8
     LANG: en_US.UTF-8
+    SETUPTOOLS_USE_DISTUTILS: stdlib
+    PATH: "{{ pulp_path }}"
   failed_when: '{{ failed_condition | default("compatibility.rc != 0") }}'
   changed_when: false
   become: true


### PR DESCRIPTION
EL7 when not installing pulp-rpm.

Solution: Add logic for the preflight to use the SCLs in its
PATH.

fixes: #9093