### PR TITLE
3.18: subject alt name prefix

### DIFF
--- a/CHANGES/1051.bugfix
+++ b/CHANGES/1051.bugfix
@@ -1,0 +1,1 @@
+Fix ``subject_alt_name`` prefix when generating a cert.

--- a/roles/pulp_webserver/tasks/generate_tls_certificates.yml
+++ b/roles/pulp_webserver/tasks/generate_tls_certificates.yml
@@ -68,7 +68,7 @@
         path: '{{ pulp_certs_dir }}/pulp_webserver.csr'
         privatekey_path: '{{ pulp_certs_dir }}/pulp_webserver.key'
         common_name: '{{ pulp_webserver_httpd_servername }}'
-        subject_alt_name: 'DNS:{{ pulp_webserver_httpd_servername }}'
+        subject_alt_name: '{{ __pulp_subject_alt_name }}'
         key_usage:
           - keyEncipherment
           - dataEncipherment

--- a/roles/pulp_webserver/vars/main.yml
+++ b/roles/pulp_webserver/vars/main.yml
@@ -2,3 +2,4 @@
 __pulp_apache_url: 'localhost'
 __pulp_webserver_apache_api_bind: "{{ pulp_api_bind.startswith('unix') | ternary(pulp_api_bind + '|http://' + __pulp_apache_url, 'http://' + pulp_api_bind ) }}"
 __pulp_webserver_apache_content_bind: "{{ pulp_content_bind.startswith('unix') | ternary(pulp_content_bind + '|http://' + __pulp_apache_url, 'http://' + pulp_content_bind ) }}"
+__pulp_subject_alt_name: '{{ pulp_webserver_httpd_servername | regex_search("^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$") | ternary("IP:" + pulp_webserver_httpd_servername , "DNS:" + pulp_webserver_httpd_servername) }}'


### PR DESCRIPTION
Subject alt name should be ``IP:`` when IP specified, otherwise
``DNS:``.

closes: #1051
https://github.com/pulp/pulp_installer/issues/1051
(cherry picked from commit 3d1c4ba5837bd37ed22274c18c995c5cdcc7ebe2)