### PR TITLE
docs: add markdown linting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,3 +174,9 @@ jobs:
       - name: Lint test
         run: |
           ansible-lint
+      - name: Install Node.js dependencies
+        run: |
+          npm ci
+      - name: Lint documentation
+        run: |
+          npm test

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ build/
 
 vagrant/boxes.d/*-local.yaml
 .vscode/
+
+# Node.js related items
+node_modules/

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,23 @@
+---
+## For a complete and comprehensive list of available rules
+## see here: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+## heading style
+## https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md003
+MD003: false  # do not check for now, might be enabled later
+# style: "setext_with_atx"
+
+## unordered list indentation
+## https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md007
+MD007:
+  # python-markdown requires 4 spaces of indentation.
+  # see https://python-markdown.github.io/#differences
+  indent: 4
+
+## line length
+## https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md013
+MD013: false  # do not check for now, might be enabled later
+# line_length: 120
+# code_blocks: false
+# tables: false
+# stern: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,566 @@
+{
+  "name": "pulp_installer",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "markdownlint-cli": "^0.31.1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/get-stdin": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+      "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
+    "node_modules/linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
+      "integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
+      "dev": true,
+      "dependencies": {
+        "markdown-it": "12.3.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/markdownlint-cli": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.31.1.tgz",
+      "integrity": "sha512-keIOMwQn+Ch7MoBwA+TdkyVMuxAeZFEGmIIlvwgV0Z1TGS5MxPnRr29XCLhkNzCHU+uNKGjU+VEjLX+Z9kli6g==",
+      "dev": true,
+      "dependencies": {
+        "commander": "~9.0.0",
+        "get-stdin": "~9.0.0",
+        "glob": "~7.2.0",
+        "ignore": "~5.2.0",
+        "js-yaml": "^4.1.0",
+        "jsonc-parser": "~3.0.0",
+        "markdownlint": "~0.25.1",
+        "markdownlint-rule-helpers": "~0.16.0",
+        "minimatch": "~3.0.5",
+        "run-con": "~1.2.10"
+      },
+      "bin": {
+        "markdownlint": "markdownlint.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/markdownlint-rule-helpers": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz",
+      "integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w==",
+      "dev": true
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-con": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.2.10.tgz",
+      "integrity": "sha512-n7PZpYmMM26ZO21dd8y3Yw1TRtGABjRtgPSgFS/nhzfvbJMXFtJhJVyEgayMiP+w/23craJjsnfDvx4W4ue/HQ==",
+      "dev": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~2.0.0",
+        "minimist": "^1.2.5",
+        "strip-json-comments": "~3.1.1"
+      },
+      "bin": {
+        "run-con": "cli.js"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "commander": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.0.0.tgz",
+      "integrity": "sha512-JJfP2saEKbQqvW+FI93OYUB4ByV5cizMpFMiiJI8xDbBvQvSkIk0VvQdn1CZ8mqAO8Loq2h0gYTYtDFUZUeERw==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
+    "entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "get-stdin": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+      "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "dependencies": {
+        "minimatch": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.1.7"
+          }
+        }
+      }
+    },
+    "ignore": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1"
+      }
+    },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
+    "linkify-it": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+      "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "markdown-it": {
+      "version": "12.3.2",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+      "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "~2.1.0",
+        "linkify-it": "^3.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
+    "markdownlint": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.25.1.tgz",
+      "integrity": "sha512-AG7UkLzNa1fxiOv5B+owPsPhtM4D6DoODhsJgiaNg1xowXovrYgOnLqAgOOFQpWOlHFVQUzjMY5ypNNTeov92g==",
+      "dev": true,
+      "requires": {
+        "markdown-it": "12.3.2"
+      }
+    },
+    "markdownlint-cli": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli/-/markdownlint-cli-0.31.1.tgz",
+      "integrity": "sha512-keIOMwQn+Ch7MoBwA+TdkyVMuxAeZFEGmIIlvwgV0Z1TGS5MxPnRr29XCLhkNzCHU+uNKGjU+VEjLX+Z9kli6g==",
+      "dev": true,
+      "requires": {
+        "commander": "~9.0.0",
+        "get-stdin": "~9.0.0",
+        "glob": "~7.2.0",
+        "ignore": "~5.2.0",
+        "js-yaml": "^4.1.0",
+        "jsonc-parser": "~3.0.0",
+        "markdownlint": "~0.25.1",
+        "markdownlint-rule-helpers": "~0.16.0",
+        "minimatch": "~3.0.5",
+        "run-con": "~1.2.10"
+      }
+    },
+    "markdownlint-rule-helpers": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.16.0.tgz",
+      "integrity": "sha512-oEacRUVeTJ5D5hW1UYd2qExYI0oELdYK72k1TKGvIeYJIbqQWAz476NAc7LNixSySUhcNl++d02DvX0ccDk9/w==",
+      "dev": true
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.8.tgz",
+      "integrity": "sha512-6FsRAQsxQ61mw+qP1ZzbL9Bc78x2p5OqNgNpnoAFLTrX8n5Kxph0CsnhmKKNXTWjXqU5L0pGPR7hYk+XWZr60Q==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
+    "run-con": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/run-con/-/run-con-1.2.10.tgz",
+      "integrity": "sha512-n7PZpYmMM26ZO21dd8y3Yw1TRtGABjRtgPSgFS/nhzfvbJMXFtJhJVyEgayMiP+w/23craJjsnfDvx4W4ue/HQ==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~2.0.0",
+        "minimist": "^1.2.5",
+        "strip-json-comments": "~3.1.1"
+      }
+    },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "docs",
+  "private": true,
+  "devDependencies": {
+    "markdownlint-cli": "^0.31.1"
+  },
+  "scripts": {
+    "test": "markdownlint ./docs/**/*.md"
+  }
+}

