### PR TITLE
galaxy-ng plugin: Keep requirements locked for

### DIFF
--- a/CHANGES/1073.bugfix
+++ b/CHANGES/1073.bugfix
@@ -1,0 +1,1 @@
+When installing the `galaxy-ng` plugin from source, only unlock its version requirements if the "main" branch is used, or if the branch (`git_revision`) is unspecified.

--- a/roles/pulp_common/README.md
+++ b/roles/pulp_common/README.md
@@ -220,6 +220,14 @@ Role Variables for advanced usage
    By default the installer will do the right thing by using the minor version of pulpcore it is designed
    for and tested with. This can also be a specific patch release (e.g.: `3.15.2`).
 * `pulp_service_timeout`: Set timeout value for pulp services. Defaults to 90.
+* `galaxy_lock_requirements`: If set to 0, when installing the plugin `galaxy-ng` from a source
+  directory (e.g., cloned via git), unlock the version requirements (i.e., install the latest versions)
+  of its dependency plugins, which are listed in `galaxy_dev_source_path`. If set to `1`, the version
+  constraints that galaxy-ng has for them are preserved. Defaults to `0` if galaxy-ng's `git_revision`
+  isn't specified or if it is set to "main". Defaults to `1` if galaxy-ng's `git_revision` is set to
+  any other git commitish (e.g., another branch.)
+* `galaxy_dev_source_path`: See `galaxy_lock_requirements`. Defaults to
+  `pulpcore:pulp_ansible:pulp_container:galaxy_ng:galaxy-importer`.
 
 Shared Variables
 ----------------

--- a/roles/pulp_common/vars/main.yml
+++ b/roles/pulp_common/vars/main.yml
@@ -47,7 +47,10 @@ __pulp_artifact_dir: "{{ pulp_media_root | regex_replace('\\/$', '')  }}/artifac
 
 __galaxy_profile: '{{ galaxy_profile | default("standalone") }}'
 __galaxy_dev_source_path: '{{ galaxy_dev_source_path | default("pulpcore:pulp_ansible:pulp_container:galaxy_ng:galaxy-importer") }}'
-__galaxy_lock_requirements: '{{ galaxy_lock_requirements | default(0) }}'
+# Set to 0 (unlock version requirements of __galaxy_dev_source_path) for main branch, the default branch for the repo
+# Set to 1 (keep requirements locked) for release branches
+__galaxy_lock_requirements_auto: "{{ ((pulp_install_plugins_normalized['galaxy-ng']['git_revision'] | default('main')) == 'main') | ternary('0','1') }}"
+__galaxy_lock_requirements: '{{ galaxy_lock_requirements | default(__galaxy_lock_requirements_auto) }}'
 
 # Pulps own replacement for django-admin setup in the proper environment
 pulp_django_admin_path: "{{ pulp_install_dir }}/bin/pulpcore-manager"


### PR DESCRIPTION
branches other than "main".

fixes: #1073