### PR TITLE
3.15: Vagrant no longer builds and installs the pulp.pulp_installer collection

### DIFF
--- a/.github/validate_commit_message.py
+++ b/.github/validate_commit_message.py
@@ -17,7 +17,7 @@ from github import Github
 
 
 NO_ISSUE = "[noissue]"
-CHANGELOG_EXTS = [".feature", ".bugfix", ".doc", ".removal", ".misc", ".deprecation"]
+CHANGELOG_EXTS = [".feature", ".bugfix", ".doc", ".removal", ".misc", ".deprecation", ".dev"]
 
 
 KEYWORDS = ["fixes", "closes"]

--- a/CHANGES/1098.dev
+++ b/CHANGES/1098.dev
@@ -1,0 +1,1 @@
+Vagrant no longer builds and installs the pulp.pulp_installer collection, but instead runs the roles out of the pulp_installer folder. To continue running using vagrant environments, run `rm -rf ~/.ansible/collections/ansible_collections/pulp/`.

--- a/vagrant/playbooks/source-install.yml
+++ b/vagrant/playbooks/source-install.yml
@@ -19,28 +19,15 @@
         msg: >
           "You must update Ansible to at least 2.10 to use this version of Pulp 3 Installer."
 
-    - name: Clean built collection
+    # TODO: Delete this task after 2023-05
+    # Previously vagrant logic installed the collection to this path.
+    # We now want to use the "./roles" folders instaed, for compatibility with
+    # molecule which uses "./roles", but has the problem of the installed
+    # collection overriding it.
+    - name: Delete installed pulp.pulp_installer collection
       file:
         state: absent
-        path: "{{ item }}"
-      with_fileglob:
-        - "../../pulp-pulp_installer-*.tar.gz"
-      delegate_to: localhost
-      become_user: "{{ lookup('env', 'USER') }}"
-
-    - name: Building pulp.pulp_installer
-      command:
-        cmd: ansible-galaxy collection build --force .
-        chdir: ../..
-      delegate_to: localhost
-      become_user: "{{ lookup('env', 'USER') }}"
-
-    - name: Installing pulp.pulp_installer
-      command:
-        cmd: "ansible-galaxy collection install --force {{ item }}"
-        chdir: ../..
-      with_fileglob:
-        - "../../pulp-pulp_installer-*.tar.gz"
+        path: "~/.ansible/collections/ansible_collections/pulp/pulp_installer"
       delegate_to: localhost
       become_user: "{{ lookup('env', 'USER') }}"
 
@@ -76,13 +63,8 @@
         source_workarounds: true
     - include_tasks: pre_tasks/selinux-workarounds.yml
 
-    - name: Dynamically include pulp.pulp_installer roles
-      include_role:
-        name: "pulp.pulp_installer.{{ roleinputvar }}"
-      loop:
-        - pulp_all_services
-        - pulp_devel
-      loop_control:
-        loop_var: roleinputvar
+  roles:
+    - pulp_all_services
+    - pulp_devel
   environment:
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings

--- a/vagrant/playbooks/user-sandbox.yml
+++ b/vagrant/playbooks/user-sandbox.yml
@@ -19,28 +19,15 @@
         msg: >
           "You must update Ansible to at least 2.10 to use this version of Pulp 3 Installer."
 
-    - name: Clean built collection
+    # TODO: Delete this task after 2023-05
+    # Previously vagrant logic installed the collection to this path.
+    # We now want to use the "./roles" folders instaed, for compatibility with
+    # molecule which uses "./roles", but has the problem of the installed
+    # collection overriding it.
+    - name: Delete installed pulp.pulp_installer collection
       file:
         state: absent
-        path: "{{ item }}"
-      with_fileglob:
-        - "../../pulp-pulp_installer-*.tar.gz"
-      delegate_to: localhost
-      become_user: "{{ lookup('env', 'USER') }}"
-
-    - name: Building pulp.pulp_installer
-      command:
-        cmd: ansible-galaxy collection build --force .
-        chdir: ../..
-      delegate_to: localhost
-      become_user: "{{ lookup('env', 'USER') }}"
-
-    - name: Installing pulp.pulp_installer
-      command:
-        cmd: "ansible-galaxy collection install --force {{ item }}"
-        chdir: ../..
-      with_fileglob:
-        - "../../pulp-pulp_installer-*.tar.gz"
+        path: "~/.ansible/collections/ansible_collections/pulp/pulp_installer"
       delegate_to: localhost
       become_user: "{{ lookup('env', 'USER') }}"
 
@@ -74,8 +61,7 @@
     - include_tasks: pre_tasks/vagrant-workarounds.yml
     - include_tasks: pre_tasks/selinux-workarounds.yml
 
-    - name: Dynamically include pulp.pulp_installer roles
-      include_role:
-        name: pulp.pulp_installer.pulp_all_services
+  roles:
+    - pulp_all_services
   environment:
     DJANGO_SETTINGS_MODULE: pulpcore.app.settings


### PR DESCRIPTION
…ion,

but instead runs the roles out of the pulp_installer folder.

To continue running using vagrant environments,
run `rm -rf ~/.ansible/collections/ansible_collections/pulp/`.

fixes: #1098
(cherry picked from commit da95fdccc47a12507ee97abc99a758d5681bd4ee)