### PR TITLE
3.11: Problem: pulp fails to function when installed from RPMs on CentOS 8

### DIFF
--- a/CHANGES/9166.bugfix
+++ b/CHANGES/9166.bugfix
@@ -1,0 +1,4 @@
+Fix the "markuppy" `pkg_resources.DistributionNotFound` error on the task
+`pulp_common : Collect static content`.
+This occurs when installing from RPM packages on EL8 (ever since EPEL8 released
+python-tablib-3.0.0-1.el8 on approximately 2021-07-23).

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -48,6 +48,7 @@ pulp_pkg_undeclared_deps:
   - pulpcore-selinux
   - python3-djangorestframework
   - python3-djangorestframework-queryfields
+  - python3-markuppy  # Because of https://bugzilla.redhat.com/show_bug.cgi?id=1986965
 pulp_pkg_upgrade_all: false
 __pulp_pkg_repo_name: "pulpcore"
 __pulp_pkg_repo_gpgkey: "{{ pulp_pkg_repo.rstrip('/') }}/../../GPG-RPM-KEY-pulpcore"


### PR DESCRIPTION
Solution: Explicitly install the undeclared dependency python3-markuppy
from the pulpcore repo for the EPEL8 RPM python3-tablib.

See https://bugzilla.redhat.com/show_bug.cgi?id=1986965

fixes: #9166