### PR TITLE
Update pulpcore-selinux to 1.2.8

### DIFF
--- a/CHANGES/826.bugfix
+++ b/CHANGES/826.bugfix
@@ -1,0 +1,1 @@
+Update pulpcore-selinux policies to 1.2.8. Fixes SELinux denials, and pulpcore-worker not starting when SELinux is enforcing, when using the new pulpcore tasking system.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -62,7 +62,7 @@ __pulp_selinux_policy_pkgs:
   - pulpcore
   - pulpcore_rhsmcertd
 __pulp_selinux_repo: 'https://github.com/pulp/pulpcore-selinux.git'
-__pulp_selinux_version: '1.2.7'
+__pulp_selinux_version: '1.2.8'
 __pulp_selinux_label_dirs:
   - "{{ pulp_install_dir }}"
   - "{{ pulp_config_dir }}"


### PR DESCRIPTION
Fixes SELinux denials, and pulpcore-worker not starting when
SELinux is enforcing, when using the new pulpcore tasking system.

fixes: #826