### PR TITLE
Remove the task "pulp_common : Set group on all

### DIFF
--- a/CHANGES/1238.removal
+++ b/CHANGES/1238.removal
@@ -1,0 +1,1 @@
+Support for upgrading from installs prior to pulp_installer 3.6.1 (Aug 2020) has been partially removed. To upgrade from them successfully, run `chgrp pulp /var/lib/pulp -R` before running the installer. This removal fixes a sporadic error with the task "pulp_common : Set group on all files in '/var/lib/pulp'" when run against an NFS /var/lib/pulp (by removing that task.)

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -247,16 +247,6 @@
 
       when: pulp_user_home_stat.stat.pw_name == "apache"
 
-    - name: Set group on all files in '{{ pulp_user_home }}'
-      file:
-        path: '{{ pulp_user_home }}'
-        state: directory
-        group: '{{ pulp_group }}'
-        recurse: true
-        follow: false
-      tags:
-        - molecule-idempotence-notest
-
   become: true
 
 - name: install pulp from {{ pulp_install_source }}


### PR DESCRIPTION
files in '/var/lib/pulp'"

Unbreaks that task sporadically when /var/lib/pulp is on NFS.

fixes: #1238