### PR TITLE
nginx confg: Set server_tokens to off

### DIFF
--- a/roles/pulp_webserver/templates/nginx.conf.j2
+++ b/roles/pulp_webserver/templates/nginx.conf.j2
@@ -15,6 +15,7 @@ http {
     include mime.types;
     # fallback in case we can't determine a type
     default_type application/octet-stream;
+    server_tokens off;
     sendfile on;
 
     # If left at the default of 1024, nginx emits a warning about being unable


### PR DESCRIPTION
Set server_tokens to off so nginx version is not leaked.

[noissue]