### PR TITLE
Move lint into a separate test for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           sudo apt remove ansible
           pip install ${{ matrix.ansible_core }}
       - name: Install Molecule
-        run: pip install "molecule!=3.3.1" docker molecule-docker ansible-lint[yamllint]
+        run: pip install "molecule!=3.3.1" docker molecule-docker
       - name: Setting pulp.pulp_installer collection
         run: |
           make vendor
@@ -137,3 +137,25 @@ jobs:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
         shell: bash
+  lint:
+    runs-on: ubuntu-latest
+    needs: git-check
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2.3.1
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Install Ansible
+        run: |
+          pip install --upgrade pip
+          sudo apt remove ansible
+          pip install ansible-core
+      - name: Install Ansible-lint
+        run: |
+          pip install ansible-lint[yamllint]
+      - name: Lint test
+        run: |
+          ansible-lint

--- a/.github/workflows/galaxy_ci.yml
+++ b/.github/workflows/galaxy_ci.yml
@@ -32,7 +32,7 @@ jobs:
           sudo apt remove ansible
           pip install ${{ matrix.ansible_core }}
       - name: Install Molecule
-        run: pip install "molecule!=3.3.1" docker molecule-docker ansible-lint[yamllint]
+        run: pip install "molecule!=3.3.1" docker molecule-docker
       - name: Setting pulp.pulp_installer collection
         run: |
           make vendor
@@ -48,3 +48,24 @@ jobs:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
         shell: bash
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2.3.1
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Install Ansible
+        run: |
+          pip install --upgrade pip
+          sudo apt remove ansible
+          pip install ansible-core
+      - name: Install Ansible-lint
+        run: |
+          pip install ansible-lint[yamllint]
+      - name: Lint test
+        run: |
+          ansible-lint

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -122,3 +122,25 @@ jobs:
       - name: After failure
         if: failure()
         run: .github/workflows/scripts/after_failure.sh ${{ matrix.test_type }}
