### PR TITLE
Run pulp_installer collection on pulplift

### DIFF
--- a/CHANGES/9371.dev
+++ b/CHANGES/9371.dev
@@ -1,0 +1,1 @@
+Run pulp_installer collection on pulplift

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,4 @@
 [defaults]
-roles_path = ~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:roles
 allow_world_readable_tmpfiles = True
 
 [ssh_connection]

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -75,6 +75,7 @@ build_ignore:
   - .travis.yml
   - .travis
   - .vagrant
+  - molecule
   - CHANGES
   - pulp_installer
   - .gitignore

--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -274,7 +274,7 @@
         django_location=$({{ pulp_install_dir }}/bin/pip3 show Django | grep Location | cut -d' ' -f2)
         sed -i 's/hashlib.md5()/hashlib.md5(usedforsecurity=False)/' "$django_location/django/db/backends/utils.py"
       when:
-        - "'pulp_devel' in role_names"
+        - "'pulp_devel' in role_names or 'pulp.pulp_installer.pulp_devel' in role_names"
         - ansible_facts.distribution in ['RedHat', 'CentOS'] or ansible_facts.python_version is version('3.9', '>=')
       check_mode: false
       changed_when: false

--- a/roles/pulp_common/tasks/main.yml
+++ b/roles/pulp_common/tasks/main.yml
@@ -38,7 +38,7 @@
 - name: Check required roles if FIPS detected
   assert:
     that:
-      - ('pulp_devel' in role_names) or (pulp_install_source == 'packages')
+      - ('pulp.pulp_installer.pulp_devel' in role_names) or ('pulp_devel' in role_names) or (pulp_install_source == 'packages')
     fail_msg: >
       Pulp cannot run in a FIPS environment because Django (a dependency) is not FIPS
       compatible

--- a/vagrant/playbooks/source-install.yml
+++ b/vagrant/playbooks/source-install.yml
@@ -12,11 +12,34 @@
 
     # The version string below is the highest of all those in roles' metadata:
     # "min_ansible_version". It needs to be kept manually up-to-date.
+    # FIPS boxes require 2.10
     - name: Verify Ansible meets min required version
       assert:
-        that: "ansible_version.full is version_compare('2.8', '>=')"
+        that: "ansible_version.full is version_compare('2.10', '>=')"
         msg: >
-          "You must update Ansible to at least 2.8 to use this version of Pulp 3 Installer."
+          "You must update Ansible to at least 2.10 to use this version of Pulp 3 Installer."
+
+    - name: Building pulp.pulp_installer
+      command:
+        cmd: ansible-galaxy collection build --force .
+        chdir: ../..
+      delegate_to: localhost
+
+    - name: Installing pulp.pulp_installer
+      command:
+        cmd: "ansible-galaxy collection install --force {{ item }}"
+        chdir: ../..
+      with_fileglob:
+        - "../../pulp-pulp_installer-*.tar.gz"
+      delegate_to: localhost
+
+    - name: Clean built collection
+      file:
+        state: absent
+        path: "{{ item }}"
+      with_fileglob:
+        - "../../pulp-pulp_installer-*.tar.gz"
+      delegate_to: localhost
 
     - name: Check (S3) storage backend is configured.
       assert:
@@ -49,6 +72,8 @@
       vars:
         source_workarounds: true
     - include_tasks: pre_tasks/selinux-workarounds.yml
+  collections:
+    - pulp.pulp_installer
   roles:
     - pulp_all_services
     - pulp_devel

--- a/vagrant/playbooks/user-sandbox.yml
+++ b/vagrant/playbooks/user-sandbox.yml
@@ -12,11 +12,34 @@
 
     # The version string below is the highest of all those in roles' metadata:
     # "min_ansible_version". It needs to be kept manually up-to-date.
+    # FIPS boxes require 2.10
     - name: Verify Ansible meets min required version
       assert:
-        that: "ansible_version.full is version_compare('2.8', '>=')"
+        that: "ansible_version.full is version_compare('2.10', '>=')"
         msg: >
-          "You must update Ansible to at least 2.8 to use this version of Pulp 3 Installer."
+          "You must update Ansible to at least 2.10 to use this version of Pulp 3 Installer."
+
+    - name: Building pulp.pulp_installer
+      command:
+        cmd: ansible-galaxy collection build --force .
+        chdir: ../..
+      delegate_to: localhost
+
+    - name: Installing pulp.pulp_installer
+      command:
+        cmd: "ansible-galaxy collection install --force {{ item }}"
+        chdir: ../..
+      with_fileglob:
+        - "../../pulp-pulp_installer-*.tar.gz"
+      delegate_to: localhost
+
+    - name: Clean built collection
+      file:
+        state: absent
+        path: "{{ item }}"
+      with_fileglob:
+        - "../../pulp-pulp_installer-*.tar.gz"
+      delegate_to: localhost
 
     - name: Check (S3) storage backend is configured.
       assert:
@@ -48,6 +71,8 @@
     - include_tasks: pre_tasks/vagrant-workarounds.yml
     - include_tasks: pre_tasks/selinux-workarounds.yml
 
+  collections:
+    - pulp.pulp_installer
   roles:
     - pulp_all_services
   environment:


### PR DESCRIPTION
The idea of this PR is to get devel env closer to the user experience, therefore installing pulp.pulp_installer collection on pulplift