### PR TITLE
Fix `pulp_common : Gather package facts` failing

### DIFF
--- a/CHANGES/969.bugfix
+++ b/CHANGES/969.bugfix
@@ -1,0 +1,1 @@
+Fix `pulp_common : Gather package facts` failing with a message like "no package manager found" when running pulp_common (e.g., pulp_api) against a minimal debian system.

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -2,13 +2,6 @@
 - name: General system changes before installation
   block:
 
-    - name: Update apt package index
-      apt:
-        update_cache: yes
-      when: ansible_facts.distribution == 'Debian'
-      # This is a lie, but necessary for Idempotence test
-      changed_when: False
-
     - name: Enable Python 3.8 module stream
       command: dnf -y module enable python38
       args:

--- a/roles/pulp_common/tasks/main.yml
+++ b/roles/pulp_common/tasks/main.yml
@@ -65,6 +65,16 @@
     - ansible_facts.distribution == 'CentOS'
     - ansible_facts.distribution_version|float < 7.7
 
+# This has to be before we Gather package facts so that ansible's apt module
+# can install python3-apt.
+# Otherwise, gathering facts will fail if this is the 1st role run.
+- name: Update apt package index
+  apt:
+    update_cache: yes
+  when: ansible_facts.distribution == 'Debian'
+  # This is a lie, but necessary for Idempotence test
+  changed_when: False
+
 - name: Gather package facts
   package_facts:
     manager: "auto"


### PR DESCRIPTION
when pulp_common is run against a minimal debian system.

fixes: #969