### PR TITLE
CentOS Stream 8 & pulp_devel idempotency workaround

### DIFF
--- a/.github/vars/main.yaml
+++ b/.github/vars/main.yaml
@@ -3,8 +3,8 @@ molecule_images:
   - name: centos-7
     image: centos:7
     command: /sbin/init
-  - name: centos-8
-    image: centos:8
+  - name: centos-stream8
+    image: centos:stream8
     command: /sbin/init
   - name: fedora-35
     image: fedora:35

--- a/CHANGES/860.removal
+++ b/CHANGES/860.removal
@@ -1,0 +1,1 @@
+CentOS 8 is now EOL, and thus Pulp no longer formally supports it. Pulp now only tests fresh installs with CentOS Stream 8, and with upgrades from CentOS 8 to CentOS Stream 8 (see migration instructions here https://centos.org/centos-stream/).

--- a/molecule/release-static/prepare.yml
+++ b/molecule/release-static/prepare.yml
@@ -13,3 +13,30 @@
       when:
         - ansible_os_family == "RedHat"
         - ansible_distribution_major_version|int == 7
+
+    - name: Migrate CentOS 8 to CentOS Stream 8
+      block:
+        - name: Get latest CentOS 8 GPG keys and its temporary dependency
+          dnf:
+            name:
+              - https://vault.centos.org/8.5.2111/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm
+              - https://vault.centos.org/8.5.2111/BaseOS/x86_64/os/Packages/centos-linux-repos-8-3.el8.noarch.rpm
+            disablerepo:
+              - baseos
+              - appstream
+              - extras
+          when:
+            - ansible_distribution == "CentOS"
+            - ansible_distribution_version in ["8.3","8.4"]
+
+        - name: Switch to CentOS 8 Stream repos
+          command: dnf -y --disablerepo * --enablerepo extras swap centos-linux-repos centos-stream-repos
+
+        - name: Finish CentOS 8 Stream migration
+          dnf:
+              name:
+                - centos-stream-release
+                - centos-gpg-keys
+      when:
+        - ansible_distribution == "CentOS"
+        - ansible_distribution_version in ["8.3","8.4","8.5"]

--- a/molecule/source-static/prepare.yml
+++ b/molecule/source-static/prepare.yml
@@ -2,12 +2,6 @@
 - hosts:
     - all
   tasks:
-    - name: Install required packages
-      package:
-        name:
-          - git
-        state: present
-
     - name: Create user {{ developer_user }}
       user:
         name: '{{ developer_user }}'
@@ -34,3 +28,30 @@
       when:
         - ansible_os_family == "RedHat"
         - ansible_distribution_major_version|int == 7
+
+    - name: Migrate CentOS 8 to CentOS Stream 8
+      block:
+        - name: Get latest CentOS 8 GPG keys and its temporary dependency
+          dnf:
+            name:
+              - https://vault.centos.org/8.5.2111/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm
+              - https://vault.centos.org/8.5.2111/BaseOS/x86_64/os/Packages/centos-linux-repos-8-3.el8.noarch.rpm
+            disablerepo:
+              - baseos
+              - appstream
+              - extras
+          when:
+            - ansible_distribution == "CentOS"
+            - ansible_distribution_version in ["8.3","8.4"]
+
+        - name: Switch to CentOS 8 Stream repos
+          command: dnf -y --disablerepo * --enablerepo extras swap centos-linux-repos centos-stream-repos
+
+        - name: Finish CentOS 8 Stream migration
+          dnf:
+              name:
+                - centos-stream-release
+                - centos-gpg-keys
+      when:
+        - ansible_distribution == "CentOS"
+        - ansible_distribution_version in ["8.3","8.4","8.5"]

--- a/roles/pulp_devel/tasks/install_docs_requirements.yml
+++ b/roles/pulp_devel/tasks/install_docs_requirements.yml
@@ -6,6 +6,8 @@
     virtualenv: '{{ pulp_install_dir }}'
     virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
   when: pulp_source_dir is defined
+  tags:
+    - molecule-idempotence-notest
 
 - name: Install pulpcore requirements for testing locally
   pip:
@@ -16,6 +18,8 @@
   when: pulp_source_dir is defined
   environment:
     SETUPTOOLS_USE_DISTUTILS: stdlib
+  tags:
+    - molecule-idempotence-notest
 
 - name: Install plugin requirements for testing locally
   pip:
@@ -28,6 +32,8 @@
   environment:
     SETUPTOOLS_USE_DISTUTILS: stdlib
   ignore_errors: yes  # noqa ignore-errors
+  tags:
+    - molecule-idempotence-notest
 
 - name: Install requirements for developer scripts
   pip:
@@ -36,6 +42,8 @@
     virtualenv: '{{ pulp_install_dir }}'
     virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
   when: pulp_source_dir is defined
+  tags:
+    - molecule-idempotence-notest
 
 - name: Install requirements for Azure/S3 tests
   pip:


### PR DESCRIPTION
```
    Migrate to CentOS Stream 8 in molecule
    
    Resolves CI failing due to 8's repos being no longer available
    due to 8's EOL.
    
    Implementation includes testing upgrades from CentOS 8 to CentOS
    Stream 8 per instructions here:
    https://centos.org/centos-stream/
    With an additional step for 8.3 upgrades.
    
    fixes: #860
```
Note: I will do a separate PR to use our new molecule images once said images are built by nightly cron.


```
    Problem: idempotency is failing because of a conflict
    
    in requirements.txt files.
    
    Solution: Do not test them for idempotency. They're only in the
    devel role anyway.
    
    [noissue]
```