### PR TITLE
Fixed upgrades often failing on the task

### DIFF
--- a/CHANGES/889.bugfix
+++ b/CHANGES/889.bugfix
@@ -1,0 +1,1 @@
+Fixed upgrades often failing on the task `pulp_common : Collect static content` due to `ModuleNotFoundError: No module named 'packaging'`.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -25,6 +25,8 @@ pulpcore_update: false
 prereq_pip_packages:
   - Jinja2
   - pygments
+  # needed due to https://github.com/rsinger86/django-lifecycle/issues/101
+  - packaging
 pulp_rhel_codeready_repo:
   - codeready-builder-for-rhel-8-x86_64-rpms
   - rhui-codeready-builder-for-rhel-8-rhui-rpms


### PR DESCRIPTION
`pulp_common : Collect static content`
due to `ModuleNotFoundError: No module named 'packaging'`

Note: New installs do not need this because redis>=4.1
pull packaging in.

fixes: #889