### PR TITLE
Fix `pulp_common : Collect static content` sporadically failing

### DIFF
--- a/CHANGES/790.bugfix
+++ b/CHANGES/790.bugfix
@@ -1,0 +1,1 @@
+Fix `pulp_common : Collect static content` sporadically failing when using a shared filesystem (.e.g, NFS) for `/var/lib/pulp` by running it sequentially across multiple Pulp nodes.

--- a/roles/pulp_common/handlers/main.yml
+++ b/roles/pulp_common/handlers/main.yml
@@ -33,6 +33,9 @@
 
 - name: Collect static content
   command: "{{ pulp_django_admin_path }} collectstatic --clear --noinput --link {{ pulp_collectstatic_ignore_list }}"
+  # When run against the same FS, we do not want the multiple nodes'
+  # commands to conflict with eachother. It sometimes happens.
+  throttle: 1
   register: staticresult
   changed_when: "staticresult.stdout is not search('\n0 static files')"
   become: true


### PR DESCRIPTION
when using a shared filesystem (.e.g, NFS) for `/var/lib/pulp` by running
it sequentially across multiple Pulp nodes.

fixes: #790