### PR TITLE
3.18: Fix the pulp user getting created incorrectly

### DIFF
--- a/CHANGES/1173.bugfix
+++ b/CHANGES/1173.bugfix
@@ -1,0 +1,1 @@
+Fix the pulp user getting created with incorrect settings, such as having its home dir under /home/pulp, when pulp_redis_bind is set to a UNIX domain socket.

--- a/molecule/packages-static/group_vars/all
+++ b/molecule/packages-static/group_vars/all
@@ -4,10 +4,12 @@ pulp_upgrade: true
 pulp_install_source: packages
 pulp_api_bind: "unix:/var/run/pulpcore-api/pulpcore-api.sock"
 pulp_content_bind: "unix:/var/run/pulpcore-content/pulpcore-content.sock"
+pulp_redis_bind: "unix:/var/run/redis/redis.sock"
 pulp_install_selinux_policies: True
 pulp_install_plugins:
   pulp-file:
   pulp-rpm:
 pulp_settings:
-  secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
+  secret_key: secret
+  redis_url: "unix:/var/run/redis/redis.sock"

--- a/molecule/release-static/group_vars/all
+++ b/molecule/release-static/group_vars/all
@@ -2,6 +2,7 @@
 pulp_default_admin_password: password
 pulp_api_bind: "unix:/var/run/pulpcore-api/pulpcore-api.sock"
 pulp_content_bind: "unix:/var/run/pulpcore-content/pulpcore-content.sock"
+pulp_redis_bind: "unix:/var/run/redis/redis.sock"
 pulp_install_plugins:
   # galaxy-ng: {}
   # pulp-ansible: {}
@@ -16,6 +17,7 @@ pulp_install_plugins:
   # pulp-python: {}
   pulp-rpm: {}
 pulp_settings:
-  secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
+  secret_key: secret
+  redis_url: "unix:/var/run/redis/redis.sock"
 pulp_webserver_server: apache

--- a/molecule/source-static/group_vars/all
+++ b/molecule/source-static/group_vars/all
@@ -5,6 +5,7 @@ pulp_git_url: "https://github.com/pulp/pulpcore"
 pulp_git_revision: "main"
 pulp_api_bind: "unix:/var/run/pulpcore-api/pulpcore-api.sock"
 pulp_content_bind: "unix:/var/run/pulpcore-content/pulpcore-content.sock"
+pulp_redis_bind: "unix:/var/run/redis/redis.sock"
 pulp_install_plugins:
   # galaxy-ng:
   #   source_dir: "/var/lib/pulp/devel/galaxy_ng"
@@ -42,5 +43,6 @@ pulp_config_dir: /opt/pulp/etc
 developer_user_home: /opt/pulp/devel
 developer_user: pulp
 pulp_settings:
-  secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"
+  secret_key: secret
+  redis_url: "unix:/var/run/redis/redis.sock"

--- a/roles/pulp_common/README.md
+++ b/roles/pulp_common/README.md
@@ -105,6 +105,18 @@ Role Variables
     of the pulp content host itself. Syntax is
     `(http|https)://(hostname|ip)[:port]`.
   * `pulp_settings.secret_key`: **Required**. Pulp's Django application `SECRET_KEY`.
+  * `pulp_settings.cache_enabled`: Whether or not to connect to a redis server to use as a cache. Defaults to
+      `true`.
+  * `pulp_settings.redis_host`: **Optional**. Hostname or IP of the redis server to connect to. Defaults to `localhost`.
+  * `pulp_settings.redis_port`: **Optional**. TCP port of the redis server to connect to. Defaults to `6379`.
+  * `pulp_settings.redis_db`: **Optional**. The name of the redis database to connect to.
+  * `pulp_settings.redis_password`: **Optional**. Password for connecting to redis.
+  * `pulp_settings.redis_url`: **Optional** Tells pulp how to connect to redis. If set, the pulp application overrides
+      individual pulp `redis_` settings on how to connect, such as `redis_host` and `redis_port`.
+      If it is a path to a UNIX domain socket (recommended value is: `unix:/var/run/redis/redis.sock`),
+      the pulp_common role will add the `{{ pulp_user }}` user to the `redis` group, if that group exists.
+      Thus giving pulp access to the redis UNIX domain socket. Make sure to set the same value as
+      you set for `pulp_redis_bind`, as documented in [pulp_redis](../../roles/pulp_redis).
 
 * `pulp_certs_dir`: Path where to generate or drop the TLS certificates, key for authentication
   tokens, and the database fields encryption key. Defaults to '{{ pulp_config_dir }}/certs' .

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -108,6 +108,23 @@
         append: true
       when: developer_user is defined
 
+    - name: Check if the redis group exists
+      command: getent group redis
+      changed_when: False
+      check_mode: False
+      register: redis_group
+      failed_when: redis_group.rc not in [0,2]
+
+    - name: Add user pulp to the redis group
+      user:
+        name: '{{ pulp_user }}'
+        groups: redis
+        append: true
+      when:
+        - __pulp_common_merged_pulp_settings.redis_url is defined
+        - "__pulp_common_merged_pulp_settings.redis_url.startswith('unix:')"
+        - redis_group.rc == 0
+
     - name: Reset ssh conn to allow user changes to affect when ssh user and pulp user are the same
       meta: reset_connection
 

--- a/roles/pulp_redis/defaults/main.yml
+++ b/roles/pulp_redis/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 pulp_cache_enabled: True
-pulp_user: pulp
 pulp_redis_bind: '127.0.0.1:6379'
 pulp_redis_package_name: redis

--- a/roles/pulp_redis/tasks/configure_uds.yml
+++ b/roles/pulp_redis/tasks/configure_uds.yml
@@ -1,10 +1,4 @@
 ---
-- name: Ensure pulp is part of group redis
-  user:
-    name: '{{ pulp_user }}'
-    groups: redis
-    append: true
-
 - name: Ensure Redis will not listen on a TCP socket
   lineinfile:
     path: '{{ pulp_redis_conf_file | default(_pulp_redis_conf_file) }}'


### PR DESCRIPTION
when pulp_redis_bind is set to a UNIX domain socket.

fixes: #1173
(cherry picked from commit c2d2b4685747b50c1a052e6e833e28093ebeab8a)