### PR TITLE
Bump pulpcore-selinux to 1.2.5

### DIFF
--- a/CHANGES/9272.bugfix
+++ b/CHANGES/9272.bugfix
@@ -1,0 +1,1 @@
+Update pulpcore-selinux policies to 1.2.5. Adds support for Type=notify systemd Services (#9271). Hides a harmless SELinux denial from the audit logs when accessing /etc/httpd/mime.types on some systems like EL7 without `mailcap` installed.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -63,7 +63,7 @@ __pulp_selinux_policy_pkgs:
   - pulpcore
   - pulpcore_rhsmcertd
 __pulp_selinux_repo: 'https://github.com/pulp/pulpcore-selinux.git'
-__pulp_selinux_version: '1.2.4'
+__pulp_selinux_version: '1.2.5'
 __pulp_selinux_label_dirs:
   - "{{ pulp_install_dir }}"
   - "{{ pulp_config_dir }}"


### PR DESCRIPTION
Adds support for systemd Type=notify

fixes: #9272
pulpcore-selinux needs SELinux changes for systemd Type=notify
https://pulp.plan.io/issues/9272

related to #9271
gunicorn processes should be managed by systemd as Type=notify
https://pulp.plan.io/issues/9271