### PR TITLE
galaxy_ng: Fix CI on 3.18 branch by installing

### DIFF
--- a/molecule/source-galaxy/group_vars/all
+++ b/molecule/source-galaxy/group_vars/all
@@ -20,6 +20,7 @@ pulp_install_plugins:
   galaxy-ng:
     source_dir: "/var/lib/pulp/devel/galaxy_ng"
     git_url: "https://github.com/ansible/galaxy_ng"
+    git_revision: "stable-4.5"
 developer_user_home: /var/lib/pulp
 developer_user: pulp
 pulp_settings:


### PR DESCRIPTION
the stable-4.5 branch of galaxy_ng.

[noissue]