### PR TITLE
Added `force_handlers: True` in every Playbook.

### DIFF
--- a/CHANGES/829.bugfix
+++ b/CHANGES/829.bugfix
@@ -1,0 +1,1 @@
+Added `force_handlers: True` in every Playbook in order to flush handlers even if some tasks fail. Because we decided that this change will leave the system in a better more correct state if something went wrong.

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -327,6 +327,7 @@ the database, redis & webserver.
 ```
 ---
 - hosts: example-pulp-server
+  force_handlers: True
   vars:
     pulp_default_admin_password: << YOUR PASSWORD FOR THE PULP APPLICATION HERE >>
     pulp_settings:
@@ -348,6 +349,7 @@ This deployment consists of a single Pulp server that relies on an existing data
 ```
 ---
 - hosts: example-pulp-server
+  force_handlers: True
   vars:
     pulp_default_admin_password: << YOUR PASSWORD FOR THE PULP APPLICATION HERE >>
     pulp_content_bind: example-pulp-server:24816
@@ -391,6 +393,7 @@ installed on it but no code will be running.
 ```
 ---
 - hosts: example-postgres-server
+  force_handlers: True
   vars:
     pulp_settings:
       databases:
@@ -403,12 +406,14 @@ installed on it but no code will be running.
     - pulp_database
 
 - hosts: example-redis-server
+  force_handlers: True
   vars:
     pulp_redis_bind: 'example-redis-server:6379'
   roles:
     - pulp_redis
 
 - hosts: example-pulp-server
+  force_handlers: True
   vars:
     pulp_default_admin_password: << YOUR PASSWORD FOR THE PULP APPLICATION HERE >>
     pulp_content_bind: example-pulp-server:24816
@@ -434,6 +439,7 @@ installed on it but no code will be running.
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings
 
 - hosts: example-webserver
+  force_handlers: True
   vars:
     pulp_content_bind: example-pulp-server:24816
     pulp_api_bind: example-pulp-server:24817
@@ -456,6 +462,7 @@ In this example, there are two Pulp worker servers.
 ```
 ---
 - hosts: example-postgres-server
+  force_handlers: True
   vars:
     pulp_settings:
       databases:
@@ -468,12 +475,14 @@ In this example, there are two Pulp worker servers.
     - pulp_database
 
 - hosts: example-redis-server
+  force_handlers: True
   vars:
     pulp_redis_bind: 'example-redis-server:6379'
   roles:
     - pulp_redis
 
 - hosts: example-pulp-api-server
+  force_handlers: True
   vars:
     pulp_default_admin_password: << YOUR PASSWORD FOR THE PULP APPLICATION HERE >>
     pulp_api_bind: example-pulp-api-server:24817
@@ -499,6 +508,7 @@ In this example, there are two Pulp worker servers.
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings
 
 - hosts: example-pulp-content-server
+  force_handlers: True
   vars:
     pulp_content_bind: example-pulp-content-server:24816
     pulp_settings:
@@ -524,6 +534,7 @@ In this example, there are two Pulp worker servers.
 - hosts:
    - example-pulp-worker-server1
    - example-pulp-worker-server2
+  force_handlers: True
   vars:
    pulp_settings:
      secret_key: << YOUR SECRET HERE >>
@@ -546,6 +557,7 @@ In this example, there are two Pulp worker servers.
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings
 
 - hosts: example-webserver
+  force_handlers: True
   vars:
    pulp_content_bind: example-pulp-server:24816
    pulp_api_bind: example-pulp-server:24817

--- a/docs/letsencrypt.md
+++ b/docs/letsencrypt.md
@@ -64,6 +64,7 @@ vim install.yml
 ```yaml
 ---
 - hosts: << domain name >>
+  force_handlers: True
   vars:
     pulp_webserver_httpd_servername: "{{ inventory_hostname }}"
     lets_encrypt_hostname: "{{ inventory_hostname }}"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,6 +53,7 @@ vim install.yml
 ```yaml
 ---
 - hosts: all
+  force_handlers: True
   vars:
     pulp_settings:
       secret_key: << YOUR SECRET HERE >>

--- a/molecule/release-dynamic/converge.yml
+++ b/molecule/release-dynamic/converge.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: all
+  force_handlers: True
   collections:
     - pulp.pulp_installer
   pre_tasks:

