### PR TITLE
Revert "Fix pip-compile failing due to pip-tools not"

### DIFF
--- a/CHANGES/876.bugfix
+++ b/CHANGES/876.bugfix
@@ -1,0 +1,1 @@
+Allow pulp to use pip>=22 again. This reverts the bugfix 'Fix pulp_installer failing on "pulp_common: Run pip-compile to check pulpcore/plugin compatibility" on most distros.' We can do this thanks to pip-tools 6.5.0 being released with pip 22 compatibility.

--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -100,7 +100,7 @@
 
     - name: Upgrade to a recent edition of pip (supporting manylinux2014)
       pip:
-        name: pip>=21.1.1,<22.0
+        name: pip>=21.1.1
         state: present
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'


### PR DESCRIPTION
This reverts commit 892d42954923430816143e046591723273cb5079.

because pip-tools 6.5.0 was released with compatibility with pip 22.0

fixes: #876