### PR TITLE
Fix unexpected download failures.

### DIFF
--- a/CHANGES/903.dev
+++ b/CHANGES/903.dev
@@ -1,0 +1,1 @@
+Fixed unexpected download failures when we have the message `Failure downloading`.

--- a/molecule/release-static/prepare.yml
+++ b/molecule/release-static/prepare.yml
@@ -31,6 +31,7 @@
           delay: 12
           register: result
           until: result is succeeded
+          failed_when: result is failed or "Failure downloading" in result.msg
           when:
             - ansible_distribution == "CentOS"
             - ansible_distribution_version in ["8.3","8.4"]

--- a/molecule/source-static/prepare.yml
+++ b/molecule/source-static/prepare.yml
@@ -46,6 +46,7 @@
           delay: 12
           register: result
           until: result is succeeded
+          failed_when: result is failed or "Failure downloading" in result.msg
           when:
             - ansible_distribution == "CentOS"
             - ansible_distribution_version in ["8.3","8.4"]


### PR DESCRIPTION
When we have the message `Failure downloading` in `result.msg`.

* [X] `molecule/release-static/prepare.yml`
* [X] `molecule/source-static/prepare.yml`

Fixes : #903