### PR TITLE
Fix situational SELinux denials for nginx/apache

### DIFF
--- a/CHANGES/1239.bugfix
+++ b/CHANGES/1239.bugfix
@@ -1,0 +1,1 @@
+Fix situational SELinux denials for nginx/apache to connect to ports 24816 or 24817.

--- a/roles/pulp_webserver/tasks/main.yml
+++ b/roles/pulp_webserver/tasks/main.yml
@@ -114,8 +114,8 @@
   when:
     - ansible_facts.os_family == 'RedHat'
     - ansible_facts.selinux.status == 'enabled'
-    - pulp_webserver_api_hosts | selectattr('address', 'match', '^unix:.+') | list | count >= 1 or
-      pulp_webserver_content_hosts  | selectattr('address', 'match','^unix:.+') | list | count >= 1
+    - pulp_webserver_api_hosts | rejectattr('address', 'match', '^unix:.+') | list | count >= 1 or
+      pulp_webserver_content_hosts  | rejectattr('address', 'match','^unix:.+') | list | count >= 1
 
 - include_tasks: firewalld.yml
   when: pulp_configure_firewall in ['firewalld', 'auto']


### PR DESCRIPTION
to connect to ports 24816 or 24817.

Fixes a regression from eaf30ed9fadbb49b6dfc65d4c84ac3cf7e0a7592

fixes: #1239