### PR TITLE
Cherry-pick: Add facts check for ipv6 for nginx server redirect

### DIFF
--- a/CHANGES/9089.bugfix
+++ b/CHANGES/9089.bugfix
@@ -1,0 +1,1 @@
+Add ipv6 check for roles/pulp_webserver/templates/nginx.conf.j2 redirect rule using ansible facts

--- a/roles/pulp_webserver/templates/nginx.conf.j2
+++ b/roles/pulp_webserver/templates/nginx.conf.j2
@@ -125,7 +125,9 @@ http {
 {% if not pulp_webserver_disable_https | bool %}
     server {
         listen {{ pulp_webserver_http_port }} default_server;
+        {% if ansible_facts['all_ipv6_addresses'] is defined and ansible_facts['all_ipv6_addresses'] | length > 0 -%}
         listen [::]:{{ pulp_webserver_http_port }} default_server;
+        {%- endif %}
         server_name _;
         return 301 https://$host$request_uri;
     }


### PR DESCRIPTION
closes #9089

(cherry picked from commit 5e5f0efc42fea235ceff79e2c4321cfe7c5b4f00)