### PR TITLE
3.14 fixes

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -17,5 +17,6 @@ exclude_paths:
   - ./.cache/ansible-lint/
   - ../../.cache/ansible-lint/
   - ../../../.cache/ansible-lint/
+  - ../../../.cache/ansible-compat/
   - ./example.dev-config.yml
   - ./docs/

--- a/.yamllint
+++ b/.yamllint
@@ -29,3 +29,5 @@ ignore: |
   roles/ansible-role-postgresql
   vagrant
   docs
+  build/collections/ansible_collections/ansible
+  build/collections/ansible_collections/community

--- a/CHANGES/9468.feature
+++ b/CHANGES/9468.feature
@@ -1,0 +1,2 @@
+Add SELinux support for the pulp-2to3-migration plugin by updating pulpcore-selinux (SELinux
+policies) to 1.2.6


### PR DESCRIPTION
The pulpcore-selinux update is already on the 3.14 branch as part of the 3.14.7 release commit.

We'll at least put it in the changelog for the upcoming 3.14.7+1 though.