### PR TITLE
We require Python 2.7, not 3, on the control node

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ System Requirements
 Before you install Pulp, review the [architecture and component documentation](https://docs.pulpproject.org/pulpcore/components.html#) to ensure you understand the deployment structure and concepts.
 
 The Ansible [control node](https://docs.ansible.com/ansible/2.5/network/getting_started/basic_concepts.html#control-node)
-(i.e., your workstation) must have Python 3 and Ansible (>= 2.9) installed.
+(i.e., your workstation) must have Python (>= 2.7) and Ansible (>= 2.9) installed.
 
 Ensure that your server meets the [hardware requirements](https://docs.pulpproject.org/pulpcore/components.html#hardware-requirements) to install and run Pulp.
 


### PR DESCRIPTION
This was accidentally listed way back in 2018 in commit
e7f76b2a74a4bbececa72aaf2711024b316c43a1
Any requirement on Python 3 is no longer present, we support
Python 2.7 primarily because the EL7 Ansible 2.9 RPMs use it.

[noissue]