### PR TITLE
Fix failure when pulp_database_config_host is set.

### DIFF
--- a/CHANGES/1130.bugfix
+++ b/CHANGES/1130.bugfix
@@ -1,0 +1,1 @@
+Fix failure when pulp_database_config_host is set. It failed in the task "pulp_database_config : Fail if some hosts in the play have the key, but pulp_database_config_host does not".

--- a/molecule/packages-cluster/group_vars/all
+++ b/molecule/packages-cluster/group_vars/all
@@ -1,6 +1,7 @@
 ---
 __pulp_run_once: true
 pulp_default_admin_password: password
+pulp_database_config_host: pulp-api1
 pulp_upgrade: true
 pulp_install_source: packages
 pulp_install_selinux_policies: True

--- a/roles/pulp_database_config/tasks/main.yml
+++ b/roles/pulp_database_config/tasks/main.yml
@@ -106,11 +106,13 @@
       with_items: "{{ groups['all'] }}"
       become: true
 
+    # 'equalto' test is not available on EL7's python-jinja2 2.7 RPM,
+    # so we use 'sameas' to compare to true/false, and 'match' to compare strings.
     - name: Fail if some hosts in the play have the key, but pulp_database_config_host does not
       assert:
         that: >
           (__pulp_db_fields_key_stat.results | selectattr('stat','defined') | selectattr('stat.exists', 'sameas', true) | list | count == 0) or
-          (__pulp_db_fields_key_stat.results | selectattr('item', 'sameas', hostvars['localhost']['pulp_database_config_host']) | map(attribute='stat.exists'))
+          (__pulp_db_fields_key_stat.results | selectattr('item', 'match', hostvars['localhost']['pulp_database_config_host']) | map(attribute='stat.exists') | list | first)
         fail_msg: >
           pulp_installer cannot continue because the host you have specified to run it
           (`pulp_database_config_host=={{ hostvars['localhost']['pulp_database_config_host'] }}`)


### PR DESCRIPTION
By replacing the incorrectly used "sameas" with "match".
Which is available on EL7's old python-jinja2 RPM.

Fixes: #1130