### PR TITLE
Correct the CI release script prompt for the minor

### DIFF
--- a/.ci/scripts/release.py
+++ b/.ci/scripts/release.py
@@ -11,8 +11,8 @@ release_path = os.path.dirname(os.path.abspath(__file__))
 plugin_path = release_path.split("/.ci")[0]
 
 plugin_name = "pulp_installer"
-release_version = input("Please enter the pulp_installer version e.g. (3.12.0): ")
-pulpcore_version = input("Please enter the pulpcore version e.g. (3.12.0): ")
+release_version = input("Please enter the pulp_installer version e.g. (3.17.0): ")
+pulpcore_version = input("Please enter the pulpcore minor version e.g. (3.17): ")
 pulpcore_selinux_version = input(
     "Please enter the pulpcore-selinux version e.g. (1.2.4): "
 )

--- a/CHANGES/862.bugfix
+++ b/CHANGES/862.bugfix
@@ -1,0 +1,1 @@
+Fixed a problem in pulp_installer 3.17.0 that it would only install pulpcore 3.17.0 rather than the latest 3.17.z micro release. pulp_installer 3.17.0 users can work around by setting the variable `pulpcore_version: 3.17`


### PR DESCRIPTION
version of pulpcore.

Also provide a changelog entry for the bug it catches, which made it
into 3.17.0 .

fixes: #862