### PR TITLE
The variable `pulp_cache_dir` has been removed.

### DIFF
--- a/CHANGES/1252.removal
+++ b/CHANGES/1252.removal
@@ -1,0 +1,1 @@
+The variable `pulp_cache_dir` has been removed. Instead of setting both `pulp_cache_dir` and `pulp_settings.working_directory` to change this directory's location, you know only have to set `pulp_settings.working_directory`. The ability to set it has also been fixed.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -114,8 +114,8 @@ There are other (intentional) differences between tests:
    used by all other scenarios. This playbook upgrades a Pulp installation multiple times to ensure
    that all upgrade scenarios work correctly.
 1. The `source-static` scenario defines paths different than the default for the following variables:
-   `pulp_media_root`, `pulp_cache_dir`, `pulp_user_home`, `pulp_install_dir`, `pulp_config_dir` and
-   `developer_user_home`.
+   `pulp_media_root`, `pulp_settings.working_directory`, `pulp_user_home`, `pulp_install_dir`,
+   `pulp_config_dir` and `developer_user_home`.
 
 In order for `cluster` scenarios to work on your local system, you must do the following to enable
 container networking:

--- a/molecule/release-static/group_vars/all
+++ b/molecule/release-static/group_vars/all
@@ -26,6 +26,7 @@ pulp_settings:
   content_origin: "https://{{ ansible_fqdn }}"
   secret_key: secret
   redis_url: "unix:/var/run/redis/redis.sock"
+  working_directory: "/pulp_tmp"
 pulp_webserver_server: apache
 
 # These variables are used by molecule verify, not the installer itself

--- a/molecule/scenario_resources/tests/test_default.rb
+++ b/molecule/scenario_resources/tests/test_default.rb
@@ -14,6 +14,18 @@ describe.one do
   end
 end
 
+describe.one do
+  describe directory('/var/lib/pulp/tmp') do
+    its('owner') { should eq 'pulp' }
+    its('group') { should eq 'pulp' }
+  end
+
+  describe directory('/opt/pulp/cache/') do
+    its('owner') { should eq 'pulp' }
+    its('group') { should eq 'pulp' }
+  end
+end
+
 ['pulpcore-api','pulpcore-content', 'pulpcore-worker@1', 'pulpcore-worker@2'].each do |pservice|
   describe service(pservice) do
     it { should be_running }

--- a/molecule/source-static/group_vars/all
+++ b/molecule/source-static/group_vars/all
@@ -41,7 +41,6 @@ pulp_install_plugins:
      - VitaminC
      - VitaminD
 pulp_media_root: /opt/pulp/media
-pulp_cache_dir: /opt/pulp/cache
 pulp_user_home: /opt/pulp/home
 pulp_install_dir: /opt/pulp/lib
 pulp_config_dir: /opt/pulp/etc
@@ -51,6 +50,7 @@ pulp_settings:
   content_origin: "https://{{ ansible_fqdn }}"
   secret_key: secret
   redis_url: "unix:/var/run/redis/redis.sock"
+  working_directory: /opt/pulp/cache
 
 # These variables are used by molecule verify, not the installer itself
 pulp_lib_path: /opt/pulp/devel

--- a/roles/pulp_common/README.md
+++ b/roles/pulp_common/README.md
@@ -64,14 +64,13 @@ Role Variables
         git_revision: "v3.1.1"   # Optional. The specific git branch/tag/commit to be cheked out.
     ```
 
-* `pulp_cache_dir`: Location of Pulp cache. Defaults to '{{ pulp_user_home }}/tmp'.
 * `pulp_config_dir`: Directory which will contain Pulp configuration files.
   Defaults to "/etc/pulp".
 * `pulp_install_dir`: Location of a virtual environment for Pulp and its Python
   dependencies. Defaults to "/usr/local/lib/pulp".
 * `pulp_user_home`: absolute path for pulp user home. Defaults to "/var/lib/pulp".
-   This variable is also referenced by others like: `pulp_cache_dir`, `pulp_media_root` and
-   `pulp_scripts_dir`.
+   This variable is also referenced by others like: `pulp_settings.working_directory`,
+   `pulp_media_root` and `pulp_scripts_dir`.
 * `pulp_media_root`: `MEDIA_ROOT` for `pulpcore`. Defaults to '{{ pulp_user_home }}/media'.
 * `pulp_certs_dir`: Path where to generate or drop the TLS certificates (see pulp_webserver role) &
   keys for authentication tokens (see pulp_api role.) Also to where the user-provided gpg key for
@@ -152,6 +151,7 @@ Role Variables
       the pulp_common role will add the `{{ pulp_user }}` user to the `redis` group, if that group exists.
       Thus giving pulp access to the redis UNIX domain socket. Make sure to set the same value as
       you set for `pulp_redis_bind`, as documented in [pulp_redis](../../roles/pulp_redis).
+    * `working_directory`: Location of Pulp cache. Defaults to '{{ pulp_user_home }}/tmp'.
     * **Example**:
 
     ```yaml

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -19,7 +19,6 @@ pulp_user_id:
 pulp_group: pulp
 pulp_group_id:
 pulp_user_home: '/var/lib/pulp'
