### PR TITLE
Update SELinux policies to 1.2.7.

### DIFF
--- a/CHANGES/9450.feature
+++ b/CHANGES/9450.feature
@@ -1,0 +1,1 @@
+Update SELinux policies to 1.2.7. Adds support for Pulp 3 connecting to remote repos through Squid and other web proxies.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -64,7 +64,7 @@ __pulp_selinux_policy_pkgs:
   - pulpcore
   - pulpcore_rhsmcertd
 __pulp_selinux_repo: 'https://github.com/pulp/pulpcore-selinux.git'
-__pulp_selinux_version: '1.2.6'
+__pulp_selinux_version: '1.2.7'
 __pulp_selinux_label_dirs:
   - "{{ pulp_install_dir }}"
   - "{{ pulp_config_dir }}"


### PR DESCRIPTION
Adds support for Pulp 3 connecting to remote repos through Squid
and other web proxies.

Fixes: #9450