### PR TITLE
3.15: Fix `pulp_common : Collect static content` sporadically failing

### DIFF
--- a/CHANGES/790.bugfix
+++ b/CHANGES/790.bugfix
@@ -1,0 +1,1 @@
+Fix `pulp_common : Collect static content` sporadically failing when using a shared filesystem (.e.g, NFS) for `/var/lib/pulp` by running it sequentially across multiple Pulp nodes.

--- a/molecule/release-dynamic/group_vars/all
+++ b/molecule/release-dynamic/group_vars/all
@@ -7,12 +7,14 @@ pulp_install_plugins:
   # pulp-container: {}
   # pulp-cookbook: {}
   # pulp-deb: {}
-  pulp-file: {}
+  pulp-file:
+    version: 1.9.1
   # pulp-gem: {}
   # pulp-maven: {}
   # pulp-npm: {}
   # pulp-python: {}
-  pulp-rpm: {}
+  pulp-rpm:
+    version: 3.16.1
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"

--- a/molecule/release-static/group_vars/all
+++ b/molecule/release-static/group_vars/all
@@ -9,12 +9,14 @@ pulp_install_plugins:
   # pulp-container: {}
   # pulp-cookbook: {}
   # pulp-deb: {}
-  pulp-file: {}
+  pulp-file:
+    version: 1.9.1
   # pulp-gem: {}
   # pulp-maven: {}
   # pulp-npm: {}
   # pulp-python: {}
-  pulp-rpm: {}
+  pulp-rpm:
+    version: 3.16.1
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"

--- a/molecule/release-static/host_vars/debian-11
+++ b/molecule/release-static/host_vars/debian-11
@@ -6,7 +6,8 @@ pulp_install_plugins:
   # pulp-container: {}
   # pulp-cookbook: {}
   # pulp-deb: {}
-  pulp-file: {}
+  pulp-file:
+    version: 1.9.1
   # pulp-gem: {}
   # pulp-maven: {}
   # pulp-npm: {}

--- a/molecule/release-upgrade/group_vars/all
+++ b/molecule/release-upgrade/group_vars/all
@@ -4,9 +4,9 @@ pulp_default_admin_password: password
 pulp_upgrade: true
 pulp_install_plugins:
   pulp-file:
-    upgrade: true
+    upgrade: 1.9.1
   pulp-rpm:
-    upgrade: true
+    version: 3.16.1
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"

--- a/molecule/release-upgrade/host_vars/debian-11
+++ b/molecule/release-upgrade/host_vars/debian-11
@@ -1,6 +1,6 @@
 ansible_python_interpreter: /usr/bin/python3
 pulp_install_plugins:
   pulp-file:
-    upgrade: true
+    version: 1.9.1
   # pulp-rpm:
   #   upgrade: true

--- a/molecule/source-dynamic/group_vars/all
+++ b/molecule/source-dynamic/group_vars/all
@@ -2,7 +2,7 @@
 pulp_default_admin_password: password
 pulp_source_dir: '/var/lib/pulp/devel/pulpcore'
 pulp_git_url: "https://github.com/pulp/pulpcore"
-pulp_git_revision: "master"
+pulp_git_revision: "3.15"
 pulp_install_plugins:
   # galaxy-ng:
   #   source_dir: "/var/lib/pulp/devel/galaxy_ng"
@@ -18,7 +18,7 @@ pulp_install_plugins:
   #   source_dir: "/var/lib/pulp/devel/pulp_deb"
   pulp-file:
     git_url: "https://github.com/pulp/pulp_file"
-    git_revision: "main"
+    git_revision: "1.9"
     source_dir: "/var/lib/pulp/devel/pulp_file"
   # pulp-gem:
   #   source_dir: "/var/lib/pulp/devel/pulp_gem"
@@ -30,7 +30,7 @@ pulp_install_plugins:
   #   source_dir: "/var/lib/pulp/devel/pulp_python"
   pulp-rpm:
     git_url: "https://github.com/pulp/pulp_rpm"
-    git_revision: "master"
+    git_revision: "3.16"
     source_dir: "/var/lib/pulp/devel/pulp_rpm"
 developer_user_home: /var/lib/pulp
 developer_user: pulp

--- a/molecule/source-static/group_vars/all
+++ b/molecule/source-static/group_vars/all
@@ -2,7 +2,7 @@
 pulp_default_admin_password: password
 pulp_source_dir: '/var/lib/pulp/devel/pulpcore'
 pulp_git_url: "https://github.com/pulp/pulpcore"
