### PR TITLE
Create a curlrc file to make curl use .netrc by default

### DIFF
--- a/.github/validate_commit_message.py
+++ b/.github/validate_commit_message.py
@@ -17,7 +17,7 @@ from github import Github
 
 
 NO_ISSUE = "[noissue]"
-CHANGELOG_EXTS = [".feature", ".bugfix", ".doc", ".removal", ".misc", ".deprecation"]
+CHANGELOG_EXTS = [".feature", ".bugfix", ".doc", ".removal", ".misc", ".deprecation", ".dev"]
 
 
 KEYWORDS = ["fixes", "closes"]

--- a/CHANGES/1005.dev
+++ b/CHANGES/1005.dev
@@ -1,0 +1,1 @@
+Added a .curlrc file with the parameter to check the .netrc

--- a/roles/pulp_devel/files/curlrc
+++ b/roles/pulp_devel/files/curlrc
@@ -1,0 +1,2 @@
+# Make curl check .netrc in home dir
+-n

--- a/roles/pulp_devel/tasks/config_files.yml
+++ b/roles/pulp_devel/tasks/config_files.yml
@@ -32,4 +32,11 @@
     dest: "{{ developer_user_home }}/.config/pulp_smash/settings.json"
     force: yes
     mode: 0600
+
+- name: Create ~/.curlrc if not already present
+  copy:
+    src: files/curlrc
+    dest: "{{ developer_user_home }}/.curlrc"
+    force: no
+    mode: '0644'
 ...


### PR DESCRIPTION
By default, curl does not check the ~/.netrc file. This commit
configures a .curlrc that will add the '-n' parameter to curl execution.