### PR TITLE
The Pulp API can now be rerooted using the new ``API_ROOT``

### DIFF
--- a/CHANGES/892.feature
+++ b/CHANGES/892.feature
@@ -1,0 +1,2 @@
+The Pulp API can now be rerooted using the new ``API_ROOT`` setting. By default it is set to
+``/pulp/``. Pulp appends the string ``api/v3/`` onto the value of ``API_ROOT``.

--- a/roles/pulp_devel/templates/alias.bashrc.j2
+++ b/roles/pulp_devel/templates/alias.bashrc.j2
@@ -191,7 +191,7 @@ pbindings(){
         rm -rf pulpcore-client
 
         # check server is up before proceeding in case server is autoreloading
-        for i in {1..5}; do http :24817/pulp/api/v3/status/ && break || sleep 5; done
+        for i in {1..5}; do http :24817{{ pulp_settings.api_root  | default("/pulp/") }}api/v3/status/ && break || sleep 5; done
     fi
 
     PULP_URL="{{ pulp_webserver_disable_https | default(false) | ternary('http', 'https') }}://{{ ansible_fqdn }}" ./generate.sh "$comp" "$lang" ${@:3}

--- a/roles/pulp_health_check/tasks/main.yml
+++ b/roles/pulp_health_check/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Ensure Pulp is up and healthy
   uri:
-    url: "http://{{ __pulp_default_host if pulp_api_bind.startswith('unix:') else pulp_api_bind }}/pulp/api/v3/status/"
+    url: "http://{{ __pulp_default_host if pulp_api_bind.startswith('unix:') else pulp_api_bind }}{{ pulp_settings.api_root  | default('/pulp/') }}api/v3/status/"
     status_code: "200"
     unix_socket: "{{ pulp_api_bind | regex_replace('^unix:', '') if pulp_api_bind.startswith('unix:') else omit }}"
     # Alternate between 30 second timeouts and 5 second timeouts when handling the situation of

--- a/roles/pulp_webserver/README.md
+++ b/roles/pulp_webserver/README.md
@@ -93,3 +93,5 @@ some of its variables.
   to '127.0.0.1:24816'.
 * `pulp_api_bind` Set the host the reverse proxy should connect to for the API server. Defaults
   to '127.0.0.1:24817'.
+* `pulp_settings`: A nested dictionary that is used to add custom values to the user's
+    `settings.py`.

--- a/roles/pulp_webserver/templates/nginx.conf.j2
+++ b/roles/pulp_webserver/templates/nginx.conf.j2
@@ -82,7 +82,7 @@ http {
             proxy_pass http://pulp-content;
         }
 
-        location /pulp/api/v3/ {
+        location {{ pulp_settings.api_root  | default("/pulp/") }}api/v3/ {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header Host $http_host;

--- a/roles/pulp_webserver/templates/pulp-vhost.conf.j2
+++ b/roles/pulp_webserver/templates/pulp-vhost.conf.j2
@@ -15,8 +15,8 @@ Define pulp-api {{ __pulp_webserver_apache_api_bind }}
   ProxyRequests Off
   ProxyPreserveHost Off
 
-  ProxyPass /pulp/api/v3 ${pulp-api}/pulp/api/v3
-  ProxyPassReverse /pulp/api/v3 ${pulp-api}/pulp/api/v3
+  ProxyPass {{ pulp_settings.api_root  | default("/pulp/") }}api/v3 ${pulp-api}{{ pulp_settings.api_root  | default("/pulp/") }}api/v3
+  ProxyPassReverse {{ pulp_settings.api_root  | default("/pulp/") }}api/v3 ${pulp-api}{{ pulp_settings.api_root  | default("/pulp/") }}api/v3
 
   ProxyPass /auth/login/ ${pulp-api}/auth/login/
   ProxyPassReverse /auth/login/ ${pulp-api}/auth/login/
@@ -70,8 +70,8 @@ Define pulp-api {{ __pulp_webserver_apache_api_bind }}
   ProxyRequests Off
   ProxyPreserveHost Off
 
-  ProxyPass /pulp/api/v3 ${pulp-api}/pulp/api/v3
-  ProxyPassReverse /pulp/api/v3 ${pulp-api}/pulp/api/v3
+  ProxyPass {{ pulp_settings.api_root  | default("/pulp/") }}api/v3 ${pulp-api}{{ pulp_settings.api_root  | default("/pulp/") }}api/v3
+  ProxyPassReverse {{ pulp_settings.api_root  | default("/pulp/") }}api/v3 ${pulp-api}{{ pulp_settings.api_root  | default("/pulp/") }}api/v3
 
   ProxyPass /auth/login/ ${pulp-api}/auth/login/
   ProxyPassReverse /auth/login/ ${pulp-api}/auth/login/


### PR DESCRIPTION
closes #892