### PR TITLE
Allow configuring galaxy UI source.

### DIFF
--- a/roles/pulp_devel/tasks/galaxy_ui.yml
+++ b/roles/pulp_devel/tasks/galaxy_ui.yml
@@ -65,6 +65,6 @@
 
 - name: Download galaxy ui from github
   shell:
-    cmd: python setup.py prepare_static
+    cmd: python setup.py prepare_static --force-download-ui
     chdir: '{{ pulp_install_plugins["galaxy-ng"]["source_dir"] }}'
-  when: __galaxy_ui_source is defined and __galaxy_ui_source == "precompiled"
+  when: __galaxy_ui_source is not defined or __galaxy_ui_source == "precompiled"

--- a/roles/pulp_devel/tasks/galaxy_ui.yml
+++ b/roles/pulp_devel/tasks/galaxy_ui.yml
@@ -48,10 +48,12 @@
           when:
             - is_hub_installed.stat.exists or ansible_hub_ui_git is defined
             - is_hub_installed.stat.exists or ansible_hub_ui_git.changed
+
         - name: Creates galaxy_ng static dir
           file:
             path: '{{ pulp_install_plugins["galaxy-ng"]["source_dir"] }}/galaxy_ng/app/static/galaxy_ng'
             state: directory
+        
         - name: Copying Ansible Hub UI to galaxy_ng static dir
           copy:
             src: '{{ hub_ui_path }}/dist/'
@@ -64,7 +66,7 @@
   when: __galaxy_ui_source is defined and __galaxy_ui_source == "source"
 
 - name: Download galaxy ui from github
-  shell:
+  command:
     cmd: python setup.py prepare_static --force-download-ui
     chdir: '{{ pulp_install_plugins["galaxy-ng"]["source_dir"] }}'
   when: __galaxy_ui_source is not defined or __galaxy_ui_source == "precompiled"

--- a/roles/pulp_devel/tasks/galaxy_ui.yml
+++ b/roles/pulp_devel/tasks/galaxy_ui.yml
@@ -1,69 +1,70 @@
 ---
-- name: Install NPM (distro-agnostic)
-  package:
-    name: npm
-    state: present
-  retries: "{{ pulp_devel_package_retries }}"
-  register: result
-  until: result is succeeded
+- name: Install galaxy UI from source
+  block:
+    - name: Install NPM (distro-agnostic)
+      package:
+        name: npm
+        state: present
+      retries: "{{ pulp_devel_package_retries }}"
+      register: result
+      until: result is succeeded
 
-- name: Check if UI is installed
-  stat:
-    path: '{{ developer_user_home }}/devel/ansible-hub-ui'
-  register: is_hub_installed
+    - name: Check if UI is installed
+      stat:
+        path: '{{ developer_user_home }}/devel/ansible-hub-ui'
+      register: is_hub_installed
 
-- name: UI from devel path
-  set_fact:
-    hub_ui_path: '{{ is_hub_installed.stat.path }}'
-  when: is_hub_installed.stat.exists
+    - name: UI from devel path
+      set_fact:
+        hub_ui_path: '{{ is_hub_installed.stat.path }}'
+      when: is_hub_installed.stat.exists
 
-- name: UI from git
-  set_fact:
-    hub_ui_path: '{{ pulp_user_home }}/ansible-hub-ui'
-  when: not is_hub_installed.stat.exists
-
-- block:
-
-    - name: Cloning Ansible Hub UI
-      git:
-        repo: 'https://github.com/ansible/ansible-hub-ui.git'
-        dest: '{{ hub_ui_path }}'
-        force: yes
-        version: master
-        update: yes
-      register: ansible_hub_ui_git
+    - name: UI from git
+      set_fact:
+        hub_ui_path: '{{ pulp_user_home }}/ansible-hub-ui'
       when: not is_hub_installed.stat.exists
-      tags:
-        - molecule-idempotence-notest
 
