### PR TITLE
Fix `pulp_common Run pip-compile ...`

### DIFF
--- a/CHANGES/973.bugfix
+++ b/CHANGES/973.bugfix
@@ -1,0 +1,1 @@
+Fix `pulp_common Run pip-compile to check pulpcore/plugin compatibility` failing on EL7 when pulp_database is not run before pulp_common (e,g, pulp_api) is run.

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -35,7 +35,7 @@
 
     - name: Get PATH
       shell: |
-        {% if 'rh-postgresql10' in ansible_facts.packages %}
+        {% if 'rh-postgresql10-runtime' in ansible_facts.packages %}
           source /opt/rh/rh-postgresql10/enable
         {% endif %}
         env | grep -E '^PATH=' | sed 's/PATH=//g'
@@ -51,7 +51,7 @@
 
     - name: Get LD_LIBRARY_PATH
       shell: |
-        {% if 'rh-postgresql10' in ansible_facts.packages %}
+        {% if 'rh-postgresql10-runtime' in ansible_facts.packages %}
           source /opt/rh/rh-postgresql10/enable
         {% endif %}
         env | grep -E '^LD_LIBRARY_PATH=' | sed 's/LD_LIBRARY_PATH=//g'


### PR DESCRIPTION
failing on EL7 when pulp_database is not run before pulp_common
(e,g, pulp_api) is run.

fixes: #973