### PR TITLE
Fix SELinux labels not being not set on files

### DIFF
--- a/CHANGES/962.bugfix
+++ b/CHANGES/962.bugfix
@@ -1,0 +1,1 @@
+Fix SELinux errors due to labels not being set on multiple files created by the installer.

--- a/roles/galaxy_post_install/tasks/galaxy_importer.yml
+++ b/roles/galaxy_post_install/tasks/galaxy_importer.yml
@@ -10,11 +10,17 @@
       path: "/etc/galaxy-importer/"
       state: directory
       mode: '0755'
+      serole: _default
+      setype: _default
+      seuser: _default
 
   - name: Write galaxy-importer config
     template:
       src: galaxy-importer.cfg.j2
       dest: /etc/galaxy-importer/galaxy-importer.cfg
       mode: '0644'
+      serole: _default
+      setype: _default
+      seuser: _default
 
   become: true

--- a/roles/galaxy_post_install/tasks/setup_galaxy_api_access_log.yml
+++ b/roles/galaxy_post_install/tasks/setup_galaxy_api_access_log.yml
@@ -7,6 +7,9 @@
       owner: '{{ pulp_user }}'
       group: '{{ pulp_group }}'
       mode: "u+rw"
+      serole: _default
+      setype: _default
+      seuser: _default
     tags:
       - molecule-idempotence-notest
 
@@ -22,6 +25,9 @@
       owner: '{{ pulp_user }}'
       group: '{{ pulp_group }}'
       mode: "u+rw"
+      serole: _default
+      setype: _default
+      seuser: _default
     notify: Restart pulpcore-api.service post galaxy
 
   become: true

--- a/roles/galaxy_post_install/tasks/signing_service.yml
+++ b/roles/galaxy_post_install/tasks/signing_service.yml
@@ -5,6 +5,9 @@
     mode: 0600
     owner: "{{ pulp_user }}"
     group: "{{ pulp_group }}"
+    serole: _default
+    setype: _default
+    seuser: _default
   become: true
 
 - name: Set permissions on galaxy signing service script
@@ -59,5 +62,8 @@
     owner: '{{ pulp_user }}'
     group: '{{ pulp_group }}'
     mode: "u+rw"
+    serole: _default
+    setype: _default
+    seuser: _default
   notify: Restart all Pulp services
   become: true

--- a/roles/pulp_api/tasks/import_token_auth_key.yml
+++ b/roles/pulp_api/tasks/import_token_auth_key.yml
@@ -6,5 +6,8 @@
     owner: "{{ pulp_user }}"
     group: "{{ pulp_group }}"
     mode: 0600
+    serole: _default
+    setype: _default
+    seuser: _default
   become: true
   become_user: "{{ pulp_user }}"

--- a/roles/pulp_api/tasks/main.yml
+++ b/roles/pulp_api/tasks/main.yml
@@ -69,4 +69,7 @@
     owner: 'root'
     group: "{{ pulp_group }}"
     mode: 0640
+    serole: _default
+    setype: _default
+    seuser: _default
   become: true

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -58,7 +58,8 @@ __pulp_selinux_label_dirs:
   - "{{ pulp_config_dir }}"
   - "{{ pulp_user_home }}"
 __pulp_selinux_label_dirs_optional:
-  # Depending on the roles applied yet whether or not Pulp is running, these may
-  # not exist, throwing error code 255 when a called command realizes nothing
-  # is present.
+  # Depending on the roles applied yet & whether or not Pulp is running, these
+  # may not exist, throwing error code 255 when a called command realizes
+  # nothing is present.
   - "/var/run/pulpcore*"
+  - "/var/log/galaxy_api_access.log"

--- a/roles/pulp_common/handlers/main.yml
+++ b/roles/pulp_common/handlers/main.yml
@@ -22,11 +22,12 @@
 
 # shell for handling '*' in the dir name
 - name: Restore SELinux contexts on Pulp dirs that may exist
-  shell: '/sbin/fixfiles restore {{ __pulp_selinux_label_dirs_optional | join(" ") }}'  # noqa 305
+  shell: '/sbin/fixfiles restore {{ item }}'  # noqa 305
   become: true
   register: result
   changed_when: result.rc == 0
   failed_when: result.rc not in [0,255]
