### PR TITLE
docs: Remove empty dictionaries from pulp_install_plugins

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -34,8 +34,8 @@ purposes.
       secret_key: << YOUR SECRET HERE >>
       content_origin: "http://{{ ansible_facts.fqdn }}"
     pulp_install_plugins:
-      pulp-container: {}
-      pulp-rpm: {}
+      pulp-container:
+      pulp-rpm:
   roles:
     - pulp_all_services
   environment:
@@ -71,8 +71,8 @@ existing and external. No new servers are used or created for them:
           USER: pulp
           PASSWORD: << YOUR DATABASE PASSWORD HERE >>
     pulp_install_plugins:
-      pulp-container: {}
-      pulp-rpm: {}
+      pulp-container:
+      pulp-rpm:
   roles:
     - pulp_services
     - pulp_health_check
@@ -135,8 +135,8 @@ This scenario has the following layout:
           USER: pulp
           PASSWORD: << YOUR DATABASE PASSWORD HERE >>
     pulp_install_plugins:
-      pulp-container: {}
-      pulp-rpm: {}
+      pulp-container:
+      pulp-rpm:
   roles:
     - pulp_services
   environment:
@@ -207,8 +207,8 @@ This is performed by re-running the installer with additional hosts (such as `ex
           USER: pulp
           PASSWORD: << YOUR DATABASE PASSWORD HERE >>
     pulp_install_plugins:
-      pulp-container: {}
-      pulp-rpm: {}
+      pulp-container:
+      pulp-rpm:
   roles:
     - pulp_services
     - pulp_health_check
@@ -285,8 +285,8 @@ This is performed by re-running the installer with additional hosts (such as
           USER: pulp
           PASSWORD: << YOUR DATABASE PASSWORD HERE >>
     pulp_install_plugins:
-      pulp-container: {}
-      pulp-rpm: {}
+      pulp-container:
+      pulp-rpm:
   roles:
     - pulp_api
     - pulp_database_config
@@ -312,8 +312,8 @@ This is performed by re-running the installer with additional hosts (such as
           USER: pulp
           PASSWORD: << YOUR DATABASE PASSWORD HERE >>
     pulp_install_plugins:
-      pulp-container: {}
-      pulp-rpm: {}
+      pulp-container:
+      pulp-rpm:
   roles:
     - pulp_content
   environment:
@@ -337,8 +337,8 @@ This is performed by re-running the installer with additional hosts (such as
           USER: pulp
           PASSWORD: << YOUR DATABASE PASSWORD HERE >>
     pulp_install_plugins:
-      pulp-container: {}
-      pulp-rpm: {}
+      pulp-container:
+      pulp-rpm:
   roles:
     - pulp_workers
   environment:
@@ -426,8 +426,8 @@ Webservers.
           USER: pulp
           PASSWORD: << YOUR DATABASE PASSWORD HERE >>
     pulp_install_plugins:
-      pulp-container: {}
-      pulp-rpm: {}
+      pulp-container:
+      pulp-rpm:
   roles:
     - pulp_api
     - pulp_database_config
@@ -456,8 +456,8 @@ Webservers.
           USER: pulp
           PASSWORD: << YOUR DATABASE PASSWORD HERE >>
     pulp_install_plugins:
-      pulp-container: {}
-      pulp-rpm: {}
+      pulp-container:
+      pulp-rpm:
   roles:
     - pulp_content
   environment:
@@ -484,8 +484,8 @@ Webservers.
           USER: pulp
           PASSWORD: << YOUR DATABASE PASSWORD HERE >>
     pulp_install_plugins:
-      pulp-container: {}
-      pulp-rpm: {}
+      pulp-container:
+      pulp-rpm:
   roles:
     - pulp_workers
   environment:

--- a/docs/customizing.md
+++ b/docs/customizing.md
@@ -24,7 +24,7 @@ Some of the installer's variables, `pulp_settings` and `pulp_install_plugins` in
 ```
   vars:
     pulp_install_plugins:
-       pulp-container: {}
+       pulp-container:
        pulp-deb:
          upgrade: true
       pulp-file:
@@ -69,7 +69,7 @@ In the following example, a multitude of variables are set:
     pulpcore_update: true
     pulp_workers: 4
     pulp_install_plugins:
-      pulp-container: {}
+      pulp-container:
       pulp-deb:
         upgrade: true
       pulp-file:
@@ -155,9 +155,9 @@ Example `pulp_install_plugins`:
 ```
   vars:
     pulp_install_plugins:
-      pulp-container: {}
-      pulp-file: {}
-      pulp-rpm: {}
+      pulp-container:
+      pulp-file:
+      pulp-rpm:
 ```
 
 Upgrading your installation:

--- a/docs/letsencrypt.md
+++ b/docs/letsencrypt.md
@@ -72,19 +72,19 @@ vim install.yml
     lets_encrypt_directories_data: "/var/lib/pulp/pulpcore_static"
     pulp_default_admin_password: << YOUR PASSWORD HERE >>
     pulp_install_plugins:
-      # galaxy-ng: {}
-      # pulp-2to3-migration: {}
-      # pulp-ansible: {}
-      # pulp-certguard: {}
-      # pulp-container: {}
-      # pulp-cookbook: {}
-      # pulp-deb: {}
-      pulp-file: {}
-      # pulp-gem: {}
-      # pulp-maven: {}
-      # pulp-npm: {}
-      # pulp-python: {}
-      # pulp-rpm: {}
+      # galaxy-ng:
+      # pulp-2to3-migration:
+      # pulp-ansible:
+      # pulp-certguard:
+      # pulp-container:
+      # pulp-cookbook:
+      # pulp-deb:
+      pulp-file:
+      # pulp-gem:
+      # pulp-maven:
+      # pulp-npm:
+      # pulp-python:
+      # pulp-rpm:
     pulp_settings:
       secret_key: << YOUR SECRET HERE >>
       content_origin: "https://{{ inventory_hostname }}"

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -67,19 +67,19 @@ vim install.yml
       content_origin: "https://{{ ansible_fqdn }}"
     pulp_default_admin_password: << YOUR PASSWORD HERE >>
     pulp_install_plugins:
-      # galaxy-ng: {}
-      # pulp-2to3-migration: {}
-      # pulp-ansible: {}
-      # pulp-certguard: {}
-      pulp-container: {}
-      # pulp-cookbook: {}
-      # pulp-deb: {}
-      # pulp-file: {}
-      # pulp-gem: {}
-      # pulp-maven: {}
-      # pulp-npm: {}
-      # pulp-python: {}
-      pulp-rpm: {}
+      # galaxy-ng:
+      # pulp-2to3-migration:
+      # pulp-ansible:
+      # pulp-certguard:
+      pulp-container:
+      # pulp-cookbook:
+      # pulp-deb:
+      # pulp-file:
+      # pulp-gem:
+      # pulp-maven:
+      # pulp-npm:
+      # pulp-python:
+      pulp-rpm:
   roles:
     - pulp.pulp_installer.pulp_all_services
   environment:

--- a/example.user-config.yml
+++ b/example.user-config.yml
@@ -1,20 +1,20 @@
 ---
 pulp_default_admin_password: password
 pulp_install_plugins:
-  # galaxy-ng: {}
-  # pulp-2to3-migration: {}
-  # pulp-ansible: {}
-  # pulp-certguard: {}
-  # pulp-cookbook: {}
-  # pulp-deb: {}
-  # pulp-container: {}
-  pulp-file: {}
-  # pulp-gem: {}
-  # pulp-maven: {}
-  # pulp-npm: {}
-  # pulp-ostree: {}
-  # pulp-python: {}
-  # pulp-rpm: {}
+  # galaxy-ng:
+  # pulp-2to3-migration:
+  # pulp-ansible:
+  # pulp-certguard:
+  # pulp-cookbook:
+  # pulp-deb:
+  # pulp-container:
+  pulp-file:
+  # pulp-gem:
+  # pulp-maven:
+  # pulp-npm:
+  # pulp-ostree:
+  # pulp-python:
+  # pulp-rpm:
 
 # # Uncomment to prevent https configuration
 # pulp_webserver_disable_https: true

--- a/molecule/release-galaxy/group_vars/all
+++ b/molecule/release-galaxy/group_vars/all
@@ -6,7 +6,7 @@ prereq_pip_packages:
   - Jinja2
   - pygments
 pulp_install_plugins:
-  galaxy-ng: {}
+  galaxy-ng:
 pulp_settings:
   secret_key: secret
   content_origin: "{{ pulp_webserver_disable_https | default(false) | ternary('http', 'https') }}://{{ ansible_fqdn }}"

--- a/molecule/release-static/group_vars/all
+++ b/molecule/release-static/group_vars/all
@@ -3,18 +3,18 @@ pulp_default_admin_password: password
 pulp_api_bind: "unix:/var/run/pulpcore-api/pulpcore-api.sock"
 pulp_content_bind: "unix:/var/run/pulpcore-content/pulpcore-content.sock"
 pulp_install_plugins:
-  # galaxy-ng: {}
-  # pulp-ansible: {}
-  # pulp-certguard: {}
-  pulp-container: {}
-  # pulp-cookbook: {}
-  # pulp-deb: {}
-  pulp-file: {}
-  # pulp-gem: {}
-  # pulp-maven: {}
-  # pulp-npm: {}
-  # pulp-python: {}
-  pulp-rpm: {}
+  # galaxy-ng:
+  # pulp-ansible:
+  # pulp-certguard:
+  pulp-container:
+  # pulp-cookbook:
+  # pulp-deb:
+  pulp-file:
+  # pulp-gem:
+  # pulp-maven:
+  # pulp-npm:
+  # pulp-python:
+  pulp-rpm:
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"

--- a/molecule/release-static/host_vars/debian-11
+++ b/molecule/release-static/host_vars/debian-11
@@ -1,14 +1,14 @@
 ansible_python_interpreter: /usr/bin/python3
 pulp_install_plugins:
-  # galaxy-ng: {}
-  # pulp-ansible: {}
-  # pulp-certguard: {}
-  # pulp-container: {}
-  # pulp-cookbook: {}
-  # pulp-deb: {}
-  pulp-file: {}
-  # pulp-gem: {}
-  # pulp-maven: {}
-  # pulp-npm: {}
-  # pulp-python: {}
-  # pulp-rpm: {}
+  # galaxy-ng:
+  # pulp-ansible:
+  # pulp-certguard:
+  # pulp-container:
+  # pulp-cookbook:
+  # pulp-deb:
+  pulp-file:
+  # pulp-gem:
+  # pulp-maven:
+  # pulp-npm:
+  # pulp-python:
+  # pulp-rpm:

--- a/playbooks/example-azure-use/group_vars/all
+++ b/playbooks/example-azure-use/group_vars/all
@@ -2,19 +2,19 @@
 pulp_default_admin_password: password
 pulp_install_object_storage: azure
 pulp_install_plugins:
-  # galaxy-ng: {}
-  # pulp-2to3-migration: {}
-  # pulp-ansible: {}
-  # pulp-certguard: {}
-  # pulp-container: {}
-  # pulp-cookbook: {}
-  # pulp-deb: {}
-  pulp-file: {}
-  # pulp-gem: {}
-  # pulp-maven: {}
-  # pulp-npm: {}
-  # pulp-python: {}
-  # pulp-rpm: {}
+  # galaxy-ng:
+  # pulp-2to3-migration:
+  # pulp-ansible:
+  # pulp-certguard:
+  # pulp-container:
+  # pulp-cookbook:
+  # pulp-deb:
+  pulp-file:
+  # pulp-gem:
+  # pulp-maven:
+  # pulp-npm:
+  # pulp-python:
+  # pulp-rpm:
 pulp_settings:
   secret_key: secret
   content_origin: "{{ pulp_webserver_disable_https | default(false) | ternary('http', 'https') }}://{{ ansible_fqdn }}"

--- a/playbooks/example-s3-use/group_vars/all
+++ b/playbooks/example-s3-use/group_vars/all
@@ -2,19 +2,19 @@
 pulp_default_admin_password: password
 pulp_install_object_storage: s3
 pulp_install_plugins:
-  # galaxy-ng: {}
-  # pulp-2to3-migration: {}
-  # pulp-ansible: {}
-  # pulp-certguard: {}
-  # pulp-container: {}
-  # pulp-cookbook: {}
-  # pulp-deb: {}
-  pulp-file: {}
-  # pulp-gem: {}
-  # pulp-maven: {}
-  # pulp-npm: {}
-  # pulp-python: {}
-  # pulp-rpm: {}
+  # galaxy-ng:
+  # pulp-2to3-migration:
+  # pulp-ansible:
+  # pulp-certguard:
+  # pulp-container:
+  # pulp-cookbook:
+  # pulp-deb:
+  pulp-file:
+  # pulp-gem:
+  # pulp-maven:
+  # pulp-npm:
+  # pulp-python:
+  # pulp-rpm:
 pulp_settings:
   secret_key: secret
   content_origin: "{{ pulp_webserver_disable_https | default(false) | ternary('http', 'https') }}://{{ ansible_fqdn }}"

--- a/playbooks/example-use/group_vars/all
+++ b/playbooks/example-use/group_vars/all
@@ -1,20 +1,20 @@
 ---
 pulp_default_admin_password: password
 pulp_install_plugins:
-  # galaxy-ng: {}
-  # pulp-2to3-migration: {}
-  # pulp-ansible: {}
-  # pulp-certguard: {}
-  # pulp-container: {}
-  # pulp-cookbook: {}
-  # pulp-deb: {}
-  pulp-file: {}
-  # pulp-gem: {}
-  # pulp-maven: {}
-  # pulp-npm: {}
-  # pulp-ostree: {}
-  # pulp-python: {}
-  # pulp-rpm: {}
+  # galaxy-ng:
+  # pulp-2to3-migration:
+  # pulp-ansible:
+  # pulp-certguard:
+  # pulp-container:
+  # pulp-cookbook:
+  # pulp-deb:
+  pulp-file:
+  # pulp-gem:
+  # pulp-maven:
+  # pulp-npm:
+  # pulp-ostree:
+  # pulp-python:
+  # pulp-rpm:
 pulp_settings:
   secret_key: secret
   content_origin: "{{ pulp_webserver_disable_https | default(false) | ternary('http', 'https') }}://{{ ansible_fqdn }}"

--- a/roles/pulp_all_services/README.md
+++ b/roles/pulp_all_services/README.md
@@ -10,18 +10,18 @@ are subject to change. The exception is when they want certain services
 on certain hosts.
 
 Currently, all it does is depend on the required roles, which are
-subject to change over time:
+subject to change over time. They are specified in the following order:
 
   - pulp_database
   - pulp_redis
   - pulp_services
+  - pulp_database_config (implicitly via pulp_services)
+  - pulp_api (implicitly via pulp_services)
+  - pulp_content (implicitly via pulp_services)
+  - pulp_workers (implicitly via pulp_services)
+  - pulp_common (implicitly via pulp_services)
   - pulp_health_check
   - pulp_webserver
-  - pulp_database_config (implicitly)
-  - pulp_api (implicitly)
-  - pulp_content (implicitly)
-  - pulp_workers (implicitly)
-  - pulp_common (implicitly)
 
 Related Roles
 -------------

--- a/roles/pulp_common/README.md
+++ b/roles/pulp_common/README.md
@@ -38,7 +38,7 @@ Role Variables
     ```yaml
     pulp_install_source: pip
     pulp_install_plugins:
-      pulp-zero: {}
+      pulp-zero:
       pulp-one: # plugin name (pulp-ansible, pulp-container, pulp-rpm, ...)
         version: "1.0.1" # specific release (pulp-file-0.3.0)
       pulp-two:
@@ -185,7 +185,7 @@ Furthermore, the following variables are used, or behave *differently* from abov
     ```yaml
     pulp_install_source: packages
     pulp_install_plugins:
-      pulp-zero: {} # Effectively python3-pulp-zero
+      pulp-zero: # Effectively python3-pulp-zero
       pulp-one:
         pkg_name: python3-pulp-one-ng
       pulp-two:

--- a/roles/pulp_rpm_prerequisites/README.md
+++ b/roles/pulp_rpm_prerequisites/README.md
@@ -24,7 +24,7 @@ Here's an example playbook for using pulp_rpm_prerequisites as part of pulp_inst
           secret_key: << YOUR SECRET HERE >>
           content_origin: "https://{{ ansible_facts.fqdn }}"
         pulp_install_plugins:
-          pulp-rpm: {} #no need to set subvar prereq_role for pulp_rpm specifically
+          pulp-rpm: # no need to set subvar prereq_role for pulp_rpm specifically
       roles:
         - pulp_all_services
       environment:

--- a/roles/pulp_services/README.md
+++ b/roles/pulp_services/README.md
@@ -61,7 +61,7 @@ Here's an example playbook for using pulp_services in pulp_installer. It assumes
               USER: pulp
               PASSWORD: << YOUR DATABASE PASSWORD HERE >>
         pulp_install_plugins:
-          pulp-rpm: {} #no need to set subvar prereq_role for pulp_rpm specifically
+          pulp-rpm: # no need to set subvar prereq_role for pulp_rpm specifically
       roles:
         - pulp_services
       environment:


### PR DESCRIPTION
They are not necessary, and simply make the example code longer.

[noissue]