### PR TITLE
Fix pulp_webserver CentOS Stream 8 support and CI

### DIFF
--- a/CHANGES/878.bugfix
+++ b/CHANGES/878.bugfix
@@ -1,0 +1,1 @@
+Fix `pulp_webserver : Start and enable Apache` failing on CentOS Stream 8 container images (quay.io/centos/centos:stream8).

--- a/molecule/packages-dynamic/molecule.yml
+++ b/molecule/packages-dynamic/molecule.yml
@@ -29,7 +29,7 @@ platforms:
     command: /sbin/init
   - <<: *platform_base
     name: centos-8
-    image: ghcr.io/pulp/molecule_centos8
+    image: ghcr.io/pulp/molecule_centosstream8
     command: /sbin/init
 provisioner:
   name: ansible

--- a/molecule/packages-static/molecule.yml
+++ b/molecule/packages-static/molecule.yml
@@ -29,7 +29,7 @@ platforms:
     command: /sbin/init
   - <<: *platform_base
     name: centos-8
-    image: ghcr.io/pulp/molecule_centos8
+    image: ghcr.io/pulp/molecule_centosstream8
     command: /sbin/init
 provisioner:
   name: ansible

--- a/molecule/release-dynamic/molecule.yml
+++ b/molecule/release-dynamic/molecule.yml
@@ -29,7 +29,7 @@ platforms:
     command: /sbin/init
   - <<: *platform_base
     name: centos-8
-    image: ghcr.io/pulp/molecule_centos8
+    image: ghcr.io/pulp/molecule_centosstream8
     command: /sbin/init
   - <<: *platform_base
     name: debian-11

--- a/molecule/release-static/molecule.yml
+++ b/molecule/release-static/molecule.yml
@@ -29,7 +29,7 @@ platforms:
     command: /sbin/init
   - <<: *platform_base
     name: centos-8
-    image: ghcr.io/pulp/molecule_centos8
+    image: ghcr.io/pulp/molecule_centosstream8
     command: /sbin/init
   - <<: *platform_base
     name: debian-11

--- a/molecule/release-static/prepare.yml
+++ b/molecule/release-static/prepare.yml
@@ -14,6 +14,8 @@
         - ansible_os_family == "RedHat"
         - ansible_distribution_major_version|int == 7
 
+    # Note: Technically these are only needed for the packages-upgrade scenario now, and it is
+    # CentOS 8.3
     - name: Migrate CentOS 8 to CentOS Stream 8
       block:
         - name: Get latest CentOS 8 GPG keys and its temporary dependency

--- a/molecule/source-dynamic/molecule.yml
+++ b/molecule/source-dynamic/molecule.yml
@@ -29,7 +29,7 @@ platforms:
     command: /sbin/init
   - <<: *platform_base
     name: centos-8
-    image: ghcr.io/pulp/molecule_centos8
+    image: ghcr.io/pulp/molecule_centosstream8
     command: /sbin/init
   - <<: *platform_base
     name: debian-11

--- a/molecule/source-static/molecule.yml
+++ b/molecule/source-static/molecule.yml
@@ -29,7 +29,7 @@ platforms:
     command: /sbin/init
   - <<: *platform_base
     name: centos-8
-    image: ghcr.io/pulp/molecule_centos8
+    image: ghcr.io/pulp/molecule_centosstream8
     command: /sbin/init
   - <<: *platform_base
     name: debian-11

--- a/molecule/source-static/prepare.yml
+++ b/molecule/source-static/prepare.yml
@@ -29,6 +29,8 @@
         - ansible_os_family == "RedHat"
         - ansible_distribution_major_version|int == 7
 
+    # Note: Technically these are only needed for the packages-upgrade scenario now, and it is
+    # CentOS 8.3
     - name: Migrate CentOS 8 to CentOS Stream 8
       block:
         - name: Get latest CentOS 8 GPG keys and its temporary dependency

--- a/roles/pulp_webserver/vars/Fedora.yml
+++ b/roles/pulp_webserver/vars/Fedora.yml
@@ -6,7 +6,11 @@ pulp_seboolean_packages:
   - python3-libsemanage
 pulp_firewall_dependencies:
   - python3-firewall
-pulp_webserver_apache_package: mod_ssl
+pulp_webserver_apache_package:
+  - mod_ssl
+  # workaround an undeclared dependency, for the centos:8stream container image
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2050888
+  - hostname
 pulp_webserver_apache_service: httpd
 pulp_webserver_apache_vhost_dir: /etc/httpd/conf.d
 pulp_webserver_apache_snippets_dir: /etc/httpd/pulp


### PR DESCRIPTION
test with CentOS Stream 8 images,
rather than outdated CentOS 8.4 images.

fixes: #878