### PR TITLE
Remove wrong fs links

### DIFF
--- a/molecule/packages-dynamic/debian-redis-server.service
+++ b/molecule/packages-dynamic/debian-redis-server.service
@@ -1,1 +1,0 @@
-../scenario_resources/debian-redis-server.service

--- a/molecule/packages-static/debian-redis-server.service
+++ b/molecule/packages-static/debian-redis-server.service
@@ -1,1 +1,0 @@
-../scenario_resources/debian-redis-server.service

--- a/molecule/packages-upgrade/debian-redis-server.service
+++ b/molecule/packages-upgrade/debian-redis-server.service
@@ -1,1 +1,0 @@
-../scenario_resources/debian-redis-server.service

--- a/molecule/release-dynamic/debian-redis-server.service
+++ b/molecule/release-dynamic/debian-redis-server.service
@@ -1,1 +1,0 @@
-../scenario_resources/debian-redis-server.service

--- a/molecule/release-static/debian-redis-server.service
+++ b/molecule/release-static/debian-redis-server.service
@@ -1,1 +1,0 @@
-../scenario_resources/debian-redis-server.service

--- a/molecule/release-upgrade/debian-redis-server.service
+++ b/molecule/release-upgrade/debian-redis-server.service
@@ -1,1 +1,0 @@
-../scenario_resources/debian-redis-server.service

--- a/molecule/source-dynamic/debian-redis-server.service
+++ b/molecule/source-dynamic/debian-redis-server.service
@@ -1,1 +1,0 @@
-../scenario_resources/debian-redis-server.service

--- a/molecule/source-upgrade/debian-redis-server.service
+++ b/molecule/source-upgrade/debian-redis-server.service
@@ -1,1 +1,0 @@
-../scenario_resources/debian-redis-server.service


### PR DESCRIPTION
links points to non existant file and prevents pulplift from installation

```
/devel/pulp_installer/molecule/default/debian-redis-server.service -> ../scenario_resources/debian-redis-server.service
/devel/pulp_installer/molecule/packages-dynamic/debian-redis-server.service -> ../scenario_resources/debian-redis-server.service
/devel/pulp_installer/molecule/packages-static/debian-redis-server.service -> ../scenario_resources/debian-redis-server.service
/devel/pulp_installer/molecule/packages-upgrade/debian-redis-server.service -> ../scenario_resources/debian-redis-server.service
/devel/pulp_installer/molecule/release-dynamic/debian-redis-server.service -> ../scenario_resources/debian-redis-server.service
/devel/pulp_installer/molecule/release-static/debian-redis-server.service -> ../scenario_resources/debian-redis-server.service
/devel/pulp_installer/molecule/release-upgrade/debian-redis-server.service -> ../scenario_resources/debian-redis-server.service
/devel/pulp_installer/molecule/source-dynamic/debian-redis-server.service -> ../scenario_resources/debian-redis-server.service
/devel/pulp_installer/molecule/source-upgrade/debian-redis-server.service -> ../scenario_resources/debian-redis-server.service
```

[noissue]