### PR TITLE
Test the installer against 3.16 RPM packages from

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,8 @@ jobs:
       - name: Pulling images for distro packages upgrades
         if: matrix.test_type == 'packages-upgrade'
         run: |
-          docker pull quay.io/pulp/pulp-ci-pkgs-c7:3.3.1
-          docker pull quay.io/pulp/pulp-ci-pkgs-c8:3.3.1
+          docker pull quay.io/pulp/pulp-ci-pkgs-c7:3.7.9
+          docker pull quay.io/pulp/pulp-ci-pkgs-c8:3.7.9
       - name: Run tox
         run: tox -e "py${{ matrix.toxpy }}-ansible${{ matrix.ansible }}-${{ matrix.test_type }}"
         env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Pulling images for distro packages upgrades
         if: matrix.test_type == 'packages-upgrade'
         run: |
-          docker pull quay.io/pulp/pulp-ci-pkgs-c7:3.3.1
-          docker pull quay.io/pulp/pulp-ci-pkgs-c8:3.3.1
+          docker pull quay.io/pulp/pulp-ci-pkgs-c7:3.7.9
+          docker pull quay.io/pulp/pulp-ci-pkgs-c8:3.7.9
       - name: Run tox
         run: tox -e "py${{ matrix.toxpy }}-ansible${{ matrix.ansible }}-${{ matrix.test_type }}"
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Pulling images for distro packages upgrades
         if: matrix.test_type == 'packages-upgrade'
         run: |
-          docker pull quay.io/pulp/pulp-ci-pkgs-c7:3.3.1
-          docker pull quay.io/pulp/pulp-ci-pkgs-c8:3.3.1
+          docker pull quay.io/pulp/pulp-ci-pkgs-c7:3.7.9
+          docker pull quay.io/pulp/pulp-ci-pkgs-c8:3.7.9
       - name: Run tox
         run: tox -e "py${{ matrix.toxpy }}-ansible${{ matrix.ansible }}-${{ matrix.test_type }}"
         env:

--- a/CHANGES/811.dev
+++ b/CHANGES/811.dev
@@ -1,0 +1,1 @@
+The installer is now tested against installing Pulp 3.16 RPM packages from theforeman.org .

--- a/CHANGES/814.removal
+++ b/CHANGES/814.removal
@@ -1,0 +1,1 @@
+No longer support upgrading from packages prior to 3.6. Instead, users should download and run pulp_installer 3.14 with a 3.14 rpm repo, then upgrade to the current version.

--- a/molecule/packages-dynamic/group_vars/all
+++ b/molecule/packages-dynamic/group_vars/all
@@ -8,7 +8,7 @@ pulp_install_plugins:
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
-pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.15/el{{ ansible_distribution_major_version }}/$basearch/"
+pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.16/el{{ ansible_distribution_major_version }}/$basearch/"
 # Setting this not because it should have any effect, but to test that it
 # doesn't:
 pulp_pkg_upgrade_all: true

--- a/molecule/packages-static/group_vars/all
+++ b/molecule/packages-static/group_vars/all
@@ -10,4 +10,4 @@ pulp_install_plugins:
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
-pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.15/el{{ ansible_distribution_major_version }}/$basearch/"
+pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.16/el{{ ansible_distribution_major_version }}/$basearch/"

--- a/molecule/packages-upgrade/group_vars/all
+++ b/molecule/packages-upgrade/group_vars/all
@@ -8,5 +8,5 @@ pulp_install_plugins:
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
-pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.15/el{{ ansible_distribution_major_version }}/$basearch/"
+pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.16/el{{ ansible_distribution_major_version }}/$basearch/"
 pulp_pkg_upgrade_all: true

--- a/molecule/packages-upgrade/molecule.yml
+++ b/molecule/packages-upgrade/molecule.yml
@@ -27,11 +27,11 @@ platforms:
   - <<: *platform_base
     name: centos-7
     # molecule often fails to pull, so we pull all images in .travis.yml
-    image: quay.io/pulp/pulp-ci-pkgs-c7:3.3.1
+    image: quay.io/pulp/pulp-ci-pkgs-c7:3.7.9
     command: /sbin/init
   - <<: *platform_base
     name: centos-8
-    image: quay.io/pulp/pulp-ci-pkgs-c8:3.3.1
+    image: quay.io/pulp/pulp-ci-pkgs-c8:3.7.9
     command: /sbin/init
 provisioner:
   name: ansible

--- a/roles/pulp_common/tasks/main.yml
+++ b/roles/pulp_common/tasks/main.yml
@@ -69,6 +69,17 @@
   package_facts:
     manager: "auto"
 
+- name: If in packages mode, check if we are upgrading from a supported version
+  fail:
+    msg: >
+      Pulp version {{ ansible_facts.packages['python3-pulpcore'].0.version }} is installed.
+      Pulp Installer does not support support upgrading from RPM packages prior to 3.6.
+      Please run Pulp Installer 3.14 with a 3.14 repo, then this version of Pulp Installer.
+  when:
+    - pulp_install_source == 'packages'
+    # python3-pulpcore was the package name back in the < 3.15 era
+    - ansible_facts.packages['python3-pulpcore'].0.version | default('99.99') is version('3.6', '<')
+
 # Note: We cannot use `systemd-path search-binaries-default` because
 # it wasn't added until systemd 239. Thus no CentOS 7 or Fedora 28
 # support, etc.


### PR DESCRIPTION
theforeman.org.

Fixes: #811

Also switching to upgrading from 3.6 instead of 3.3 to resolve another dependency issue with python3-drf-yasg and django during upgrade to python 3.8 RPMs.

Also add a task that fails, and prompts the user to re-run, if using RPM packages prior to 3.8.