### PR TITLE
pulp_common: Always add EPEL on EL7.

### DIFF
--- a/CHANGES/1071.bugfix
+++ b/CHANGES/1071.bugfix
@@ -1,0 +1,1 @@
+pulp_common: Always add EPEL on EL7. Prevents a libmodulemd2 package error when installing from packages.

--- a/roles/pulp_common/tasks/main.yml
+++ b/roles/pulp_common/tasks/main.yml
@@ -124,7 +124,7 @@
     name: pulp_repos
   vars:
     __pulp_repos_centos_powertools_repo_enable_default: True
-    __pulp_repos_epel_enable_default: '{{ (pulp_install_source == "packages") | ternary(false, true) }}'
+    # __pulp_repos_epel_enable_default: comes from the role
     __pulp_repos_rhel_codeready_enable_default: True
     __pulp_repos_rhel_optional_enable_default: True
     __pulp_rhel_pulpcore_repo_enable_default: True

--- a/roles/pulp_common/vars/CentOS-7.yml
+++ b/roles/pulp_common/vars/CentOS-7.yml
@@ -21,3 +21,6 @@ pulp_python_cryptography:
   - python2-cryptography
 # Used by galaxy_post_install, which doesn't have per-distro vars yet
 __pulp_gpg_inspect_command: "gpg --with-fingerprint"
+
+# Needed for libmodulemd2 on EL7, even when installing from packages
+__pulp_repos_epel_enable_default: true

--- a/roles/pulp_common/vars/CentOS-8.yml
+++ b/roles/pulp_common/vars/CentOS-8.yml
@@ -19,3 +19,4 @@ pulp_python_cryptography:
   - python3-cryptography
 # Used by galaxy_post_install, which doesn't have per-distro vars yet
 __pulp_gpg_inspect_command: "gpg --import-options show-only --import --with-fingerprint"
+__pulp_repos_epel_enable_default: '{{ (pulp_install_source == "packages") | ternary(false, true) }}'

--- a/roles/pulp_common/vars/RedHat-9.yml
+++ b/roles/pulp_common/vars/RedHat-9.yml
@@ -19,3 +19,4 @@ pulp_python_cryptography:
   - python3-cryptography
 # Used by galaxy_post_install, which doesn't have per-distro vars yet
 __pulp_gpg_inspect_command: "gpg --import-options show-only --import --with-fingerprint"
+__pulp_repos_epel_enable_default: '{{ (pulp_install_source == "packages") | ternary(false, true) }}'

--- a/roles/pulp_repos/defaults/main.yml
+++ b/roles/pulp_repos/defaults/main.yml
@@ -2,7 +2,7 @@
 pulp_repos_enable: True
 
 __pulp_repos_epel_enable_default: False
-pulp_repos_epel_enable: '{{ (pulp_install_source == "packages") | ternary(false, true) }}'
+pulp_repos_epel_enable: True
 
 __pulp_repos_rhel_optional_enable_default: False
 pulp_repos_rhel_optional_enable: True


### PR DESCRIPTION
Prevents a libmodulemd2 package error when installing from packages

Fixes: #1071