--- a/molecule/release-upgrade/converge.yml
+++ b/molecule/release-upgrade/converge.yml
@@ -1,6 +1,7 @@
 ---
 # Test upgrade to specific micro versions
 - hosts: all
+  force_handlers: True
   tasks:
     - set_fact:
         pulpcore_version: "3.14.5"
@@ -34,6 +35,7 @@
       when: ansible_facts.os_family == 'RedHat'
 # Test not updating (upgrade=false on a branch)
 - hosts: all
+  force_handlers: True
   tasks:
     - set_fact:
         pulpcore_version: "3.14"
@@ -71,6 +73,7 @@
       when: ansible_facts.os_family == 'RedHat'
 # Test updates (upgrade=true on a branch)
 - hosts: all
+  force_handlers: True
   tasks:
     - set_fact:
         pulpcore_version: "3.14"
@@ -108,6 +111,7 @@
       when: ansible_facts.os_family == 'RedHat'
 # Test upgrading to latest version (new branches but upgrade=false)
 - hosts: all
+  force_handlers: True
   tasks:
     - set_fact:
         pulpcore_version: "3.17"

--- a/molecule/source-dynamic/converge.yml
+++ b/molecule/source-dynamic/converge.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: all
+  force_handlers: True
   collections:
     - pulp.pulp_installer
   pre_tasks:

--- a/playbooks/example-source/playbook.yml
+++ b/playbooks/example-source/playbook.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: all
+  force_handlers: True
   pre_tasks:
     # The version string below is the highest of all those in roles' metadata:
     # "min_ansible_version". It needs to be kept manually up-to-date.

--- a/playbooks/example-use/playbook.yml
+++ b/playbooks/example-use/playbook.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: all
+  force_handlers: True
   pre_tasks:
     # The version string below is the highest of all those in roles' metadata:
     # "min_ansible_version". It needs to be kept manually up-to-date.

--- a/roles/pulp_devel/README.md
+++ b/roles/pulp_devel/README.md
@@ -9,6 +9,7 @@ Example Usage
 
 ```yaml
 - hosts: all
+  force_handlers: True
   roles:
     - pulp_all_services
     - pulp_devel

--- a/roles/pulp_rpm_prerequisites/README.md
+++ b/roles/pulp_rpm_prerequisites/README.md
@@ -17,6 +17,7 @@ Here's an example playbook for using pulp_rpm_prerequisites as part of pulp_inst
 
     ---
     - hosts: all
+      force_handlers: True
       vars:
         pulp_default_admin_password: << YOUR PASSWORD HERE >>
         pulp_settings:

--- a/roles/pulp_rpm_prerequisites/tests/test.yml
+++ b/roles/pulp_rpm_prerequisites/tests/test.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: localhost
+  force_handlers: True
   remote_user: root
   roles:
     - pulp_rpm_prerequisites

--- a/roles/pulp_services/README.md
+++ b/roles/pulp_services/README.md
@@ -44,6 +44,7 @@ Here's an example playbook for using pulp_services in pulp_installer. It assumes
 
     ---
     - hosts: all
+      force_handlers: True
       vars:
         pulp_default_admin_password: << YOUR PASSWORD FOR THE PULP APPLICATION HERE >>
         pulp_settings:


### PR DESCRIPTION
We added that  in order to flush handlers even if some tasks fail. Because we decided that this change will leave the system in a better more correct state if something went wrong.

## Playbooks                                                                                                                                                                                             
* [X] `playbooks/example-source/playbook.yml` 
* [X] `playbooks/example-use/playbook.yml`
* [X] `molecule/release-dynamic/converge.yml` 
* [X] `molecule/release-upgrade/converge.yml` 
* [X] `molecule/source-dynamic/converge.yml` 

## Docs
* [X] `roles/pulp_devel/README.md` 
* [X] `roles/pulp_rpm_prerequisites/README.md` 
* [X] `roles/pulp_rpm_prerequisites/tests/test.yml` 
* [X] `roles/pulp_services/README.md` 
* [X] `docs/quickstart.md` 
* [X] `docs/letsencrypt.md` 
* [X] `docs/customizing.md`

Fixes : https://github.com/pulp/pulp_installer/issues/829