### PR TITLE
Do not add the pulpcore RPM repository to systems

### DIFF
--- a/CHANGES/1046.bugfix
+++ b/CHANGES/1046.bugfix
@@ -1,0 +1,1 @@
+On EL7 & EL8, do not add the pulpcore RPM repository to systems when pulp_install_source=="pip".

--- a/roles/pulp_repos/README.md
+++ b/roles/pulp_repos/README.md
@@ -18,11 +18,11 @@ With its defaults.
 * `pulp_repos_enable`: Effectively can disable enablement of all repositories mentioned below.
   Defaults to `True`.
 
-* `pulp_repos_centos_powertools_repo_enable`: to enable PowerTools repository (defaults to `True`)
+* `pulp_repos_centos_powertools_repo_enable`: to enable CentOS 8 PowerTools repository (defaults to `True`)
 * `pulp_repos_epel_enable`: to enable EPEL repository (defaults to `True`)
-* `pulp_repos_rhel_codeready_enable`: to enable RHEL CodeReady repository (defaults to `True`)
-* `pulp_repos_rhel_optional_enable`: to enable RHEL Optional repository (defaults to `True`)
-* `pulp_rhel_pulpcore_repo_enable`: to enable RHEL Pulpcore repo (defaults to `True`).
+* `pulp_repos_rhel_codeready_enable`: to enable RHEL8 CodeReady repository (defaults to `True`)
+* `pulp_repos_rhel_optional_enable`: to enable RHEL7 Optional repository (defaults to `True`)
+* `pulp_rhel_pulpcore_repo_enable`: to add the RHEL/CentOS Pulpcore repo to the system (defaults to `True`).
 * `pulp_rhel_scl_repo_enable`: to enable SCL repository (defaults to `True`).
 
 * `pulp_rhel_codeready_repo`: List of possible names for rhel8+ CodeReady Builder repo
@@ -58,6 +58,11 @@ These variables corresponding to role repository variables above when is called 
 * `__pulp_repos_rhel_optional_enable_default`: Defaults to `False`
 * `__pulp_rhel_pulpcore_repo_enable_default`: Defaults to `False`
 * `__pulp_rhel_scl_repo_enable_default`: Defaults to `False`
+
+Shared Variables
+----------------
+* `pulp_install_source`: If set to `packages`, and pulp_rhel_pulpcore_repo_enable==true, Add the
+  pulpcore repo to the system.
 
 ### Example
 

--- a/roles/pulp_repos/defaults/main.yml
+++ b/roles/pulp_repos/defaults/main.yml
@@ -25,6 +25,8 @@ __pulp_pkg_repo_gpgkey: "{{ pulp_pkg_repo.rstrip('/') }}/../../GPG-RPM-KEY-pulpc
 pulp_pkg_repo: "https://yum.theforeman.org/pulpcore/3.17/el{{ ansible_distribution_major_version }}/$basearch/"
 pulp_pkg_repo_gpgcheck: True
 
+pulp_install_source: pip
+
 pulp_rhel_codeready_repo:
   - codeready-builder-for-rhel-8-x86_64-rpms
   - rhui-codeready-builder-for-rhel-8-rhui-rpms

--- a/roles/pulp_repos/tasks/main.yml
+++ b/roles/pulp_repos/tasks/main.yml
@@ -173,9 +173,8 @@
     src: pulpcore.repo.j2
     dest: /etc/yum.repos.d/pulpcore.repo
     mode: '0644'
-
   when:
     - ansible_facts.os_family == "RedHat"
-    - pulp_pkg_repo is not none
+    - pulp_install_source == "packages"
     - __pulp_rhel_pulpcore_repo_enable_default and pulp_rhel_pulpcore_repo_enable and pulp_repos_enable
   become: true


### PR DESCRIPTION
when pulp_install_source=="pip".

fixes: #1046