### PR TITLE
Add config needed for Galaxy api access log to galaxy_post_install role

### DIFF
--- a/CHANGES/9177.feature
+++ b/CHANGES/9177.feature
@@ -1,0 +1,1 @@
+Add configuration needed for Galaxy api access log

--- a/roles/galaxy_post_install/handlers/main.yml
+++ b/roles/galaxy_post_install/handlers/main.yml
@@ -1,2 +1,9 @@
 ---
 # handlers for galaxy post install
+- name: Restart pulpcore-api.service
+  systemd:
+    name: pulpcore-api.service
+    enabled: true
+    state: restarted
+    daemon_reload: true
+  become: true

--- a/roles/galaxy_post_install/tasks/main.yml
+++ b/roles/galaxy_post_install/tasks/main.yml
@@ -1,2 +1,3 @@
 ---
 - import_tasks: galaxy_importer.yml
+- import_tasks: setup_galaxy_api_access_log.yml

--- a/roles/galaxy_post_install/tasks/setup_galaxy_api_access_log.yml
+++ b/roles/galaxy_post_install/tasks/setup_galaxy_api_access_log.yml
@@ -1,0 +1,41 @@
+---
+- block:
+  - name: Create Galaxy api access log file
+    file:
+      path: '/var/log/galaxy_api_access.log'
+      state: touch
+      owner: '{{ pulp_user }}'
+      group: '{{ pulp_group }}'
+      mode: "u+rw"
+
+  - name: Verify /etc/default/pulpcore-api exists
+    stat:
+      path: /etc/default/pulpcore-api
+    register: stat_result
+
+  - name: Create /etc/default/pulpcore-api
+    file:
+      path: /etc/default/pulpcore-api
+      state: touch
+      owner: '{{ pulp_user }}'
+      group: '{{ pulp_group }}'
+      mode: "u+rw"
+    when: not stat_result.stat.exists
+
+  - name: Verify /etc/default/pulpcore-api exists
+    stat:
+      path: /etc/default/pulpcore-api
+    register: stat_result2
+
+  - name: Set environment variable for Galaxy api access logging
+    lineinfile:
+      path: /etc/default/pulpcore-api
+      line: GALAXY_ENABLE_API_ACCESS_LOG={{ pulp_settings['galaxy_enable_api_access_log'] | default(False) }}
+      insertafter: EOF
+      state: present
+    notify: Restart pulpcore-api.service
+    failed_when: not stat_result2.stat.exists
+    when:
+      - stat_result2.stat.exists
+
+  become: true

--- a/roles/pulp_api/templates/pulpcore-api.service.j2
+++ b/roles/pulp_api/templates/pulpcore-api.service.j2
@@ -4,6 +4,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
+EnvironmentFile=-/etc/default/pulpcore-api
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS={{ pulp_settings_file }}"
 Environment="PATH={{ pulp_install_dir }}/bin:{{ default_bin_path }}"


### PR DESCRIPTION
- Creates log file
- Creates `/etc/default/pulpcore-api` to add needed environment variable
- Added environment variable to file

fixes: #9177