-    - name: Install packages based on package.json
-      npm:
-        path: '{{ hub_ui_path }}'
+    - block:
+        - name: Cloning Ansible Hub UI
+          git:
+            repo: 'https://github.com/ansible/ansible-hub-ui.git'
+            dest: '{{ hub_ui_path }}'
+            force: yes
+            version: master
+            update: yes
+          register: ansible_hub_ui_git
+          when: not is_hub_installed.stat.exists
+          tags:
+            - molecule-idempotence-notest
 
-    - name: Building Ansible Hub UI
-      command: npm run build-standalone
-      args:
-        chdir: '{{ hub_ui_path }}'
-      when:
-        - is_hub_installed.stat.exists or ansible_hub_ui_git is defined
-        - is_hub_installed.stat.exists or ansible_hub_ui_git.changed
+        - name: Install packages based on package.json
+          npm:
+            path: '{{ hub_ui_path }}'
 
-  become: yes
-  become_user: '{{ pulp_user }}'
+        - name: Building Ansible Hub UI
+          command: npm run build-standalone
+          args:
+            chdir: '{{ hub_ui_path }}'
+          when:
+            - is_hub_installed.stat.exists or ansible_hub_ui_git is defined
+            - is_hub_installed.stat.exists or ansible_hub_ui_git.changed
+        - name: Creates galaxy_ng static dir
+          file:
+            path: '{{ pulp_install_plugins["galaxy-ng"]["source_dir"] }}/galaxy_ng/app/static/galaxy_ng'
+            state: directory
+        - name: Copying Ansible Hub UI to galaxy_ng static dir
+          copy:
+            src: '{{ hub_ui_path }}/dist/'
+            dest: '{{ pulp_install_plugins["galaxy-ng"]["source_dir"] }}/galaxy_ng/app/static/galaxy_ng'
+            remote_src: yes
+      become: yes
+      become_user: '{{ pulp_user }}'
 
-- name: Creates static dir
-  file:
-    path: '{{ pulp_user_home }}/assets'
-    owner: '{{ pulp_user }}'
-    group: '{{ pulp_group }}'
-    state: directory
-    mode: '0775'
 
-- name: Copying Ansible Hub UI to static dir
-  copy:
-    src: '{{ hub_ui_path }}/dist/'
-    dest: '{{ pulp_user_home }}/assets/galaxy_ng'
-    remote_src: yes
-    owner: '{{ pulp_user }}'
-    group: '{{ pulp_group }}'
-    mode: '0775'
+  when: __galaxy_ui_source is defined and __galaxy_ui_source == "source"
+
+- name: Download galaxy ui from github
+  shell:
+    cmd: python setup.py prepare_static
+    chdir: '{{ pulp_install_plugins["galaxy-ng"]["source_dir"] }}'
+  when: __galaxy_ui_source is defined and __galaxy_ui_source == "precompiled"

--- a/roles/pulp_devel/tasks/galaxy_ui.yml
+++ b/roles/pulp_devel/tasks/galaxy_ui.yml
@@ -53,7 +53,7 @@
           file:
             path: '{{ pulp_install_plugins["galaxy-ng"]["source_dir"] }}/galaxy_ng/app/static/galaxy_ng'
             state: directory
-        
+
         - name: Copying Ansible Hub UI to galaxy_ng static dir
           copy:
             src: '{{ hub_ui_path }}/dist/'


### PR DESCRIPTION
This adds a `__galaxy_ui_source` option to `local.dev-config.yml` that allows a user to specify if the UI should be compiled from source or downloaded from github: https://github.com/ansible/ansible-hub-ui/releases/tag/dev.

__galaxy_ui_source accepts:
- none: the ui isn't provided at all
- precompiled: the ui is downloaded from github
- source: the ui repo is cloned and the ui is compiled from it

By default the UI will download from github if nothing is specified.

Note, this is waiting on https://github.com/ansible/galaxy_ng/pull/858 to be merged, which adds the option to force download the UI from github if the UI is already present.