### PR TITLE
Add `pulp.pulp_installer.pulp_repos` in Redis role.

### DIFF
--- a/CHANGES/894.bugfix
+++ b/CHANGES/894.bugfix
@@ -1,0 +1,1 @@
+Added `pulp.pulp_installer.pulp_repos` in `pulp_redis` dependencies and also in quickstart playbook example.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -72,13 +72,8 @@ vim install.yml
       # pulp-npm: {}
       # pulp-python: {}
       pulp-rpm: {}
-  # can be removed once this is resolved: https://pulp.plan.io/issues/8701
-  pre_tasks:
-    - name: install EPEL
-      yum:
-        name: epel-release
-      become: yes
   roles:
+    - pulp.pulp_installer.pulp_repos
     - pulp.pulp_installer.pulp_all_services
   environment:
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings

--- a/roles/pulp_common/vars/Fedora-33.yml
+++ b/roles/pulp_common/vars/Fedora-33.yml
@@ -1,0 +1,1 @@
+Fedora.yml

--- a/roles/pulp_common/vars/Fedora-35.yml
+++ b/roles/pulp_common/vars/Fedora-35.yml
@@ -1,0 +1,1 @@
+Fedora.yml

--- a/roles/pulp_redis/meta/main.yml
+++ b/roles/pulp_redis/meta/main.yml
@@ -22,4 +22,6 @@ galaxy_info:
   galaxy_tags:
     - pulp
     - pulpcore
-dependencies: []
+dependencies:
+  - pulp_common
+  - pulp_repos


### PR DESCRIPTION
* [X] Added in quickstart playbook example the `pulp.pulp_installer.pulp_repos` role instead of pre_tasks.
* [X] Added `pulp.pulp_installer.pulp_repos` in `pulp_redis` dependencies.

Fixes : pulp#894