### PR TITLE
Problem: pulp-installer CI doesn't properly test upgrading RPM packages

### DIFF
--- a/CHANGES/9180.dev
+++ b/CHANGES/9180.dev
@@ -1,0 +1,4 @@
+Add CI-only workaround for the following issue: pulp-installer doesn't not properly test
+upgrading RPM packages when `pulp_pkg_repo` (the repo URL) is set to a new value.
+The workaround is to delete the old repo file (`/etc/yum.repos.d/pulpcore.repo)
+during the molecule prepare phase.

--- a/molecule/release-static/prepare.yml
+++ b/molecule/release-static/prepare.yml
@@ -19,3 +19,9 @@
       when:
         - ansible_os_family == "RedHat"
         - ansible_distribution_major_version|int == 7
+
+    # The task to add the repo doesn't upgrade it, so we have to remove it.
+    - name: Remove old pulpcore package repo
+      file:
+        path: /etc/yum.repos.d/pulpcore.repo
+        state: absent


### PR DESCRIPTION
Solution: Remove the old repo file during molecule prepare phase.

fixes: #9180