### PR TITLE
Fix failure on task "pulp_common : Install

### DIFF
--- a/CHANGES/1227.bugfix
+++ b/CHANGES/1227.bugfix
@@ -1,0 +1,1 @@
+Fix failure on task "pulp_common : Install dependencies for LDAP via dnf" when not running the entire playbook with `become==true`.

--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -198,6 +198,7 @@
 - name: "Install dependencies for LDAP support via {{ ansible_facts.pkg_mgr }}"
   package:
     name: "{{ __galaxy_ldap_packages }}"
+  become: true
   when:
     - pulp_install_plugins_normalized['galaxy-ng'] is defined
 


### PR DESCRIPTION
dependencies for LDAP via dnf" when not running the entire playbook
with `become==true`.