### PR TITLE
Problem: pulp_devel is failing to install libseccomp2 2.4

### DIFF
--- a/roles/pulp_devel/tasks/install_podman.yml
+++ b/roles/pulp_devel/tasks/install_podman.yml
@@ -36,7 +36,7 @@
 - name: Install libseccomp2 from backports (Debian-specific)
   apt:
     name:
-      - libseccomp2=2.4*
+      - libseccomp2=2.5*
     default_release: buster-backports
     state: present
   retries: "{{ pulp_devel_package_retries }}"


### PR DESCRIPTION
Solution: Install 2.5 instead. It is the current version in backports.

[noissue]