### PR TITLE
Add nightly CI for ansible-core tests

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,11 +80,11 @@ jobs:
     name: Publish docs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Run publish docs script
-      env:
-        PULP_DOCS_KEY: ${{ secrets.PULP_DOCS_KEY }}
-      run: .ci/scripts/publish_docs.sh ${GITHUB_REF##*/}
+      - uses: actions/checkout@v2
+      - name: Run publish docs script
+        env:
+          PULP_DOCS_KEY: ${{ secrets.PULP_DOCS_KEY }}
+        run: .ci/scripts/publish_docs.sh ${GITHUB_REF##*/}
   vagrant:
     runs-on: ubuntu-20.04
     strategy:
@@ -122,9 +122,44 @@ jobs:
       - name: After failure
         if: failure()
         run: .github/workflows/scripts/after_failure.sh ${{ matrix.test_type }}
+  core:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      # Testing different python versions because of
+      # https://pulp.plan.io/issues/5768#note-17
+      matrix:
+        include:
+          - ansible_core: ansible-core
+          - ansible_core: git+https://github.com/ansible/ansible.git
+    steps:
+      - uses: actions/checkout@v2.3.1
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Install Ansible
+        run: |
+          pip install --upgrade pip
+          sudo apt remove ansible
+          pip install ${{ matrix.ansible_core }}
+      - name: Install Molecule
+        run: pip install "molecule!=3.3.1" docker molecule-docker
+      - name: Setting pulp.pulp_installer collection
+        run: |
+          make vendor
+          make install
+          ansible-galaxy collection install -p build/collections --force community.docker
+      - name: Molecule Test
+        run: |
+          ansible --version
+          molecule test --scenario-name source-static
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+        shell: bash
   lint:
     runs-on: ubuntu-latest
-    needs: git-check
     strategy:
       fail-fast: false
     steps:


### PR DESCRIPTION
Should help us identify when an external project breaks these
CI tests.

Also fix 2 bugs (not breaking anything) in nightly.yml.

[noissue]