### PR TITLE
3.18 backport: Fix init_t SELinux errors from pulp application

### DIFF
--- a/CHANGES/1023.bugfix
+++ b/CHANGES/1023.bugfix
@@ -1,0 +1,1 @@
+When in `pip` install mode, fix SELinux accidentally blocking the pulp appplication from doing certain tasks. This was due to the pulp application during the install (before it completes) getting accidentally labeled as init_t.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -70,3 +70,6 @@ __pulp_selinux_label_dirs_optional:
   # nothing is present.
   - "/var/run/pulpcore*"
   - "/var/log/galaxy_api_access.log"
+__pulp_binaries:
+  - "{{ pulp_install_dir }}/bin/gunicorn"
+  - "{{ pulp_install_dir }}/bin/pulpcore-worker"

--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -269,6 +269,21 @@
       tags:
         - molecule-idempotence-notest
 
+    # As soon as the pulpcore binaries are installed, we need to label them. So no pulp processes
+    # are started mid-install under the wrong context.
+    - name: Set SELinux contexts on pulpcore's binaries
+      file:
+        path: "{{ item }}"
+        serole: _default
+        setype: _default
+        seuser: _default
+      with_items: "{{ __pulp_binaries }}"
+      when:
+        - ansible_facts.os_family == 'RedHat'
+        # when permissive or enforcing. That would be stored in .mode & .config_mode
+        - pulp_install_selinux_policies|bool or
+          (ansible_facts.selinux.status == "enabled" and pulp_install_selinux_policies == "auto")
+
     # We have to do this separate task, even though the pip module should
     # register the installed version, because when tested (Ansible 2.9, with no
     # changes applied), the registered result from "Install pulpcore package


### PR DESCRIPTION
during the middle of the installation

fixes: #1023

(cherry picked from commit dcabbcf8f6650bda2d0428e1e40bae5fc9a55156)