--- a/roles/pulp_all_services/README.md
+++ b/roles/pulp_all_services/README.md
@@ -12,19 +12,20 @@ on certain hosts.
 Currently, all it does is depend on the required roles, which are
 subject to change over time. They are specified in the following order:
 
-  - [pulp_database](../../roles/pulp_database)
-  - [pulp_redis](../../roles/pulp_redis)
-  - [pulp_services](../pulp_services)
-  - [pulp_database_config](../../roles/pulp_database_config) (implicitly via pulp_services)
-  - [pulp_api](../../roles/pulp_api) (implicitly via pulp_services)
-  - [pulp_content](../../roles/pulp_content) (implicitly via pulp_services)
-  - [pulp_workers](../../roles/pulp_workers) (implicitly via pulp_services)
-  - [pulp_common](../../roles/pulp_common) (implicitly via pulp_services)
-  - [pulp_health_check](../../roles/pulp_health_check)
-  - [pulp_webserver](../../roles/pulp_webserver)
+- [pulp_database](../../roles/pulp_database)
+- [pulp_redis](../../roles/pulp_redis)
+- [pulp_services](../pulp_services)
+- [pulp_database_config](../../roles/pulp_database_config) (implicitly via pulp_services)
+- [pulp_api](../../roles/pulp_api) (implicitly via pulp_services)
+- [pulp_content](../../roles/pulp_content) (implicitly via pulp_services)
+- [pulp_workers](../../roles/pulp_workers) (implicitly via pulp_services)
+- [pulp_common](../../roles/pulp_common) (implicitly via pulp_services)
+- [pulp_health_check](../../roles/pulp_health_check)
+- [pulp_webserver](../../roles/pulp_webserver)
 
 Related Roles
 -------------
+
 - [pulp_services](../pulp_services/): A role to install & configure Pulp 3's
   first-party services (including the state of the Pulp database) on a single host.
 

--- a/roles/pulp_common/README.md
+++ b/roles/pulp_common/README.md
@@ -7,6 +7,7 @@ The default administrative user for the Pulp application is: 'admin'
 
 Role Variables
 --------------
+
 * `pulp_install_plugins`: **Required** A nested dictionary of plugins to install & their
   installation options.
     * *Dictionary Key*: **Required**. The pip installable plugin name. This is defined in each
@@ -39,6 +40,7 @@ Role Variables
     extras.
     If set to false the plugin name will be passed as `--ignore` at collectstatic time.
     * **Example**:
+
     ```yaml
     pulp_install_source: pip
     pulp_install_plugins:
@@ -61,6 +63,7 @@ Role Variables
         git_url: "https://github..."  # Optional. URL to the git repo from where plugin will be pulled.
         git_revision: "v3.1.1"   # Optional. The specific git branch/tag/commit to be cheked out.
     ```
+
 * `pulp_cache_dir`: Location of Pulp cache. Defaults to '{{ pulp_user_home }}/tmp'.
 * `pulp_config_dir`: Directory which will contain Pulp configuration files.
   Defaults to "/etc/pulp".