+  with_items: "{{ __pulp_selinux_label_dirs_optional }}"
   when:
     - ansible_facts.os_family == 'RedHat'
     - ansible_facts.selinux.status == "enabled"

--- a/roles/pulp_common/tasks/configure.yml
+++ b/roles/pulp_common/tasks/configure.yml
@@ -7,7 +7,9 @@
         owner: root
         group: '{{ pulp_group }}'
         mode: 0750
-      notify: Restore SELinux contexts on Pulp dirs that must exist
+        serole: _default
+        setype: _default
+        seuser: _default
 
     - name: Create configuration file for Pulp
       template:
@@ -17,6 +19,9 @@
         group: '{{ pulp_group }}'
         mode: 0640
         force: yes
+        serole: _default
+        setype: _default
+        seuser: _default
       notify: Restart all Pulp services
 
     - name: Create wrapper to call pulpcore-manager
@@ -35,6 +40,9 @@
         owner: root
         group: root
         mode: "0440"
+        serole: _default
+        setype: _default
+        seuser: _default
 
     - name: Include galaxy_ng post install role
       include_role:

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -157,6 +157,9 @@
         owner: '{{ pulp_user }}'
         group: '{{ pulp_group }}'
         mode: "u+rwx,g+rwx,o+rx"
+        serole: _default
+        setype: _default
+        seuser: _default
 
     - name: Create cache dir for Pulp
       file:
@@ -165,6 +168,9 @@
         owner: '{{ pulp_user }}'
         group: '{{ pulp_group }}'
         mode: "u+rwx,g+rwx,o+rx"
+        serole: _default
+        setype: _default
+        seuser: _default
 
     - name: Create scripts directory to hold user-provided scripts
       file:
@@ -181,6 +187,9 @@
         owner: "{{ pulp_user }}"
         group: "{{ pulp_group }}"
         mode: 0700
+        serole: _default
+        setype: _default
+        seuser: _default
 
     # If so, owner will be apache
     - name: Check if we have Pulp 2 installed

--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -223,6 +223,7 @@
         SETUPTOOLS_USE_DISTUTILS: stdlib
         PATH: "{{ pulp_path }}"
       notify:
+        - Restore SELinux contexts on Pulp dirs that must exist
         - Collect static content
         - Restart all Pulp services
 
@@ -252,6 +253,7 @@
         SETUPTOOLS_USE_DISTUTILS: stdlib
         PATH: "{{ pulp_path }}"
       notify:
+        - Restore SELinux contexts on Pulp dirs that must exist
         - Collect static content
         - Restart all Pulp services
       # Editable pip installs are always changed, which fails molecule's idempotence test.

--- a/roles/pulp_database_config/tasks/generate_database_fields_key.yml
+++ b/roles/pulp_database_config/tasks/generate_database_fields_key.yml
@@ -45,4 +45,7 @@
     owner: 'root'
     group: "{{ pulp_group }}"
     mode: 0640
+    serole: _default
+    setype: _default
+    seuser: _default
   become: true

--- a/roles/pulp_database_config/tasks/main.yml
+++ b/roles/pulp_database_config/tasks/main.yml
@@ -33,6 +33,9 @@
     owner: 'root'
     group: "{{ pulp_group }}"
     mode: 0640
+    serole: _default
+    setype: _default
+    seuser: _default
   notify: Restart all Pulp services
   when: pulp_db_fields_key | length
 

--- a/roles/pulp_webserver/tasks/apache.yml
+++ b/roles/pulp_webserver/tasks/apache.yml
@@ -48,6 +48,9 @@
         path: "{{ pulp_webserver_apache_snippets_dir }}"
         state: directory
         mode: '0755'
+        serole: _default
+        setype: _default
+        seuser: _default
 
     - name: Symlink Apache snippets
       script:

--- a/roles/pulp_webserver/tasks/generate_tls_certificates.yml
+++ b/roles/pulp_webserver/tasks/generate_tls_certificates.yml
@@ -17,6 +17,9 @@
     - name: Generate CA key
       openssl_privatekey:
         path: '{{ pulp_certs_dir }}/root.key'
