### PR TITLE
Fix pulpcore-resource-manager.service still existing

### DIFF
--- a/CHANGES/1016.bugfix
+++ b/CHANGES/1016.bugfix
@@ -1,0 +1,1 @@
+Fix `pulp_health_check : Checking Pulp services` sometimes failing during upgrades due to the pulpcore-resource-manager service still exisitng.

--- a/roles/pulp_workers/tasks/main.yml
+++ b/roles/pulp_workers/tasks/main.yml
@@ -20,12 +20,15 @@
         name: pulpcore-resource-manager.service
         state: stopped
         enabled: false
-        daemon_reload: true
 
     - name: Remove pulpcore-resource-manager service
       file:
         path: /lib/systemd/system/pulpcore-resource-manager.service
         state: absent
+
+    - name: Reload systemd for the pulpcore-resource-manager removal
+      systemd:
+        daemon_reload: true
 
   become: true
   when:


### PR DESCRIPTION
sometimes during upgrades.

Was causing `pulp_health_check : Checking Pulp services` to fail.

fixes: #1016