### PR TITLE
Update pulpcore-selinux to 1.3.1 to support the

### DIFF
--- a/CHANGES/1022.feature
+++ b/CHANGES/1022.feature
@@ -1,0 +1,1 @@
+Update the SELinux polcies (pulpcore-selinux) to 1.3.1 to support the galaxy-importer plugin.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -59,7 +59,7 @@ __pulp_selinux_policy_pkgs:
   - pulpcore
   - pulpcore_rhsmcertd
 __pulp_selinux_repo: 'https://github.com/pulp/pulpcore-selinux.git'
-__pulp_selinux_version: '1.3.0'
+__pulp_selinux_version: '1.3.1'
 __pulp_selinux_label_dirs:
   - "{{ pulp_install_dir }}"
   - "{{ pulp_config_dir }}"


### PR DESCRIPTION
galaxy-importer plugin.

fixes: #1022