### PR TITLE
mkdocs: fix `edit_uri` to point to main branch

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_author: Pulp Team
 site_url: https://docs.pulpproject.org/pulp_installer/
 repo_name: pulp/pulp_installer
 repo_url: https://github.com/pulp/pulp_installer
+edit_uri: edit/main/docs
 theme:
   features:
     - search.suggest


### PR DESCRIPTION
The edit button in the documentation was pointing to the non-existing master branch. This commit explicitly sets the `edit_uri` to `edit/main/docs`.

See [mkdocs documentation](https://www.mkdocs.org/user-guide/configuration/#edit_uri) and [mkdocs-material documentation](https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#edit-button).