+        serole: _default
+        setype: _default
+        seuser: _default
 
     - name: Generate CA CSR
       openssl_csr:
@@ -26,6 +29,9 @@
         organization_name: Pulp
         country_name: US
         basic_constraints: 'CA:TRUE'
+        serole: _default
+        setype: _default
+        seuser: _default
 
     - name: Generate CA certificate
       x509_certificate:
@@ -33,6 +39,9 @@
         csr_path: '{{ pulp_certs_dir }}/root.csr'
         privatekey_path: '{{ pulp_certs_dir }}/root.key'
         provider: selfsigned
+        serole: _default
+        setype: _default
+        seuser: _default
   when: not __pulp_webserver_ca_cert.stat.exists
 
 - name: Look for webserver certificate
@@ -50,6 +59,9 @@
         path: '{{ pulp_certs_dir }}/pulp_webserver.key'
         owner: root
         group: "{{ pulp_group }}"
+        serole: _default
+        setype: _default
+        seuser: _default
 
     - name: Generate CSRs standalone
       openssl_csr:
@@ -64,6 +76,9 @@
           - serverAuth
         owner: root
         group: "{{ pulp_group }}"
+        serole: _default
+        setype: _default
+        seuser: _default
 
     - name: Generate certificates
       x509_certificate:
@@ -76,6 +91,9 @@
         ownca_not_after: '+824d'
         owner: root
         group: "{{ pulp_group }}"
+        serole: _default
+        setype: _default
+        seuser: _default
       notify: reload {{ pulp_webserver_server }}
   when: not __pulp_webserver_cert.stat.exists
 

--- a/roles/pulp_webserver/tasks/import_certificates.yml
+++ b/roles/pulp_webserver/tasks/import_certificates.yml
@@ -7,6 +7,9 @@
     group: "{{ pulp_group }}"
     mode: 0600
     remote_src: "{{ pulp_webserver_tls_files_remote }}"
+    serole: _default
+    setype: _default
+    seuser: _default
   notify: reload {{ pulp_webserver_server }}
 
 - name: Import specified TLS private key
@@ -17,4 +20,7 @@
     group: "{{ pulp_group }}"
     mode: 0600
     remote_src: "{{ pulp_webserver_tls_files_remote }}"
+    serole: _default
+    setype: _default
+    seuser: _default
   notify: reload {{ pulp_webserver_server }}

--- a/roles/pulp_webserver/tasks/main.yml
+++ b/roles/pulp_webserver/tasks/main.yml
@@ -50,6 +50,9 @@
     owner: root
     group: root
     remote_src: "{{ pulp_webserver_tls_files_remote }}"
+    serole: _default
+    setype: _default
+    seuser: _default
   when: pulp_webserver_tls_custom_ca_cert is not mdellweg.filters.empty
   become: true
   notify: update ca trust
@@ -61,6 +64,9 @@
     mode: 0755
     owner: "{{ pulp_user }}"
     group: "{{ pulp_group }}"
+    serole: _default
+    setype: _default
+    seuser: _default
   become: true
   loop:
     - "{{ pulp_webserver_static_dir }}"

--- a/roles/pulp_webserver/tasks/nginx.yml
+++ b/roles/pulp_webserver/tasks/nginx.yml
@@ -48,6 +48,9 @@
         path: "/etc/nginx/pulp/"
         state: directory
         mode: '0755'
+        serole: _default
+        setype: _default
+        seuser: _default
 
     - name: Symlink nginx snippets
       script:


### PR DESCRIPTION
that are created by the installer.

There are 3 ways this is done:
1. serole/seuser/setype on files created before the handler
"Load the SELinux policy packages" gets run -
these are for when the installer is re-run, to correct drift.
2. serole/seuser/setype on files created after said handler -
these apply the actual selinux labels to the files.
3. The 2 handlers to restore contexts - these are needed for apply
the context to files created before the "Load" handler gets run,
and for recursion.

Note that in the future, we may replace the handlers that call commands
with `file` module tasks or handlers that recurse.

fixes: #962