### PR TITLE
Restart pulcore-api.service only when it exists

### DIFF
--- a/roles/galaxy_post_install/handlers/main.yml
+++ b/roles/galaxy_post_install/handlers/main.yml
@@ -1,9 +1,10 @@
 ---
 # handlers for galaxy post install
-- name: Restart pulpcore-api.service
+- name: Restart pulpcore-api.service post galaxy
   systemd:
     name: pulpcore-api.service
     enabled: true
     state: restarted
     daemon_reload: true
   become: true
+  when: ansible_facts.services['pulpcore-api.service'] is defined

--- a/roles/galaxy_post_install/tasks/setup_galaxy_api_access_log.yml
+++ b/roles/galaxy_post_install/tasks/setup_galaxy_api_access_log.yml
@@ -27,13 +27,16 @@
       path: /etc/default/pulpcore-api
     register: stat_result2
 
+  - name: Populate service facts
+    service_facts:
+
   - name: Set environment variable for Galaxy api access logging
     lineinfile:
       path: /etc/default/pulpcore-api
       line: GALAXY_ENABLE_API_ACCESS_LOG={{ pulp_settings['galaxy_enable_api_access_log'] | default(False) }}
       insertafter: EOF
       state: present
-    notify: Restart pulpcore-api.service
+    notify: Restart pulpcore-api.service post galaxy
     failed_when: not stat_result2.stat.exists
     when:
       - stat_result2.stat.exists


### PR DESCRIPTION
Restart the pulpcore-api.service only when it exists. The first time the installer runs the service doesn't exist, so the handler fails. On subsequent runs the service does exist and should be restarted when the environment file is modified.

fixes: #9177