### PR TITLE
Fix pulplift on fresh installs

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,5 @@
 [defaults]
+roles_path = ~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:roles
 allow_world_readable_tmpfiles = True
 
 [ssh_connection]

--- a/roles/pulp_all_services/meta/main.yml
+++ b/roles/pulp_all_services/meta/main.yml
@@ -28,3 +28,9 @@ dependencies:
   - pulp_services
   - pulp_health_check
   - pulp_webserver
+# When dynamically including roles,  it only installs the collection dependencies
+# for the role that you explicitly specify.
+collections:
+  - ansible.posix  # dependency for pulp_webserver
+  - community.crypto  # dependency for pulp_webserver
+  - community.postgresql   # dependency for pulp_database

--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -274,7 +274,7 @@
         django_location=$({{ pulp_install_dir }}/bin/pip3 show Django | grep Location | cut -d' ' -f2)
         sed -i 's/hashlib.md5()/hashlib.md5(usedforsecurity=False)/' "$django_location/django/db/backends/utils.py"
       when:
-        - "'pulp_devel' in role_names or 'pulp.pulp_installer.pulp_devel' in role_names"
+        - developer_user is defined or developer_user_home is defined
         - ansible_facts.distribution in ['RedHat', 'CentOS'] or ansible_facts.python_version is version('3.9', '>=')
       check_mode: false
       changed_when: false

--- a/roles/pulp_common/tasks/main.yml
+++ b/roles/pulp_common/tasks/main.yml
@@ -38,7 +38,7 @@
 - name: Check required roles if FIPS detected
   assert:
     that:
-      - ('pulp.pulp_installer.pulp_devel' in role_names) or ('pulp_devel' in role_names) or (pulp_install_source == 'packages')
+      - (developer_user is defined or developer_user_home is defined) or (pulp_install_source == 'packages')
     fail_msg: >
       Pulp cannot run in a FIPS environment because Django (a dependency) is not FIPS
       compatible

--- a/vagrant/playbooks/source-install.yml
+++ b/vagrant/playbooks/source-install.yml
@@ -54,7 +54,7 @@
           - pulp_settings.aws_s3_region_name is defined
           - pulp_settings.media_root is defined
           - pulp_settings.default_file_storage is defined
-      when: pulp_install_object_storage == "s3"
+      when: pulp_install_object_storage is defined and pulp_install_object_storage == "s3"
 
     - name: Check (Azure) storage backend is configured.
       assert:
@@ -66,16 +66,20 @@
           - pulp_settings.azure_overwrite_files is defined
           - pulp_settings.azure_location is defined
           - pulp_settings.default_file_storage is defined
-      when: pulp_install_object_storage == "azure"
+      when: pulp_install_object_storage is defined and pulp_install_object_storage == "azure"
 
     - include_tasks: pre_tasks/vagrant-workarounds.yml
       vars:
         source_workarounds: true
     - include_tasks: pre_tasks/selinux-workarounds.yml
-  collections:
-    - pulp.pulp_installer
-  roles:
-    - pulp_all_services
-    - pulp_devel
+
+    - name: Dynamically include pulp.pulp_installer roles
+      include_role:
+        name: "pulp.pulp_installer.{{ roleinputvar }}"
+      loop:
+        - pulp_all_services
+        - pulp_devel
+      loop_control:
+        loop_var: roleinputvar
   environment:
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings

--- a/vagrant/playbooks/user-sandbox.yml
+++ b/vagrant/playbooks/user-sandbox.yml
@@ -54,7 +54,7 @@
           - pulp_settings.aws_s3_region_name is defined
           - pulp_settings.media_root is defined
           - pulp_settings.default_file_storage is defined
-      when: pulp_install_object_storage == "s3"
+      when: pulp_install_object_storage is defined and pulp_install_object_storage == "s3"
 
     - name: Check (Azure) storage backend is configured.
       assert:
@@ -66,14 +66,13 @@
           - pulp_settings.azure_overwrite_files is defined
           - pulp_settings.azure_location is defined
           - pulp_settings.default_file_storage is defined
-      when: pulp_install_object_storage == "azure"
+      when: pulp_install_object_storage is defined and pulp_install_object_storage == "azure"
 
     - include_tasks: pre_tasks/vagrant-workarounds.yml
     - include_tasks: pre_tasks/selinux-workarounds.yml
 
-  collections:
-    - pulp.pulp_installer
-  roles:
-    - pulp_all_services
+    - name: Dynamically include pulp.pulp_installer roles
+      include_role:
+        name: pulp.pulp_installer.pulp_all_services
   environment:
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings


### PR DESCRIPTION
After deleting all collections from `$HOME/.ansible` I got errors when trying to provision, as `pulp.pulp_installer` wasn't there.
Now it dynamically includes the `pulp.pulp_installer` roles for avoiding these errors