### PR TITLE
Fix release-upgrade CI

### DIFF
--- a/molecule/release-upgrade/converge.yml
+++ b/molecule/release-upgrade/converge.yml
@@ -5,6 +5,10 @@
   tasks:
     - set_fact:
         pulpcore_version: "3.14.5"
+        prereq_pip_packages:
+          - Jinja2
+          - pygments
+          - redis==4.1.4  # Needed to avoid a pulpcore 3.14 version conflict for dependency async-timeout
     - set_fact:
         pulp_install_plugins:
           pulp_file:

--- a/roles/pulp_common/templates/requirements.in.j2
+++ b/roles/pulp_common/templates/requirements.in.j2
@@ -21,3 +21,7 @@ git+{{ value['git_url']}}{{ value['git_revision'] | ternary('@', '') }}{{ value[
 {% endif %}
 
 {%- endfor %}
+
+{% for package in prereq_pip_packages %}
+{{ package }}
+{% endfor %}


### PR DESCRIPTION
It was failing with:
Could not find a version that matches async-timeout<4.0,>=3.0,>=4.0.2 (from redis==4.2.0->pulpcore==3.14.5->-r requirements.in (line 1))

[noissue]