### PR TITLE
Update debian image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Pulling images for PyPI upgrades
         if: matrix.test_type == 'release-upgrade' || matrix.test_type == 'source-upgrade'
         run: |
-          docker pull quay.io/pulp/pulp-ci-dbullseye:3.14.3
+          docker pull quay.io/pulp/pulp-ci-dbullseye:3.14.4
           docker pull quay.io/pulp/pulp_rpm-ci-f33:3.9.0
           docker pull quay.io/pulp/pulp_rpm-ci-c7:3.1.0
       - name: Pulling images for distro packages upgrades

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Pulling images for PyPI upgrades
         if: matrix.test_type == 'release-upgrade' || matrix.test_type == 'source-upgrade'
         run: |
-          docker pull quay.io/pulp/pulp-ci-dbullseye:3.14.3
+          docker pull quay.io/pulp/pulp-ci-dbullseye:3.14.4
           docker pull quay.io/pulp/pulp_rpm-ci-f33:3.9.0
           docker pull quay.io/pulp/pulp_rpm-ci-c7:3.1.0
       - name: Pulling images for distro packages upgrades

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Pulling images for PyPI upgrades
         if: matrix.test_type == 'release-upgrade' || matrix.test_type == 'source-upgrade'
         run: |
-          docker pull quay.io/pulp/pulp-ci-dbullseye:3.14.3
+          docker pull quay.io/pulp/pulp-ci-dbullseye:3.14.4
           docker pull quay.io/pulp/pulp_rpm-ci-f33:3.9.0
           docker pull quay.io/pulp/pulp_rpm-ci-c7:3.1.0
       - name: Pulling images for distro packages upgrades

--- a/molecule/release-upgrade/molecule.yml
+++ b/molecule/release-upgrade/molecule.yml
@@ -32,7 +32,7 @@ platforms:
     command: /sbin/init
   - <<: *platform_base
     name: debian-11
-    image: quay.io/pulp/pulp-ci-dbullseye:3.14.3
+    image: quay.io/pulp/pulp-ci-dbullseye:3.14.4
     command: /sbin/init
   - <<: *platform_base
     name: fedora-33

--- a/molecule/source-upgrade/molecule.yml
+++ b/molecule/source-upgrade/molecule.yml
@@ -28,7 +28,7 @@ platforms:
   - <<: *platform_base
     name: debian-11
     # molecule often fails to pull, so we pull all images in .travis.yml
-    image: quay.io/pulp/pulp-ci-dbullseye:3.14.3
+    image: quay.io/pulp/pulp-ci-dbullseye:3.14.4
     command: /sbin/init
   - <<: *platform_base
     name: fedora-33

--- a/roles/pulp_database/tasks/install_postgres.yml
+++ b/roles/pulp_database/tasks/install_postgres.yml
@@ -20,6 +20,8 @@
     name:
       - 'centos-release-scl-rh'
       - 'centos-release-scl'
+    state: present
+  become: yes
   when:
     - ansible_facts.distribution == "CentOS"
     - ansible_facts.distribution_major_version|int == 7


### PR DESCRIPTION
```
~ via 🐍 v3.9.1 (venv) 
❯ docker run -it quay.io/pulp/pulp-ci-dbullseye:3.14.3 bash
Unable to find image 'quay.io/pulp/pulp-ci-dbullseye:3.14.3' locally
3.14.3: Pulling from pulp/pulp-ci-dbullseye
7b303595d9b3: Pull complete 
edaaa1ca487d: Pull complete 
66b7de5b0987: Pull complete 
eda2a0e6a716: Pull complete 
Digest: sha256:d884c246c5625c684d07e591c942078e48498e0649cda37ef756acaab24a2f92
Status: Downloaded newer image for quay.io/pulp/pulp-ci-dbullseye:3.14.3
root@0742015581e3:/# apt update
Get:1 http://deb.debian.org/debian testing InRelease [94.4 kB]
E: Repository 'http://deb.debian.org/debian testing InRelease' changed its 'Codename' value from 'bullseye' to 'bookworm'
N: This must be accepted explicitly before updates for this repository can be applied. See apt-secure(8) manpage for details.
```