### PR TITLE
    Fix pip-compile failing due to pip-tools not

### DIFF
--- a/CHANGES/858.bugfix
+++ b/CHANGES/858.bugfix
@@ -1,0 +1,1 @@
+Fix pulp_installer failing on "pulp_common: Run pip-compile to check pulpcore/plugin compatibility" on most distros. This occurs with pip 22.0 (just released) and pip-tools 6.4.0 (several months old and incompatible), so we are fixing it by limiting pip to 21 for now.

--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -100,7 +100,7 @@
 
     - name: Upgrade to a recent edition of pip (supporting manylinux2014)
       pip:
-        name: pip>=21.1.1
+        name: pip>=21.1.1,<22.0
         state: present
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'


### PR DESCRIPTION
being compatible with pip 22.0 by installing prior pip.

fixes: #858