### PR TITLE
Address failures on the task

### DIFF
--- a/CHANGES/868.bugfix
+++ b/CHANGES/868.bugfix
@@ -1,0 +1,1 @@
+Address failures on the task `pulp_common : Set state of pulpcore app` by having it do 5 retries over 60 seconds.

--- a/roles/pulp_common/tasks/main.yml
+++ b/roles/pulp_common/tasks/main.yml
@@ -130,3 +130,10 @@
     state: started
     enabled: true
   become: true
+  # This task is occassionally failing. We are assuming it to be a timing issue,
+  # with the restarting of the service that just happened, and are thus
+  # adding these retries.
+  retries: 5
+  delay: 6
+  register: result
+  until: result is succeeded


### PR DESCRIPTION
`pulp_common : Set state of pulpcore app` by having it do
5 retries over 60 seconds.

fixes: #868

Note: I know this is bad form. I think to realistically investigate this for a proper fix, we would need to output a bunch of information instead when this task errors. And then not recover from it, so the CI failure shows up. (Perhaps recover from it for users, but don't recover in CI. We could control this with a `when:` variable.)