### PR TITLE
Fix "pulp_devel : Initialize virtualenvwrapper"

### DIFF
--- a/CHANGES/1236.bugfix
+++ b/CHANGES/1236.bugfix
@@ -1,0 +1,1 @@
+Fix "pulp_devel : Initialize virtualenvwrapper" failing on CentOS 9.

--- a/roles/pulp_devel/tasks/install_basic_packages.yml
+++ b/roles/pulp_devel/tasks/install_basic_packages.yml
@@ -35,7 +35,7 @@
     virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
   when:
     - (ansible_facts.distribution == 'CentOS') or (ansible_facts.distribution == 'RedHat')
-    - ansible_facts.distribution_major_version|int == 8
+    - ansible_facts.distribution_major_version|int >= 8
 
 - name: Create virtualenvwrapper symlink
   file:
@@ -44,7 +44,7 @@
     state: link
   when:
     - (ansible_facts.distribution == 'CentOS') or (ansible_facts.distribution == 'RedHat')
-    - ansible_facts.distribution_major_version|int == 8
+    - ansible_facts.distribution_major_version|int >= 8
 
 - name: Install Minio Client
   get_url:


### PR DESCRIPTION
failing on CentOS 9.

fixes: #1236