### PR TITLE
Fix an issue where by the pulp_webserver role

### DIFF
--- a/CHANGES/1186.bugfix
+++ b/CHANGES/1186.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where by the pulp_webserver role would fail on "Copy Snippets" if it were run after pulp_devel is run.

--- a/roles/pulp_devel/tasks/bashrc.yml
+++ b/roles/pulp_devel/tasks/bashrc.yml
@@ -39,6 +39,18 @@
       mode: '0644'
     when: ansible_facts.distribution != 'Ubuntu'
 
+  # We need to do this or else it fails to initialize, and every time a new
+  # shell is spawned, it spews messages like:
+  # virtualenvwrapper.user_scripts creating /usr/local/lib/premkproject
+  # Which in turn breaks the task:
+  # pulp_webserver : Copy snippets from the pulp_database_config host
+  - name: Initialize virtualenvwrapper
+    command: 'bash {{ developer_user_home }}/.bashrc.d/venv.bashrc'
+    args:
+      creates: '{{ pulp_install_dir }}../premkproject'
+    become_user: root
+    register: virtualenvwrapper
+
   - name: Install bindings requirements for testing locally  # noqa no-changed-when
     shell: >-
       source {{ developer_user_home }}/.bashrc.d/alias.bashrc


### PR DESCRIPTION
would fail on "Copy Snippets" if it were run after pulp_devel is run.

fixes: #1186


Note: users who see the output like `virtualenvwrapper.user_scripts creating /usr/local/lib/premkproject` whenever they login need to fix this manually by running `sudo bash /home/vagrant/.bashrc.d/venv.bashrc`. This PR will only prevent it from being needed in the future.