### PR TITLE
Update yum packages for installations behind proxies

### DIFF
--- a/roles/pulp_common/vars/CentOS-7.yml
+++ b/roles/pulp_common/vars/CentOS-7.yml
@@ -17,4 +17,4 @@ pulp_preq_packages:
 
 pulp_python_interpreter: '/opt/rh/rh-python38/root/usr/bin/python3.8'
 pulp_python_cryptography:
-  - python-cryptography
+  - python2-cryptography


### PR DESCRIPTION
This is somewhat of a sample pull request as other areas are also affected. But various packages in this repo are referred to by their alias'. Normally this doesn't have much affect but in environments where you work with a golden image and behind a proxy Ansible even with `state: latest` will go and check for the packages existence. won't find it with this name and then goes to install it via the internet (which then fails).

This also affected the python36 installs upto now. But with the move to python 3.8 I assume this should be fixed.

The only other option I can come up with is to add a tag on package installs that would allow these to be skipped in such environments.