@@ -150,6 +153,7 @@ Role Variables
       Thus giving pulp access to the redis UNIX domain socket. Make sure to set the same value as
       you set for `pulp_redis_bind`, as documented in [pulp_redis](../../roles/pulp_redis).
     * **Example**:
+
     ```yaml
         pulp_settings:
           content_origin: "https://{{ ansible_fqdn }}"
@@ -161,6 +165,7 @@ Role Variables
               USER: pulp
               PASSWORD: password
     ```
+
 * `pulp_certs_dir`: Path where to generate or drop the TLS certificates, key for authentication
   tokens, and the database fields encryption key. Defaults to '{{ pulp_config_dir }}/certs' .
 * `pulpcore_update`: Boolean that specifies whether the pulpcore package should be updated to the
@@ -172,6 +177,7 @@ Role Variables
 
 Role Variables if installing from RPMs
 --------------------------------------
+
 Normally, Pulp is installed from Python pip packages (from PyPI.) pulp_installer can install Pulp from
 RPM packages instead if this variable is set. Other distro packaging formats may work as well:
 
@@ -203,6 +209,7 @@ Furthermore, the following variables are used, or behave *differently* from abov
     "pulp-file", the package `python3-pulp-file` will be installed. This variable overrides the entire package name.
     * `version`: Like with pip, a user can specify a specific version of a package one wants installed.
     * **Example**:
+
     ```yaml
     pulp_install_source: packages
     pulp_install_plugins:
@@ -213,6 +220,7 @@ Furthermore, the following variables are used, or behave *differently* from abov
         pkg_name: pulp_two_underscores
         version: 2.2.0
     ```
+
 * `pulp_install_dir`: Location of the filesystem prefix where package installed python programs
   (gunicorn & rq) are looked for on the filesystem.  Defaults to "/usr" (such as for "/usr/bin/gunicorn").
 * `pulp_pkg_name_prefix`: The beginning of the Linux distro (RPM) package names for pulp, that is
@@ -264,7 +272,6 @@ function). Also, a `prereq_role` may append to it.
 
 This role is required by the `pulp_database` role and uses some variables from it.
 
-
 Operating System Variables
 --------------------------
 
@@ -273,7 +280,9 @@ directory.
 
 Idempotency
 -----------
+
 This role is idempotent by default. It is dependent on these settings remaining `false`:
+
 * Every `upgrade` under `pulp_install_plugins`
 * pulp_upgraded_manually
 

--- a/roles/pulp_database/README.md
+++ b/roles/pulp_database/README.md
@@ -31,7 +31,7 @@ When not used together, this role provides identical defaults.
 * `pulp_settings.databases.default`: A dictionary. Its primary use is by the
   pulp_common role, where it configures Pulp on how to talk to the database via a larger set of settings.
   Its secondary use is by the this role, where it configures the database server according to a
-  smaller set of settings. The smaller set of settings is listed below. Note that these default settings are merged by the 
+  smaller set of settings. The smaller set of settings is listed below. Note that these default settings are merged by the
   installer with your own; merely setting pulp_settings with 1 setting under it will not blow away all
   the other default settings.
     * `NAME` The name of the Pulp database to create.  Defaults to `pulp`.
@@ -39,6 +39,7 @@ When not used together, this role provides identical defaults.
     * `PASSWORD` The password to be created for the user account to talk to the Pulp database.
     Defaults to `pulp`, but please change it to something secure!
     * **Example**:
+
     ```yaml
     pulp_settings:
       databases:

--- a/roles/pulp_database_config/README.md
+++ b/roles/pulp_database_config/README.md
@@ -53,7 +53,8 @@ variables which are documented in that role:
 This role **is tightly coupled** with the required the `galaxy_post_install` role (which is called
 by pulp_common when galaxy-ng is an installed plugin) and uses some of variables which are
 documented in that role:
-*  `galaxy_create_default_collection_signing_service` Defaults to `false`.
+
+* `galaxy_create_default_collection_signing_service` Defaults to `false`.
 
 This role understands how to talk to the database server via `pulp_settings_file`,
 which is written to disk in the `pulp_common` role, and whose relevant
@@ -63,6 +64,7 @@ values are set via the following variables:
 
 Limitations
 -----------
+
 * pulp_database_config is designed to be run against only 1 host.
 
 If it is accidentally run against multiple hosts (which will happen if

--- a/roles/pulp_devel/README.md
+++ b/roles/pulp_devel/README.md
@@ -21,6 +21,7 @@ Variables
 The variables that this role uses are listed below:
 
 The following variables have a default value:
+
 ```yaml
 pulp_devel_install_podman: true
 pulp_devel_package_retries: 5
