### PR TITLE
Update pulpcore-selinux policies from 1.3.1 to 1.3.2

### DIFF
--- a/CHANGES/1223.bugfix
+++ b/CHANGES/1223.bugfix
@@ -1,0 +1,1 @@
+Update pulpcore-selinux policies from 1.3.1 to 1.3.2 to enable API/Content processes to read the kernel keyring of the worker processes.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -61,7 +61,7 @@ __pulp_selinux_policy_pkgs:
   - pulpcore
   - pulpcore_rhsmcertd
 __pulp_selinux_repo: 'https://github.com/pulp/pulpcore-selinux.git'
-__pulp_selinux_version: '1.3.1'
+__pulp_selinux_version: '1.3.2'
 __pulp_selinux_label_dirs:
   - "{{ pulp_install_dir }}"
   - "{{ pulp_config_dir }}"


### PR DESCRIPTION
to enable API/Content processes to read the kernel keyring of the
worker processes.

fixes: #1223
fixes: AAP-3970