### PR TITLE
Drop become_user: root as become: true is set

### DIFF
--- a/CHANGES/844.bugfix
+++ b/CHANGES/844.bugfix
@@ -1,0 +1,1 @@
+Removed extraneous use of become_user: root from devel role.

--- a/roles/pulp_devel/tasks/config_files.yml
+++ b/roles/pulp_devel/tasks/config_files.yml
@@ -32,19 +32,4 @@
     dest: "{{ developer_user_home }}/.config/pulp_smash/settings.json"
     force: yes
     mode: 0600
-
-- name: Trusting Pulp CA
-  shell: |
-    set -o pipefail
-    CERTIFI=$({{ pulp_install_dir }}/bin/python -c 'import certifi; print(certifi.where())')
-    cat {{ pulp_certs_dir }}/root.crt | tee -a $CERTIFI
-    CERT=$({{ pulp_install_dir }}/bin/python -c 'import ssl; print(ssl.get_default_verify_paths().openssl_cafile)')
-    cat $CERTIFI | tee -a $CERT
-  args:
-    # Debian defaults to bourne, but it doesn't understand pipefail.
-    executable: /bin/bash
-  changed_when: false
-  check_mode: false
-  become: yes
-  become_user: root
 ...

--- a/roles/pulp_devel/tasks/main.yml
+++ b/roles/pulp_devel/tasks/main.yml
@@ -49,6 +49,20 @@
   become: true
   become_user: "{{ developer_user }}"
 
+- name: Trusting Pulp CA
+  shell: |
+    set -o pipefail
+    CERTIFI=$({{ pulp_install_dir }}/bin/python -c 'import certifi; print(certifi.where())')
+    cat {{ pulp_certs_dir }}/root.crt | tee -a $CERTIFI
+    CERT=$({{ pulp_install_dir }}/bin/python -c 'import ssl; print(ssl.get_default_verify_paths().openssl_cafile)')
+    cat $CERTIFI | tee -a $CERT
+  args:
+    # Debian defaults to bourne, but it doesn't understand pipefail.
+    executable: /bin/bash
+  changed_when: false
+  check_mode: false
+  become: yes
+
 - import_tasks: pulp_cli.yml
   become: true
   become_user: "{{ developer_user }}"


### PR DESCRIPTION
Fixes: https://github.com/pulp/pulp_installer/issues/844

In some environments, doing `sudo su - ` is not allowed, but doing `sudo CMD` is fine. 

When a task has `become: true` and `become_user: root` creates a conflict. 

This PR removes the `become_user: root` but yet the task runs as privileged credentials.