### PR TITLE
Fix gnutls error on the webserver

### DIFF
--- a/CHANGES/1182.bugfix
+++ b/CHANGES/1182.bugfix
@@ -1,0 +1,1 @@
+Fix gnutls error on the webserver `Peer's certificate does not allow digital signatures. Key usage violation detected.` by adding the key_usage digitalSignature to the CSR.

--- a/roles/pulp_webserver/tasks/generate_tls_certificates.yml
+++ b/roles/pulp_webserver/tasks/generate_tls_certificates.yml
@@ -72,6 +72,7 @@
         key_usage:
           - keyEncipherment
           - dataEncipherment
+          - digitalSignature
         extended_key_usage:
           - serverAuth
         owner: root


### PR DESCRIPTION
`Peer's certificate does not allow digital signatures. Key usage violation detected.`
by adding the key_usage digitalSignature to the CSR.

Fixes: #1182