### PR TITLE
The variable `pulp_media_dir` has been removed.

### DIFF
--- a/CHANGES/1265.removal
+++ b/CHANGES/1265.removal
@@ -1,0 +1,1 @@
+The variable `pulp_media_dir` has been removed. It has been replaced with `pulp_settings.media_root`, which mimics the behavior of pulpcore with the MEDIA_ROOT variable.

--- a/molecule/source-static/group_vars/all
+++ b/molecule/source-static/group_vars/all
@@ -40,7 +40,6 @@ pulp_install_plugins:
     extras:
      - VitaminC
      - VitaminD
-pulp_media_root: /opt/pulp/media
 pulp_user_home: /opt/pulp/home
 pulp_install_dir: /opt/pulp/lib
 pulp_config_dir: /opt/pulp/etc
@@ -48,6 +47,7 @@ developer_user_home: /opt/pulp/devel
 developer_user: pulp
 pulp_settings:
   content_origin: "https://{{ ansible_fqdn }}"
+  media_root: /opt/pulp/media
   secret_key: secret
   redis_url: "unix:/var/run/redis/redis.sock"
   static_root: /opt/pulp/assets

--- a/roles/pulp_common/README.md
+++ b/roles/pulp_common/README.md
@@ -69,10 +69,8 @@ Role Variables
 * `pulp_install_dir`: Location of a virtual environment for Pulp and its Python
   dependencies. Defaults to "/usr/local/lib/pulp".
 * `pulp_user_home`: absolute path for pulp user home. Defaults to "/var/lib/pulp".
-   This variable is also referenced by others like: `pulp_settings.working_directory`,
-   `pulp_media_root` and `pulp_scripts_dir`.
-* `pulp_media_root`: `MEDIA_ROOT` for `pulpcore`. Defaults to '{{ pulp_settings.deploy_root }}/media',
-  which evaluates by default to `/var/lib/pulp/media`.
+  This variable is also default for "{{ pulp_settings.deploy_root }}, which multiple directories
+  are under. Also, `pulp_scripts_dir` is placed under it.
 * `pulp_certs_dir`: Path where to generate or drop the TLS certificates (see pulp_webserver role) &
   keys for authentication tokens (see pulp_api role.) Also to where the user-provided gpg key for
   the galaxy-ng collection signing service is placed (see galaxy_post_install role.) Defaults to
@@ -152,11 +150,13 @@ Role Variables
       the pulp_common role will add the `{{ pulp_user }}` user to the `redis` group, if that group exists.
       Thus giving pulp access to the redis UNIX domain socket. Make sure to set the same value as
       you set for `pulp_redis_bind`, as documented in [pulp_redis](../../roles/pulp_redis).
-    * `deploy_root` Location on disk whereby `static_root`, `working_directory` and
-      `pulp_media_root` are stored under. Defaults to `{{ pulp_user_home }}`, which evaluates by default to
-      `/var/lib/pulp`.
+    * `deploy_root` Location on disk where `pulp_settings.static_root`, `pulp_settings.working_directory`
+      and `pulp_settings.media_root` are stored under. Defaults to `{{ pulp_user_home }}`, which evaluates
+      by default to `/var/lib/pulp`.
+    * `media_root`: Location where Pulp will store files. Defaults to '{{ pulp_settings.deploy_root }}/media',
+      which evaluates by default to `/var/lib/pulp/media`.
     * `static_root`: Location on disk of the static content served by the pulpcore-api service. Defaults to
-      `{{ pulp_user_home }}{{ pulp_settings.static_url }}`, which
+      `{{ pulp_settings.deploy_root }}{{ pulp_settings.static_url }}`, which
       evaluates by default to `/var/lib/pulp/assets`.
     * `static_url`: The URL under which static content is served by the pulpcore-api service. Also a
       component of the location on disk where the static content is stored (see

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -151,7 +151,7 @@
 
     - name: Create media dir for Pulp
       file:
-        path: '{{ pulp_media_root }}'
+        path: '{{ __pulp_common_merged_pulp_settings.media_root }}'
         state: directory
         owner: '{{ pulp_user }}'
         group: '{{ pulp_group }}'

--- a/roles/pulp_common/templates/settings.py.j2
+++ b/roles/pulp_common/templates/settings.py.j2
@@ -5,5 +5,4 @@
 {% endfor %}
 {# https://github.com/pulp/pulpcore/blob/master/pulpcore/app/settings.py#L37-L38 #}
 FILE_UPLOAD_TEMP_DIR = "{{ __pulp_common_merged_pulp_settings.working_directory }}"
-MEDIA_ROOT = "{{ pulp_media_root }}"
 DB_ENCRYPTION_KEY = "{{ pulp_certs_dir }}/database_fields.symmetric.key"

--- a/roles/pulp_common/vars/main.yml
+++ b/roles/pulp_common/vars/main.yml
@@ -33,6 +33,7 @@ __pulp_common_pulp_settings_defaults:
   redis_host: localhost
   redis_port: 6379
   cache_enabled: True
+  media_root: "{{ pulp_settings.deploy_root | default(pulp_user_home) | regex_replace('\\/$', '') }}/media"
   private_key_path: "{{ pulp_certs_dir }}/token_private_key.pem"
   public_key_path: "{{ pulp_certs_dir }}/token_public_key.pem"
   static_root: "{{ pulp_settings.deploy_root | default(pulp_user_home) | regex_replace('\\/$', '') }}{{ pulp_settings.static_url | default('/assets/') | regex_replace('\\/$', '') }}"
@@ -47,7 +48,7 @@ __pulp_common_merged_pulp_settings: "{{ __pulp_common_pulp_settings_defaults | c
 __pulpcore_version: '{{ pulpcore_version | default("3.20") }}'
 
 __pulp_old_artifact_dir: "{{ pulp_user_home | regex_replace('\\/$', '')  }}/artifact"
-__pulp_artifact_dir: "{{ pulp_media_root | regex_replace('\\/$', '')  }}/artifact"
+__pulp_artifact_dir: "{{ __pulp_common_merged_pulp_settings.media_root | regex_replace('\\/$', '')  }}/artifact"
 
 __galaxy_profile: '{{ galaxy_profile | default("standalone") }}'
 __galaxy_dev_source_path: '{{ galaxy_dev_source_path | default("pulpcore:pulp_ansible:pulp_container:galaxy_ng:galaxy-importer") }}'
@@ -58,4 +59,3 @@ __galaxy_lock_requirements: '{{ galaxy_lock_requirements | default(__galaxy_lock
 
 # Pulps own replacement for django-admin setup in the proper environment
 pulp_django_admin_path: "{{ pulp_install_dir }}/bin/pulpcore-manager"
-pulp_media_root: "{{ __pulp_common_merged_pulp_settings.deploy_root | regex_replace('\\/$', '') }}/media"

--- a/roles/pulp_devel/templates/alias.bashrc.j2
+++ b/roles/pulp_devel/templates/alias.bashrc.j2
@@ -44,7 +44,7 @@ _pdbreset_help="$_dbreset_help - `setterm -foreground red -bold on`THIS DESTROYS
 
 pclean() {
     pdbreset
-    sudo rm -rf {{ pulp_media_root }}/*
+    sudo rm -rf {{ __pulp_common_merged_pulp_settings.media_root }}/*
     redis-cli FLUSHALL
     {{ pulp_django_admin_path }} collectstatic --clear --noinput --link
 }


### PR DESCRIPTION
It has been replaced with `pulp_settings.media_root`,
which mimics the behavior of pulpcore with the MEDIA_ROOT variable.

fixes: #1265