### PR TITLE
Fix 2 failures on certain Ansible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,17 +62,17 @@ jobs:
             python: "3.9"
             toxpy: "39"
           - test_type: release-upgrade
-            ansible: "2.9"
-            python: "2.7"
-            toxpy: "27"
+            ansible: "3.0"
+            python: "3.6"
+            toxpy: "36"
           - test_type: source-upgrade
             ansible: "2.10"
             python: "3.6"
             toxpy: "36"
           - test_type: packages-upgrade
-            ansible: "2.10"
-            python: "3.6"
-            toxpy: "36"
+            ansible: "2.9"
+            python: "2.7"
+            toxpy: "27"
     steps:
       - uses: actions/checkout@v2.3.1
       - name: Set up Python

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,17 +38,17 @@ jobs:
             python: "3.7"
             toxpy: "37"
           - test_type: release-upgrade
-            ansible: "2.9"
-            python: "2.7"
-            toxpy: "27"
+            ansible: "3.0"
+            python: "3.6"
+            toxpy: "36"
           - test_type: source-upgrade
             ansible: "2.10"
             python: "3.6"
             toxpy: "36"
           - test_type: packages-upgrade
-            ansible: "2.10"
-            python: "3.6"
-            toxpy: "36"
+            ansible: "2.9"
+            python: "2.7"
+            toxpy: "27"
     steps:
       - uses: actions/checkout@v2.3.1
       - name: Set up Python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,13 @@ jobs:
             python: "3.7"
             toxpy: "37"
           - test_type: release-upgrade
+            ansible: "3.0"
+            python: "3.6"
+            toxpy: "36"
+          - test_type: packages-upgrade
             ansible: "2.9"
             python: "2.7"
             toxpy: "27"
-          - test_type: packages-upgrade
-            ansible: "2.10"
-            python: "3.6"
-            toxpy: "36"
     steps:
       - uses: actions/checkout@v2.3.1
       - name: Set up Python

--- a/CHANGES/833.bugfix
+++ b/CHANGES/833.bugfix
@@ -1,0 +1,1 @@
+Fix pulp_installer failing to install rubygems on Debian 11 when using Ansible's main branch.

--- a/CHANGES/836.removal
+++ b/CHANGES/836.removal
@@ -1,0 +1,1 @@
+Ansible 2.9 and Python 2.7 are now further deprecated. We observed a bug whereby a pip_package_info task in the playbook fails after running the task `include_role: pulp_all_services`. The only fix for this bug is to upgrade to a known working and tested configuration like Python 3 and ansible-base 2.10+.

--- a/roles/pulp_devel/tasks/install_basic_packages.yml
+++ b/roles/pulp_devel/tasks/install_basic_packages.yml
@@ -15,7 +15,6 @@
           - wget
           - curl
           - gnupg
-          - rubygems
           - npm
           - rsyslog
         state: present
@@ -49,7 +48,6 @@
           - wget
           - curl
           - gnupg
-          - rubygems
           - npm
           - rsyslog
         state: present

--- a/roles/pulp_devel/vars/CentOS-7.yml
+++ b/roles/pulp_devel/vars/CentOS-7.yml
@@ -4,4 +4,5 @@ pulp_devel_distro_pkgs:
   - python-virtualenvwrapper
   - ruby-devel
   - jnettop
+  - rubygems
   - setroubleshoot

--- a/roles/pulp_devel/vars/CentOS-8.yml
+++ b/roles/pulp_devel/vars/CentOS-8.yml
@@ -9,5 +9,6 @@ pulp_devel_distro_pkgs:
   - python3-virtualenv-clone
   - vim-enhanced
   - ruby-devel
+  - rubygems
   - setroubleshoot
   - crun

--- a/roles/pulp_devel/vars/Debian.yml
+++ b/roles/pulp_devel/vars/Debian.yml
@@ -9,6 +9,7 @@ pulp_devel_distro_pkgs:
   - ripgrep
   - vim
   - software-properties-common
+  - ruby
   - ruby-dev
   - jnettop
   - nmap

--- a/roles/pulp_devel/vars/Fedora-34.yml
+++ b/roles/pulp_devel/vars/Fedora-34.yml
@@ -11,6 +11,7 @@ pulp_devel_distro_pkgs:
   - python3-virtualenvwrapper
   - ripgrep
   - vim-enhanced
+  - rubygems
   - ruby-devel
   - crun
   - setroubleshoot

--- a/roles/pulp_devel/vars/Fedora.yml
+++ b/roles/pulp_devel/vars/Fedora.yml
@@ -12,6 +12,7 @@ pulp_devel_distro_pkgs:
   - python3-virtualenvwrapper
   - ripgrep
   - vim-enhanced
+  - rubygems
   - ruby-devel
   - jnettop
   - setroubleshoot


### PR DESCRIPTION
1. Fix compatibility with ansible main branch by specifying the explicit package name for rubygems, "ruby", on Debian.

Fixes: #833

2. Switch tests' ansible versions around so that the pip_package_info in release-upgrade converge.yml bug is not triggered on Ansible 2.9.

fixes: #836