-pulp_git_revision: "master"
+pulp_git_revision: "3.15"
 pulp_api_bind: "unix:/var/run/pulpcore-api/pulpcore-api.sock"
 pulp_content_bind: "unix:/var/run/pulpcore-content/pulpcore-content.sock"
 pulp_install_plugins:
@@ -20,7 +20,7 @@ pulp_install_plugins:
   #   source_dir: "/var/lib/pulp/devel/pulp_deb"
   pulp-file:
     git_url: "https://github.com/pulp/pulp_file"
-    git_revision: "main"
+    git_revision: "1.9"
     source_dir: "/var/lib/pulp/devel/pulp_file"
   # pulp-gem:
   #   source_dir: "/var/lib/pulp/devel/pulp_gem"
@@ -32,7 +32,7 @@ pulp_install_plugins:
   #   source_dir: "/var/lib/pulp/devel/pulp_python"
   pulp-rpm:
     git_url: "https://github.com/pulp/pulp_rpm"
-    git_revision: "master"
+    git_revision: "3.16"
     source_dir: "/var/lib/pulp/devel/pulp_rpm"
 developer_user_home: /var/lib/pulp
 developer_user: pulp

--- a/molecule/source-static/host_vars/debian-11
+++ b/molecule/source-static/host_vars/debian-11
@@ -14,6 +14,7 @@ pulp_install_plugins:
   #   source_dir: "/var/lib/pulp/devel/pulp_deb"
   pulp-file:
     git_url: "https://github.com/pulp/pulp_file"
+    git_revision: "1.9"
     source_dir: "/var/lib/pulp/devel/pulp_file"
   # pulp-gem:
   #   source_dir: "/var/lib/pulp/devel/pulp_gem"

--- a/molecule/source-upgrade/group_vars/all
+++ b/molecule/source-upgrade/group_vars/all
@@ -3,7 +3,7 @@ __pulp_database_config_run_once: false
 pulp_default_admin_password: password
 pulp_source_dir: '/var/lib/pulp/devel/pulpcore'
 pulp_git_url: "https://github.com/pulp/pulpcore"
-pulp_git_revision: "master"
+pulp_git_revision: "3.15"
 pulp_upgrade: true
 # Needed to determine whether or not pulpcore was actually upgraded, to
 # trigger the handler.
@@ -11,12 +11,12 @@ pulp_pip_editable: false
 pulp_install_plugins:
   pulp-file:
     git_url: "https://github.com/pulp/pulp_file"
-    git_revision: "main"
+    git_revision: "1.9"
     upgrade: true
     source_dir: "/var/lib/pulp/devel/pulp_file"
   pulp-rpm:
     git_url: "https://github.com/pulp/pulp_rpm"
-    git_revision: "master"
+    git_revision: "3.16"
     upgrade: true
     source_dir: "/var/lib/pulp/devel/pulp_rpm"
 developer_user_home: /var/lib/pulp

--- a/molecule/source-upgrade/host_vars/debian-11
+++ b/molecule/source-upgrade/host_vars/debian-11
@@ -3,6 +3,7 @@ pulp_install_plugins:
   pulp-file:
     upgrade: true
     git_url: "https://github.com/pulp/pulp_file"
+    git_revision: "1.9"
     source_dir: "/var/lib/pulp/devel/pulp_file"
   # pulp-rpm:
   #   upgrade: true

--- a/roles/pulp_common/handlers/main.yml
+++ b/roles/pulp_common/handlers/main.yml
@@ -33,6 +33,9 @@
 
 - name: Collect static content
   command: "{{ pulp_django_admin_path }} collectstatic --clear --noinput --link {{ pulp_collectstatic_ignore_list }}"
+  # When run against the same FS, we do not want the multiple nodes'
+  # commands to conflict with eachother. It sometimes happens.
+  throttle: 1
   register: staticresult
   changed_when: "staticresult.stdout is not search('\n0 static files')"
   become: true


### PR DESCRIPTION
when using a shared filesystem (.e.g, NFS) for `/var/lib/pulp` by running
it sequentially across multiple Pulp nodes.

fixes: #790

Also included in the PR: Specifying plugin version variables for pulpcore 3.15 / pulp-file 1.9 / pulp-rpm 3.16