+  lint:
+    runs-on: ubuntu-latest
+    needs: git-check
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2.3.1
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Install Ansible
+        run: |
+          pip install --upgrade pip
+          sudo apt remove ansible
+          pip install ansible-core
+      - name: Install Ansible-lint
+        run: |
+          pip install ansible-lint[yamllint]
+      - name: Lint test
+        run: |
+          ansible-lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,3 +98,25 @@ jobs:
         env:
           PULP_DOCS_KEY: ${{ secrets.PULP_DOCS_KEY }}
         run: .ci/scripts/publish_docs.sh ${GITHUB_REF##*/}
+  lint:
+    runs-on: ubuntu-latest
+    needs: git-check
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2.3.1
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Install Ansible
+        run: |
+          pip install --upgrade pip
+          sudo apt remove ansible
+          pip install ansible-core
+      - name: Install Ansible-lint
+        run: |
+          pip install ansible-lint[yamllint]
+      - name: Lint test
+        run: |
+          ansible-lint

--- a/molecule/packages-dynamic/molecule.yml
+++ b/molecule/packages-dynamic/molecule.yml
@@ -6,7 +6,6 @@ dependency:
 driver:
   name: docker
 lint: |
-    yamllint .
     ansible-lint
 # This is ignored by molecule, but can be reused in yaml
 .platform_base: &platform_base
@@ -48,7 +47,6 @@ provisioner:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - syntax
     - create
     - prepare

--- a/molecule/packages-static/molecule.yml
+++ b/molecule/packages-static/molecule.yml
@@ -6,7 +6,6 @@ dependency:
 driver:
   name: docker
 lint: |
-    yamllint .
     ansible-lint
 # This is ignored by molecule, but can be reused in yaml
 .platform_base: &platform_base
@@ -48,7 +47,6 @@ provisioner:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - syntax
     - create
     - prepare

--- a/molecule/packages-upgrade/molecule.yml
+++ b/molecule/packages-upgrade/molecule.yml
@@ -6,7 +6,6 @@ dependency:
 driver:
   name: docker
 lint: |
-    yamllint .
     ansible-lint
 # This is ignored by molecule, but can be reused in yaml
 .platform_base: &platform_base
@@ -49,7 +48,6 @@ provisioner:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - syntax
     - create
     - prepare

--- a/molecule/release-dynamic/molecule.yml
+++ b/molecule/release-dynamic/molecule.yml
@@ -6,9 +6,7 @@ dependency:
 driver:
   name: docker
 lint: |
-    yamllint .
     ansible-lint
-    # rubocop
 # This is ignored by molecule, but can be reused in yaml
 .platform_base: &platform_base
   privileged: False
@@ -57,7 +55,6 @@ provisioner:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - syntax
     - create
     - prepare

--- a/molecule/release-static/molecule.yml
+++ b/molecule/release-static/molecule.yml
@@ -6,9 +6,7 @@ dependency:
 driver:
   name: docker
 lint: |
-    yamllint .
     ansible-lint
-    # rubocop
 # This is ignored by molecule, but can be reused in yaml
 .platform_base: &platform_base
   privileged: False
@@ -57,7 +55,6 @@ provisioner:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - syntax
     - create
     - prepare

--- a/molecule/release-upgrade/molecule.yml
+++ b/molecule/release-upgrade/molecule.yml
@@ -6,9 +6,7 @@ dependency:
 driver:
   name: docker
 lint: |
-    yamllint .
     ansible-lint
-    # rubocop
 # This is ignored by molecule, but can be reused in yaml
 .platform_base: &platform_base
   privileged: False
@@ -53,7 +51,6 @@ provisioner:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - syntax
     - create
     - prepare

--- a/molecule/source-dynamic/molecule.yml
+++ b/molecule/source-dynamic/molecule.yml
@@ -6,9 +6,7 @@ dependency:
 driver:
   name: docker
 lint: |
-    yamllint .
     ansible-lint
-    # rubocop
 # This is ignored by molecule, but can be reused in yaml
 .platform_base: &platform_base
   privileged: False
@@ -57,7 +55,6 @@ provisioner:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - syntax
     - create
     - prepare

--- a/molecule/source-static/molecule.yml
+++ b/molecule/source-static/molecule.yml
@@ -6,9 +6,7 @@ dependency:
 driver:
   name: docker
 lint: |
-    yamllint .
     ansible-lint
-    # rubocop
 # This is ignored by molecule, but can be reused in yaml
 .platform_base: &platform_base
   privileged: False
@@ -57,7 +55,6 @@ provisioner:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - syntax
     - create
     - prepare

--- a/molecule/source-upgrade/molecule.yml
+++ b/molecule/source-upgrade/molecule.yml
@@ -6,9 +6,7 @@ dependency:
 driver:
   name: docker
 lint: |
-    yamllint .
     ansible-lint
-    # rubocop
 # This is ignored by molecule, but can be reused in yaml
 .platform_base: &platform_base
   privileged: False
@@ -49,7 +47,6 @@ provisioner:
 scenario:
   test_sequence:
     - dependency
-    - lint
     - syntax
     - create
     - prepare

--- a/tox.ini
+++ b/tox.ini
@@ -42,9 +42,6 @@ passenv =
 # We removed cleanup from the end because it complicate Travis
 # debugging.
 commands =
-    # Do not lint on python 2.7 (ansible-lint dropped support for python 2)
-    # https://github.com/ansible-community/ansible-lint/releases/tag/v4.3.0
-    py27: bash -c "find ./molecule/*/molecule.yml -exec sed -i '/- lint/d' \{\} \;"
     # For molecule:
     ansible-galaxy collection install -p build/collections --force community.docker
     # Installing pulp.pulp_installer collection


### PR DESCRIPTION
Reduces time to run other tests by 5:33

Implementation includes:
1. Removes lint from the `molecule test` command.
2. A new CI test called "lint"
3. Removes calling yamllint, since ansible-lint calls it.
4. Cleans up old commented out verifier step of `rubocop`.

[noissue]