### PR TITLE
Fix being unable to install from katello's latest

### DIFF
--- a/CHANGES/913.bugfix
+++ b/CHANGES/913.bugfix
@@ -1,0 +1,1 @@
+Fix being unable to install from katello's latest RPMs by no longer ignoring libcomps (reverts bugfix for #809)

--- a/roles/pulp_common/tasks/install_packages.yml
+++ b/roles/pulp_common/tasks/install_packages.yml
@@ -65,7 +65,6 @@
         conf_file: "{{ __dnf_conf.path | default(omit) }}"
         # update_only is a needed part of installing older updates
         update_only: true
-        exclude: '{{ pulp_pkg_exclude | default(omit) }}'
       notify:
         - Collect static content
         - Restart all Pulp services

--- a/roles/pulp_common/vars/CentOS-7.yml
+++ b/roles/pulp_common/vars/CentOS-7.yml
@@ -1,9 +1,4 @@
 ---
-# Fixes upgrading from older repos. libcomps-0.1.8-14.el7.x86_64 does not include a python2 subpackage.
-pulp_pkg_exclude:
-  - tfm-pulpcore-python3-libcomps-0.1.18-1.el7.x86_64
-  - libcomps-devel-0.1.18-1.el7.x86_64
-  - libcomps-0.1.18-1.el7.x86_64
 pulp_pkg_name_prefix: "tfm-pulpcore-python3-"
 pulp_preq_packages:
   # pip module doc: "The interpreter used by Ansible (see ansible_python_interpreter) requires the


### PR DESCRIPTION
RPMs by no longer ignoring libcomps
(reverts bugfix for #809)

fixes: #913