### PR TITLE
pulp_devel: Vendor npm module used in pulp_devel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,7 @@ vendor:
 	mkdir -p plugins/modules
 	cp temp/ansible_collections/community/general/plugins/modules/files/ini_file.py plugins/modules
 	cp temp/ansible_collections/community/general/plugins/modules/packaging/language/pip_package_info.py plugins/modules
+	cp temp/ansible_collections/community/general/plugins/modules/packaging/language/npm.py plugins/modules
 	cp temp/ansible_collections/community/general/plugins/modules/system/locale_gen.py plugins/modules
 	cp temp/ansible_collections/community/general/plugins/modules/system/make.py plugins/modules
 	cp temp/ansible_collections/community/general/plugins/modules/system/seport.py plugins/modules


### PR DESCRIPTION
[noissue]