### PR TITLE
Fix 404 not found on all content by default

### DIFF
--- a/CHANGES/1157.bugfix
+++ b/CHANGES/1157.bugfix
@@ -1,0 +1,1 @@
+Fix HTTP 404 "not found" errors by making pulp_settings.content_path_prefix default to "/pulp/content/" rather than "/pulp/content".

--- a/roles/pulp_common/README.md
+++ b/roles/pulp_common/README.md
@@ -110,7 +110,7 @@ Role Variables
     that must be set at the time of running pulp_installer, or that the installer behaves
     differently based on .
     * `pulp_settings.content_path_prefix`: Base path where the content will be served. Defaults to
-    "/pulp/content". **Do not append trailing slash.**
+    "/pulp/content/". **Make sure to append the trailing slash.**
     * `content_origin`: **Required**. The URL to the pulp_content
       host that clients will access, and that will be appended to in HTTP
       responses by multiple content plugins. Any load balancers / proxies (such

--- a/roles/pulp_common/vars/main.yml
+++ b/roles/pulp_common/vars/main.yml
@@ -36,7 +36,7 @@ __pulp_common_pulp_settings_defaults:
   public_key_path: "{{ pulp_certs_dir }}/token_public_key.pem"
   token_server: "{{ pulp_webserver_disable_https | default(false) | ternary('http', 'https') }}://{{ ansible_facts.fqdn }}/token/"
   token_signature_algorithm: ES256
-  content_path_prefix: "{{ pulp_settings.content_path_prefix | default('/pulp/content') }}"
+  content_path_prefix: "{{ pulp_settings.content_path_prefix | default('/pulp/content/') }}"
 
 __pulp_common_merged_pulp_settings: "{{ __pulp_common_pulp_settings_defaults | combine(pulp_settings, recursive=True) }}"
 

--- a/roles/pulp_webserver/defaults/main.yml
+++ b/roles/pulp_webserver/defaults/main.yml
@@ -25,7 +25,7 @@ pulp_client_max_body_size: "{{ '1m' if pulp_webserver_server == 'nginx' else '0'
 
 # Defaults for settings
 __pulp_common_merged_pulp_settings:
-  content_path_prefix: "/pulp/content"
+  content_path_prefix: "/pulp/content/"
 
 pulp_webserver_api_hosts: "{{ [{ 'address' : pulp_api_bind }] }}"
 pulp_webserver_content_hosts: "{{ [{ 'address' : pulp_content_bind }] }}"

--- a/roles/pulp_webserver/templates/nginx.conf.j2
+++ b/roles/pulp_webserver/templates/nginx.conf.j2
@@ -85,7 +85,7 @@ http {
         # purposes are served through the webserver.
         root {{ pulp_webserver_static_dir }};
 
-        location {{ __pulp_common_merged_pulp_settings.content_path_prefix }}/ {
+        location {{ __pulp_common_merged_pulp_settings.content_path_prefix }} {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header Host $http_host;


### PR DESCRIPTION
Due to an incorrect value of pulp_settings.content_path_prefix

fixes: #1157