### PR TITLE
Fix building the collection failing on MacOS

### DIFF
--- a/CHANGES/823.bugfix
+++ b/CHANGES/823.bugfix
@@ -1,0 +1,1 @@
+Fix building the collection failing on MacOS due to an `install` command error.

--- a/Makefile
+++ b/Makefile
@@ -43,8 +43,10 @@ test: $(MANIFEST)
 $(MANIFEST): $(NAMESPACE)-$(NAME)-$(VERSION).tar.gz
 	ansible-galaxy collection install -p build/collections $< --force
 
+# We cannot use a single `install -DT` command here because MacOS `install` lacks `-D` & `-T`.
 build/src/%: %
-	install -m 644 -DT $< $@
+	install -m 755 -d $(@D)
+	install -m 644 $< $@
 
 $(NAMESPACE)-$(NAME)-$(VERSION).tar.gz: $(addprefix build/src/,$(DEPENDENCIES))
 	ansible-galaxy collection build build/src --force


### PR DESCRIPTION
due to an `install` command error.