### PR TITLE
Fix pulp_installer failing to label ports when

### DIFF
--- a/CHANGES/1233.bugfix
+++ b/CHANGES/1233.bugfix
@@ -1,0 +1,1 @@
+Fix pulp_installer failing to label ports when pulp_install_selinux_policies is set to false.

--- a/roles/pulp_api/tasks/main.yml
+++ b/roles/pulp_api/tasks/main.yml
@@ -56,8 +56,8 @@
       when:
         - not (pulp_api_bind.startswith('unix:'))
         - ansible_facts.os_family == 'RedHat'
-        # We can also try using seport's ignore_selinux_state variable
         - ansible_facts.selinux.status == "enabled"
+        - pulp_install_selinux_policies|bool or pulp_install_selinux_policies == "auto"
 
     - name: Install pulpcore-api service files
       template:

--- a/roles/pulp_common/handlers/main.yml
+++ b/roles/pulp_common/handlers/main.yml
@@ -27,6 +27,7 @@
   when:
     - ansible_facts.os_family == 'RedHat'
     - ansible_facts.selinux.status == "enabled"
+    - pulp_install_selinux_policies|bool or pulp_install_selinux_policies == "auto"
 
 - name: Collect static content
   command: "{{ pulp_django_admin_path }} collectstatic --clear --noinput --link {{ pulp_collectstatic_ignore_list }}"
@@ -57,6 +58,7 @@
     - ansible_facts.os_family == 'RedHat'
     # when permissive or enforcing. That would be stored in .mode & .config_mode
     - ansible_facts.selinux.status == "enabled"
+    - pulp_install_selinux_policies|bool or pulp_install_selinux_policies == "auto"
 
 - name: Restart all Pulp services
   include_tasks: handlers/restart_all_pulp.yml

--- a/roles/pulp_content/tasks/main.yml
+++ b/roles/pulp_content/tasks/main.yml
@@ -32,8 +32,8 @@
       when:
         - not (pulp_content_bind.startswith('unix:'))
         - ansible_facts.os_family == 'RedHat'
-        # We can also try using seport's ignore_selinux_state variable
         - ansible_facts.selinux.status == "enabled"
+        - pulp_install_selinux_policies|bool or pulp_install_selinux_policies == "auto"
 
     - name: Install pulpcore-content service file
       template:


### PR DESCRIPTION
pulp_install_selinux_policies is set to false.

Fixes: #1233