### PR TITLE
Fix pulp_installer failing on

### DIFF
--- a/CHANGES/965.bugfix
+++ b/CHANGES/965.bugfix
@@ -1,0 +1,1 @@
+Fix pulp_installer failing on `pulp_common: Install prerequisites` on EL7 when pulp_database was not applied.

--- a/roles/pulp_common/tasks/main.yml
+++ b/roles/pulp_common/tasks/main.yml
@@ -118,6 +118,7 @@
     __pulp_repos_rhel_codeready_enable_default: True
     __pulp_repos_rhel_optional_enable_default: True
     __pulp_rhel_pulpcore_repo_enable_default: True
+    __pulp_rhel_scl_repo_enable_default: True
 
 - import_tasks: install.yml
 - import_tasks: configure.yml


### PR DESCRIPTION
`pulp_common: Install prerequisites` on EL7 when pulp_database
was not applied.

fixes: #965