### PR TITLE
have systemd manage the gunicorn services as

### DIFF
--- a/CHANGES/9271.feature
+++ b/CHANGES/9271.feature
@@ -1,0 +1,1 @@
+Have systemd manage the pulpcore-api and pulpcore-content services as type=notify rather than type=simple. This means systemd will better understand whether the service is up and running before it lists it as "running".

--- a/roles/pulp_api/templates/pulpcore-api.service.j2
+++ b/roles/pulp_api/templates/pulpcore-api.service.j2
@@ -4,6 +4,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
+Type=notify
 EnvironmentFile=-/etc/default/pulpcore-api
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS={{ pulp_settings_file }}"

--- a/roles/pulp_content/templates/pulpcore-content.service.j2
+++ b/roles/pulp_content/templates/pulpcore-content.service.j2
@@ -4,6 +4,7 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
+Type=notify
 Environment="DJANGO_SETTINGS_MODULE=pulpcore.app.settings"
 Environment="PULP_SETTINGS={{ pulp_settings_file }}"
 Environment="PATH={{ pulp_install_dir }}/bin:{{ default_bin_path }}"


### PR DESCRIPTION
Type=notify

fixes: #9271
gunicorn processes should be managed by systemd as Type=notify
https://pulp.plan.io/issues/9271