@@ -29,6 +30,7 @@ pulp_devel_supplement_bashrc: false
 
 The following variables have no default value, and we recommend the following
 for development purposes on vagrant (as part of [pulplift](https://github.com/pulp/pulplift).)
+
 ```yaml
 developer_user: vagrant
 developer_user_home: /home/vagrant
@@ -57,7 +59,6 @@ but it does use some of the same variables. When not used together, these values
 are **required**.
 
 * `pulp_default_admin_password`
-
 
 Aliases
 -------

--- a/roles/pulp_redis/README.md
+++ b/roles/pulp_redis/README.md
@@ -6,7 +6,7 @@ Install and start Redis.
 Role Variables
 --------------
 
-* `pulp_cache_enabled`: Install and enable Redis as a cache. Defaults to `True` 
+* `pulp_cache_enabled`: Install and enable Redis as a cache. Defaults to `True`
   This option effectively disable or enable this role.
 * `pulp_redis_bind`: Interface and Port where Redis service will listen. One can specify a unix
    socket path instead (recommended value is `'unix:/var/run/redis/redis.sock'`). Defaults to `'127.0.0.1:6379'`.

--- a/roles/pulp_repos/README.md
+++ b/roles/pulp_repos/README.md
@@ -5,7 +5,9 @@ Role to enable repositories needed to install pulp. It can be disabled if user a
 
 It is automatically called by the `pulp_common` role.
 
-    This role is meant to be called by `include_role` with specific variable.
+```text
+This role is meant to be called by `include_role` with specific variable.
+```
 
 Requirements
 ------------
@@ -43,7 +45,8 @@ With its defaults.
   Also accepts a single string or empty string.
   Only affects CentOS/RHEL.
   Defaults to  ["epel-release",
-  "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_facts.distribution_major_version }}.noarch.rpm"
+  <!-- markdownlint-disable-next-line MD034 -->
+  "https://dl.fedoraproject.org/pub/epel/epel-release-latest-`{{ ansible_facts.distribution_major_version }}`.noarch.rpm"
 * `rhel7_optional_repo`: List of possible names for the rhel7 optional repo
   to enable. Once the 1st name is enabled (or found to already be enabled),
   no further names are attempted.
@@ -65,6 +68,7 @@ These variables corresponding to role repository variables above when is called 
 
 Shared Variables
 ----------------
+
 * `pulp_install_source`: If set to `packages`, and pulp_rhel_pulpcore_repo_enable==true, Add the
   pulpcore repo to the system.
 
@@ -81,7 +85,7 @@ Shared Variables
 Example Usage
 -------------
 
-If you want to install Pulp on a device with EPEL repository already enabled, you don't want to enable it second time. 
+If you want to install Pulp on a device with EPEL repository already enabled, you don't want to enable it second time.
 In this case it is enough just put line bellow into your `config.yml`.
 
 ```yaml

--- a/roles/pulp_services/README.md
+++ b/roles/pulp_services/README.md
@@ -16,11 +16,11 @@ on certain hosts.
 Currently, all it does is depend on the required roles, which are
 subject to change over time:
 
-  - [pulp_database_config](../../roles/pulp_database_config)
-  - [pulp_api](../../roles/pulp_api)
-  - [pulp_content](../../roles/pulp_content)
-  - [pulp_workers](../../roles/pulp_workers)
-  - [pulp_common](../../roles/pulp_common) (implicitly)
+- [pulp_database_config](../../roles/pulp_database_config)
+- [pulp_api](../../roles/pulp_api)
+- [pulp_content](../../roles/pulp_content)
+- [pulp_workers](../../roles/pulp_workers)
+- [pulp_common](../../roles/pulp_common) (implicitly)
 
 Example Usage
 -------------
@@ -72,6 +72,7 @@ Here's an example playbook for using pulp_services in pulp_installer. It assumes
 
 Related Roles
 -------------
+
 - [pulp_all_services](../pulp_all_services/): A role to install all Pulp 3
 services (first-party & third-party) on a single host.
 

--- a/roles/pulp_webserver/README.md
+++ b/roles/pulp_webserver/README.md
@@ -15,7 +15,6 @@ Nginx and Apache are supported as the web server.
 By default TLS will be enabled (with self-signed certificates if none are provided). An automatic
 redirect from http to https will take place.
 
-
 Role Variables
 --------------
 
@@ -40,130 +39,128 @@ Role Variables
    or on the ansible management node (`false`). Defaults to `false`.
 * `pulp_webserver_httpd_servername`: Servername to use when deploying httpd. Defaults to
   `ansible_fqdn`.
-- `pulp_webserver_static_dir` absolute path where to place static files, such as for the .well-known
+* `pulp_webserver_static_dir` absolute path where to place static files, such as for the .well-known
    directory for ACME (letsencrypt) files or SSL certs. This is not to be confused with the Pulp
    application's setting `STATIC_ROOT`, which is a function of Pulp itself (not the webserver) and servces
    a different set of files. Defaults to `{{ pulp_user_home}}/pulpcore_static`, which is `/var/lib/pulp/pulpcore_static`
-- `pulp_client_max_body_size`: Sets the maximum allowed size of the client request body.
+* `pulp_client_max_body_size`: Sets the maximum allowed size of the client request body.
 
 Role Variables for Clusters
 ---------------------------
 
 1. If the installer is run against a single host, `pulp_content_bind` and `pulp_api_bind` are defaulted
-   so that the webserver reverse proxies to the API server and content server running on the single host.
-
+   so that the webserver reverse proxies to the API server and content server running on the single host.  
    Thus there is no need to set any cluster variables for a single host.
 
 2. If the installer is run against a single `pulp_content` host and a single `pulp_api` host, setting
    `pulp_content_bind` and `pulp_api_bind` is sufficient for the `pulp_webserver` host(s) to reverse proxy
-    to them.
-
+   to them.  
    These 2 shared variables need to be set for both the `pulp_api`/`pulp_cluster` hosts, and the
-   `pulp_webserver` hosts.
-```yaml
-pulp_api_bind: "example-pulp-api-server:24817
-pulp_content_bind: "example-pulp-api-server:24816"
-```
+   `pulp_webserver` hosts.  
+
+    ```yaml
+    pulp_api_bind: "example-pulp-api-server:24817"
+    pulp_content_bind: "example-pulp-api-server:24816"
+    ```
 
 3. If the installer is run against multiple `pulp_content` hosts or multiple `pulp_api` hosts,
    it becomes necessary to set `pulp_api_bind` and `pulp_content_bind` in combination with
    `pulp_webserver_api_hosts` and `pulp_webserver_content_hosts`. These latter 2 variables
-    set the reverse proxy behavior for when there are multiple servers to proxy to.
-
+    set the reverse proxy behavior for when there are multiple servers to proxy to.  
    `pulp_api_bind` and `pulp_content_bind`
    only need to be set for the `pulp_api` and `pulp_content` hosts (they are not shared variables
    anymore), while `pulp_webserver_api_hosts` and `pulp_webserver_content_hosts` only need to
-   be set for the `pulp_webserver` hosts.
-
+   be set for the `pulp_webserver` hosts.  
    Additionally, there are **optional** load balancing variables
-   and optional load balancing nested variables, and they differ based on nginx or apache.
+   and optional load balancing nested variables, and they differ based on nginx or apache.  
+   Here are 3 examples, the 1st example works for either `pulp_webserver_server==apache` or
+   `pulp_webserver_server==nginx`, the latter 2 are specific to a apache/nginx.  
 
-   Here are
-   3 examples, the 1st example works for either `pulp_webserver_server==apache` or
-   `pulp_webserver_server==nginx`, the latter 2 are specific to a apache/nginx.
-```yaml
-pulp_api_bind: "{{ ansible_facts.fqdn }}:24817"
-pulp_content_bind: "{{ ansible_facts.fqdn }}:24816"
-pulp_webserver_api_hosts:
-  - address: "pulp-api1:24817"
-  - address: "pulp-api2:24817"
-pulp_webserver_content_hosts:
-  - address: "pulp-content1:24817"
-  - address: "pulp-content2:24817"
-```
-```yaml
-pulp_webserver_server: nginx
-pulp_api_bind: "{{ ansible_facts.fqdn }}:24817"
-pulp_content_bind: "{{ ansible_facts.fqdn }}:24816"
-pulp_webserver_api_hosts:
-  - address: "pulp-api1:24817"
-    nginx_parameters:
-      - weight=1
-      - max_conns=100
-  - address: "pulp-api2:24817"
-    nginx_parameters:
-      - weight=2
-      - max_conns=100
-pulp_webserver_content_hosts:
-  - address: "pulp-content1:24817"
-    nginx_parameters:
-      - weight=1
-      - max_conns=100
-  - address: "pulp-content2:24817"
-    nginx_parameters:
-      - weight=2
-      - max_conns=100
-pulp_webserver_api_balancer_nginx_directives:
-  - name: zone
-    parameters:
-     - upstream_dynamic
-     - 64k
-pulp_webserver_content_balancer_nginx_directives:
-  - name: zone
-    parameters:
-     - upstream_dynamic
-```
-```yaml
-pulp_webserver_server: apache
-pulp_api_bind: "{{ ansible_facts.fqdn }}:24817"
-pulp_content_bind: "{{ ansible_facts.fqdn }}:24816"
-pulp_webserver_api_hosts:
-  - address: "pulp-api1:24817"
-    apache_parameters:
-      - keepalive=on
-      - lbset=1
-  - address: "pulp-api2:24817"
-    apache_parameters:
-      - keepalive=on
-      - lbset=2
-pulp_webserver_content_hosts:
-  - address: "pulp-content1:24817"
-    apache_parameters:
-      - keepalive=on
-      - lbset=1
-  - address: "pulp-content2:24817"
-    apache_parameters:
-      - keepalive=on
-      - lbset=2
-     - upstream_dynamic
-pulp_webserver_content_balancer_apache_parameters:
-  - lbmethod=bytraffic
-  - timeout=10
-pulp_webserver_api_balancer_apache_parameters:
-  - lbmethod=bytraffic
-  - timeout=10
-```
+    ```yaml
+    pulp_api_bind: "{{ ansible_facts.fqdn }}:24817"
+    pulp_content_bind: "{{ ansible_facts.fqdn }}:24816"
+    pulp_webserver_api_hosts:
+      - address: "pulp-api1:24817"
+      - address: "pulp-api2:24817"
+    pulp_webserver_content_hosts:
+      - address: "pulp-content1:24817"
+      - address: "pulp-content2:24817"
+    ```
 
-For more info on these optional load balancing variables:
-* `apache_parameters` for `pulp_webserver_api_hosts`/`pulp_webserver_content_hosts`: See the Apache "Worker|BalancerMember parameters" under [this link.](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxypass) (Note however that the servers ("BalancerMember") are not specified in the "url" format listed on the link, they must be specified in the "address" format (hostname:port or ip:port) as listed in these docs because pulp generates the URL.)
-* `pulp_webserver_content_balancer_apache_parameters`/`pulp_webserver_api_balancer_apache_parameters`: See the Apache "Balancer parameters" under [the same link as before.](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxypass)
-* `nginx_parameters` for `pulp_webserver_api_hosts`/`pulp_webserver_content_hosts`: See the
-  Nginx server "parameters" under [this
-link.](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#server)
-* `pulp_webserver_api_balancer_nginx_directives`/`pulp_webserver_content_balancer_nginx_directives`:
-  See the Nginx "Directives" under [the same page as
-before.](http://nginx.org/en/docs/http/ngx_http_upstream_module.html)
+    ```yaml
+    pulp_webserver_server: nginx
+    pulp_api_bind: "{{ ansible_facts.fqdn }}:24817"
+    pulp_content_bind: "{{ ansible_facts.fqdn }}:24816"
+    pulp_webserver_api_hosts:
+      - address: "pulp-api1:24817"
+        nginx_parameters:
+          - weight=1
+          - max_conns=100
+      - address: "pulp-api2:24817"
+        nginx_parameters:
+          - weight=2
+          - max_conns=100
+    pulp_webserver_content_hosts:
+      - address: "pulp-content1:24817"
+        nginx_parameters:
+          - weight=1
+          - max_conns=100
+      - address: "pulp-content2:24817"
+        nginx_parameters:
+          - weight=2
+          - max_conns=100
+    pulp_webserver_api_balancer_nginx_directives:
+      - name: zone
+        parameters:
+        - upstream_dynamic
+        - 64k
+    pulp_webserver_content_balancer_nginx_directives:
+      - name: zone
+        parameters:
+        - upstream_dynamic
+    ```
 
+    ```yaml
+    pulp_webserver_server: apache
+    pulp_api_bind: "{{ ansible_facts.fqdn }}:24817"
+    pulp_content_bind: "{{ ansible_facts.fqdn }}:24816"
+    pulp_webserver_api_hosts:
+      - address: "pulp-api1:24817"
+        apache_parameters:
+          - keepalive=on
+          - lbset=1
+      - address: "pulp-api2:24817"
+        apache_parameters:
+          - keepalive=on
+          - lbset=2
+    pulp_webserver_content_hosts:
+      - address: "pulp-content1:24817"
+        apache_parameters:
+          - keepalive=on
+          - lbset=1
+      - address: "pulp-content2:24817"
+        apache_parameters:
+          - keepalive=on
+          - lbset=2
+        - upstream_dynamic
+    pulp_webserver_content_balancer_apache_parameters:
+      - lbmethod=bytraffic
+      - timeout=10
+    pulp_webserver_api_balancer_apache_parameters:
+      - lbmethod=bytraffic
+      - timeout=10
+    ```
+
+    For more info on these optional load balancing variables:
+
+    * `apache_parameters` for `pulp_webserver_api_hosts`/`pulp_webserver_content_hosts`: See the Apache "Worker|BalancerMember parameters" under [this link.](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxypass) (Note however that the servers ("BalancerMember") are not specified in the "url" format listed on the link, they must be specified in the "address" format (hostname:port or ip:port) as listed in these docs because pulp generates the URL.)
+    * `pulp_webserver_content_balancer_apache_parameters`/`pulp_webserver_api_balancer_apache_parameters`: See the Apache "Balancer parameters" under [the same link as before.](https://httpd.apache.org/docs/2.4/mod/mod_proxy.html#proxypass)
+    * `nginx_parameters` for `pulp_webserver_api_hosts`/`pulp_webserver_content_hosts`: See the
+      Nginx server "parameters" under [this
+    link.](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#server)
+    * `pulp_webserver_api_balancer_nginx_directives`/`pulp_webserver_content_balancer_nginx_directives`:
+      See the Nginx "Directives" under [the same page as
+    before.](http://nginx.org/en/docs/http/ngx_http_upstream_module.html)
 
 Plugin Webserver Configs
 ------------------------
@@ -171,14 +168,14 @@ Plugin Webserver Configs
 The installer copies config fragments from plugin Python packages, installed on the host that runs
 the `pulp_api` role, to either nginx or apache on the `pulp_webserver` host.
 These fragments typically provide additional url routing to either the Pulp API or
-Pulp Content App. pulp_ansible has an example of such configs [here](https://github.com/pulp/
-pulp_ansible/tree/main/pulp_ansible/app/webserver_snippets).
+Pulp Content App. pulp_ansible has an example of such configs
+[here](https://github.com/pulp/pulp_ansible/tree/main/pulp_ansible/app/webserver_snippets).
 
 The Nginx config provides definitions for the location of the Pulp Content App and the Pulp API as
 pulp-api and pulp-content respectively. To route the url `/pulp_ansible/galaxy/` to the Pulp API you
 could use this definition in a snippet like:
 
-```
+```nginx
 location /pulp_ansible/galaxy/ {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
@@ -194,7 +191,7 @@ The Apache config provides variables containing the location of the Pulp Content
 API as pulp-api and pulp-content respectively. Below is an equivalent snippet to the one above, only
 for Apache:
 
-```
+```apache
 ProxyPass /pulp_ansible/galaxy http://${pulp-api}/pulp_ansible/galaxy
 ProxyPassReverse /pulp_ansible/galaxy http://${pulp-api}/pulp_ansible/galaxy
 ```


### PR DESCRIPTION
To make it easier to find errors, such as those fixed in PR #1193, this commit adds `markdownlint` and a documentation linting step to the GHA pipeline. There is an initial configuration in `.markdownlint.yml` which silences the most common linting errors.

The following linting rule errors were fixed:

- MD004/ul-style
- MD007/ul-indent
- MD009/no-trailing-spaces
- MD012/no-multiple-blanks
- MD022/blanks-around-headings/blanks-around-headers
- MD029/ol-prefix
- MD030/list-marker-space
- MD031/blanks-around-fences
- MD032/blanks-around-lists
- MD034/no-bare-urls
- MD040/fenced-code-language
- MD046/code-block-style

For a detailed description of the rules see here: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md