### PR TITLE
Fix pulp_installer failing to symlink snippets

### DIFF
--- a/CHANGES/9139.bugfix
+++ b/CHANGES/9139.bugfix
@@ -1,0 +1,1 @@
+Fix occasional failures on the tasks `pulp-webserver: Symlink Apache snippets` & `pulp-webserver: Symlink nginx snippets`.

--- a/roles/pulp_webserver/tasks/apache.yml
+++ b/roles/pulp_webserver/tasks/apache.yml
@@ -50,9 +50,12 @@
     # FIXME: The ansible output here over the results is very ugly.
     # It may be a lot cleaner if we were to use the command module,
     # above and/or create a temporary data structure.
+    #
+    # We use "first" because sometimes the stdout has a 2nd line with "\u001b[0m"
+    # which is a color ANSI color code.
     - name: Symlink Apache snippets
       file:
-        src: "{{ __pulp_webserver_snippet.stdout_lines | last }}"
+        src: "{{ __pulp_webserver_snippet.stdout_lines | first }}"
         dest: "{{ pulp_webserver_apache_snippets_dir }}/{{ __pulp_webserver_snippet.__pulp_webserver_plugin.key | regex_replace('-', '_') }}.conf"
         state: link
       loop: '{{ snippets.results }}'

--- a/roles/pulp_webserver/tasks/nginx.yml
+++ b/roles/pulp_webserver/tasks/nginx.yml
@@ -43,9 +43,12 @@
     # FIXME: The ansible output here over the results is very ugly.
     # It may be a lot cleaner if we were to use the command module,
     # above and/or create a temporary data structure.
+    #
+    # We use "first" because sometimes the stdout has a 2nd line with "\u001b[0m"
+    # which is a color ANSI color code.
     - name: Symlink nginx snippets
       file:
-        src: "{{ __pulp_webserver_snippet.stdout_lines | last }}"
+        src: "{{ __pulp_webserver_snippet.stdout_lines | first }}"
         dest: "/etc/nginx/pulp/{{ __pulp_webserver_snippet.__pulp_webserver_plugin.key | regex_replace('-', '_') }}.conf"
         state: link
       loop: '{{ snippets.results }}'


### PR DESCRIPTION
By operating on the 1st line of output from check_snippet.py,
rather than the last.

fixes: #9139