### PR TITLE
Multiple changes for installing pulp 3.15 from RPM packages.

### DIFF
--- a/CHANGES/795.bugfix
+++ b/CHANGES/795.bugfix
@@ -1,0 +1,1 @@
+Update packages mode support for Pulp 3.15 by changing the default package name prefix (`pulp_pkg_name_prefix`) from `python3-` to `tfm-pulpcore-python3-`.

--- a/CHANGES/798.bugfix
+++ b/CHANGES/798.bugfix
@@ -1,0 +1,1 @@
+When installing from packages, fix pulpcore getting upgraded prematurely during "pulp_common : Install the Pulp undeclared yum package dependencies" by no longer installing pulpcore-selinux there. pulpcore-selinux will be installed as a declared dependency of pulpcore.

--- a/CHANGES/809.bugfix
+++ b/CHANGES/809.bugfix
@@ -1,0 +1,1 @@
+When installing in "packages" mode on EL7, workaround upgrading RPM packages by ignoring the latest libcomps. (Fixes error with upgrading python2-libcomps.)

--- a/CHANGES/810.bugfix
+++ b/CHANGES/810.bugfix
@@ -1,0 +1,1 @@
+When installing in "packages" mode on EL8, fix upgrading from RPMs prior to 3.8 by excluding the no-longer-needed dependency python3-drf-yasg from upgrade.

--- a/molecule/packages-dynamic/group_vars/all
+++ b/molecule/packages-dynamic/group_vars/all
@@ -8,7 +8,7 @@ pulp_install_plugins:
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
-pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.14/el{{ ansible_distribution_major_version }}/$basearch/"
+pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.15/el{{ ansible_distribution_major_version }}/$basearch/"
 # Setting this not because it should have any effect, but to test that it
 # doesn't:
 pulp_pkg_upgrade_all: true

--- a/molecule/packages-static/group_vars/all
+++ b/molecule/packages-static/group_vars/all
@@ -10,4 +10,4 @@ pulp_install_plugins:
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
-pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.14/el{{ ansible_distribution_major_version }}/$basearch/"
+pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.15/el{{ ansible_distribution_major_version }}/$basearch/"

--- a/molecule/packages-upgrade/group_vars/all
+++ b/molecule/packages-upgrade/group_vars/all
@@ -8,5 +8,5 @@ pulp_install_plugins:
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
-pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.14/el{{ ansible_distribution_major_version }}/$basearch/"
+pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.15/el{{ ansible_distribution_major_version }}/$basearch/"
 pulp_pkg_upgrade_all: true

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -43,7 +43,6 @@ epel_release_packages:
 # set it, and even then we may just help them to append to a list.
 pulp_irregularly_named_plugins:
   - galaxy-ng
-pulp_pkg_name_prefix: "python3-"
 pulp_pkg_pulpcore_name: "{{ pulp_pkg_name_prefix }}pulpcore"
 pulp_pkg_repo:
 pulp_pkg_repo_gpgcheck: True

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -47,7 +47,6 @@ pulp_pkg_pulpcore_name: "{{ pulp_pkg_name_prefix }}pulpcore"
 pulp_pkg_repo:
 pulp_pkg_repo_gpgcheck: True
 pulp_pkg_undeclared_deps:
-  - pulpcore-selinux
   - "{{ pulp_pkg_name_prefix }}psycopg2"
   - "{{ pulp_pkg_name_prefix }}djangorestframework"
   - "{{ pulp_pkg_name_prefix }}djangorestframework-queryfields"

--- a/roles/pulp_common/tasks/install_packages.yml
+++ b/roles/pulp_common/tasks/install_packages.yml
@@ -63,6 +63,9 @@
       notify:
         - Collect static content
         - Restart all Pulp services
+      tags:
+        # When upgrading from very early RPMs (like 3.3), this task happens twice
+        - molecule-idempotence-notest
 
   become: true
   when:
@@ -102,6 +105,7 @@
           = {{ __pulp_common_package.value.version }}
           {%- endif -%}
         state: "{{ pulp_pkg_upgrade_all | ternary('latest','present') }}"
+        exclude: '{{ pulp_pkg_exclude | default(omit) }}'
       # We use pulp_install_plugins rather than pulp_install_plugins_normalized
       # so that users can specify package names with underscores if distros
       # require it.

--- a/roles/pulp_common/tasks/install_packages.yml
+++ b/roles/pulp_common/tasks/install_packages.yml
@@ -59,6 +59,7 @@
         conf_file: "{{ __dnf_conf.path | default(omit) }}"
         # update_only is a needed part of installing older updates
         update_only: true
+        exclude: '{{ pulp_pkg_exclude | default(omit) }}'
       notify:
         - Collect static content
         - Restart all Pulp services
@@ -75,6 +76,7 @@
       package:
         name: "{{ pulp_pkg_undeclared_deps }}"
         state: "{{ pulp_pkg_upgrade_all | ternary('latest','present') }}"
+        exclude: '{{ pulp_pkg_exclude | default(omit) }}'
       notify:
         - Collect static content
         - Restart all Pulp services
@@ -87,6 +89,7 @@
           = {{ pulpcore_version }}
           {%- endif -%}
         state: "{{ pulp_pkg_upgrade_all | ternary('latest','present') }}"
+        exclude: '{{ pulp_pkg_exclude | default(omit) }}'
       notify:
         - Collect static content
         - Restart all Pulp services

--- a/roles/pulp_common/vars/CentOS-7.yml
+++ b/roles/pulp_common/vars/CentOS-7.yml
@@ -1,4 +1,9 @@
 ---
+# Fixes upgrading from older repos. libcomps-0.1.8-14.el7.x86_64 does not include a python2 subpackage.
+pulp_pkg_exclude:
+  - tfm-pulpcore-python3-libcomps-0.1.18-1.el7.x86_64
+  - libcomps-devel-0.1.18-1.el7.x86_64
+  - libcomps-0.1.18-1.el7.x86_64
 pulp_pkg_name_prefix: "tfm-pulpcore-python3-"
 pulp_preq_packages:
   # pip module doc: "The interpreter used by Ansible (see ansible_python_interpreter) requires the

--- a/roles/pulp_common/vars/CentOS-7.yml
+++ b/roles/pulp_common/vars/CentOS-7.yml
@@ -1,4 +1,5 @@
 ---
+pulp_pkg_name_prefix: "tfm-pulpcore-python3-"
 pulp_preq_packages:
   # pip module doc: "The interpreter used by Ansible (see ansible_python_interpreter) requires the
   # setuptools package, regardless of the version of pip set with the executable option."

--- a/roles/pulp_common/vars/CentOS-8.yml
+++ b/roles/pulp_common/vars/CentOS-8.yml
@@ -1,4 +1,5 @@
 ---
+pulp_pkg_name_prefix: "python38-"
 pulp_preq_packages:
   - python38
   - python38-devel

--- a/roles/pulp_common/vars/CentOS-8.yml
+++ b/roles/pulp_common/vars/CentOS-8.yml
@@ -1,4 +1,5 @@
 ---
+pulp_pkg_exclude: "python3-drf-yasg"  # Fixes upgrading from pre-3.8. It would depend on python3-django.
 pulp_pkg_name_prefix: "python38-"
 pulp_preq_packages:
   - python38


### PR DESCRIPTION
Update packages mode support for Pulp 3.15

Fixes github: #795

[noissue]

Also fixed 3 issues with installing these new packages.