-pulp_cache_dir: "{{ pulp_user_home | regex_replace('\\/$', '') }}/tmp"
 pulp_media_root: "{{ pulp_user_home | regex_replace('\\/$', '') }}/media"
 pulp_scripts_dir: "{{ pulp_user_home | regex_replace('\\/$', '') }}/scripts"
 pulp_pip_editable: yes

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -176,7 +176,7 @@
 
     - name: Create cache dir for Pulp
       file:
-        path: '{{ pulp_cache_dir }}'
+        path: '{{ __pulp_common_merged_pulp_settings.working_directory }}'
         state: directory
         owner: '{{ pulp_user }}'
         group: '{{ pulp_group }}'

--- a/roles/pulp_common/templates/settings.py.j2
+++ b/roles/pulp_common/templates/settings.py.j2
@@ -7,6 +7,5 @@
 DEPLOY_ROOT = "{{ pulp_user_home }}"
 MEDIA_ROOT = "{{ pulp_media_root }}"
 STATIC_ROOT = "{{ pulp_user_home }}/assets"
-WORKING_DIRECTORY = "{{ pulp_user_home }}/tmp"
-FILE_UPLOAD_TEMP_DIR = "{{ pulp_user_home }}/tmp"
+FILE_UPLOAD_TEMP_DIR = "{{ __pulp_common_merged_pulp_settings.working_directory }}"
 DB_ENCRYPTION_KEY = "{{ pulp_certs_dir }}/database_fields.symmetric.key"

--- a/roles/pulp_common/vars/main.yml
+++ b/roles/pulp_common/vars/main.yml
@@ -36,6 +36,7 @@ __pulp_common_pulp_settings_defaults:
   public_key_path: "{{ pulp_certs_dir }}/token_public_key.pem"
   token_server: "{{ pulp_webserver_disable_https | default(false) | ternary('http', 'https') }}://{{ ansible_facts.fqdn }}/token/"
   token_signature_algorithm: ES256
+  working_directory: "{{ pulp_user_home | regex_replace('\\/$', '') }}/tmp"
   content_path_prefix: "{{ pulp_settings.content_path_prefix | default('/pulp/content/') }}"
 
 __pulp_common_merged_pulp_settings: "{{ __pulp_common_pulp_settings_defaults | combine(pulp_settings, recursive=True) }}"

--- a/roles/pulp_database_config/tasks/main.yml
+++ b/roles/pulp_database_config/tasks/main.yml
@@ -226,7 +226,7 @@
     PULP_DEPLOY_ROOT: "{{ pulp_user_home }}"
     PULP_MEDIA_ROOT: "{{ pulp_media_root }}"
     PULP_STATIC_ROOT: "{{ pulp_user_home }}/assets"
-    PULP_WORKING_DIRECTORY: "{{ pulp_user_home }}/tmp"
+    PULP_WORKING_DIRECTORY: "{{ __pulp_common_merged_pulp_settings.working_directory }}"
     PULP_FILE_UPLOAD_TEMP_DIR: "{{ pulp_user_home }}/tmp"
 
 # This task is located here in pulp_database_config because it depends on the database fields encryption key


### PR DESCRIPTION
Instead of setting both `pulp_cache_dir` and
`pulp_settings.working_directory` to change this directory's
location, you know only have to set
`pulp_settings.working_directory`.

The ability to set it has also been fixed.

Fixes: #1252