### PR TITLE
Fix pip-tools / pip error

### DIFF
--- a/CHANGES/1100.bugfix
+++ b/CHANGES/1100.bugfix
@@ -1,0 +1,1 @@
+Fix occassional error on `Run pip-compile to check pulpcore/plugin compatibility` with error message `ImportError: cannot import name 'BAR_TYPES' from 'pip._internal.cli.progress_bars'`.

--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -133,7 +133,7 @@
     - name: Install pip-tools, which provides pip-compile to check version compatibility
       pip:
         name:
-          - pip-tools>=5.2.0
+          - pip-tools>=6.6.1
           - importlib-metadata
         state: present
         virtualenv: '{{ pulp_install_dir }}'


### PR DESCRIPTION
ImportError: cannot import name 'BAR_TYPES' from
'pip._internal.cli.progress_bars'

[noissue]