### PR TITLE
Fix pulp_settings.file_upload_temp_dir

### DIFF
--- a/CHANGES/1269.bugfix
+++ b/CHANGES/1269.bugfix
@@ -1,0 +1,1 @@
+Fix the ability to specify `pulp_settings.file_upload_temp_dir`.

--- a/molecule/source-static/group_vars/all
+++ b/molecule/source-static/group_vars/all
@@ -52,6 +52,7 @@ pulp_settings:
   redis_url: "unix:/var/run/redis/redis.sock"
   static_root: /opt/pulp/assets
   working_directory: /opt/pulp/cache
+  file_upload_temp_dir: /opt/pulp/file_upload_temp
 
 # These variables are used by molecule verify, not the installer itself
 pulp_lib_path: /opt/pulp/devel

--- a/roles/pulp_common/README.md
+++ b/roles/pulp_common/README.md
@@ -153,6 +153,9 @@ Role Variables
     * `deploy_root` Location on disk where `pulp_settings.static_root`, `pulp_settings.working_directory`
       and `pulp_settings.media_root` are stored under. Defaults to `{{ pulp_user_home }}`, which evaluates
       by default to `/var/lib/pulp`.
+    * `file_upload_temp_dir`: The directory to store data to (typically files larger than
+      `pulp_settings.file_upload_max_memory_size`) temporarily while uploading files. Defaults to
+      `{{ pulp_settings.working_directory }}`, which evaluates by default to `/var/lib/pulp/tmp`.
     * `media_root`: Location where Pulp will store files. Defaults to '{{ pulp_settings.deploy_root }}/media',
       which evaluates by default to `/var/lib/pulp/media`.
     * `static_root`: Location on disk of the static content served by the pulpcore-api service. Defaults to

--- a/roles/pulp_common/tasks/install.yml
+++ b/roles/pulp_common/tasks/install.yml
@@ -171,6 +171,17 @@
         setype: _default
         seuser: _default
 
+    - name: Create file upload temp dir for Pulp
+      file:
+        path: '{{ __pulp_common_merged_pulp_settings.file_upload_temp_dir }}'
+        state: directory
+        owner: '{{ pulp_user }}'
+        group: '{{ pulp_group }}'
+        mode: "u+rwx,g+rwx,o+rx"
+        serole: _default
+        setype: _default
+        seuser: _default
+
     - name: Create assets (static) dir for Pulp
       file:
         path: '{{ __pulp_common_merged_pulp_settings.static_root }}'

--- a/roles/pulp_common/templates/settings.py.j2
+++ b/roles/pulp_common/templates/settings.py.j2
@@ -4,5 +4,4 @@
 {{ setting | upper }} = {{ value | mdellweg.filters.repr }}
 {% endfor %}
 {# https://github.com/pulp/pulpcore/blob/master/pulpcore/app/settings.py#L37-L38 #}
-FILE_UPLOAD_TEMP_DIR = "{{ __pulp_common_merged_pulp_settings.working_directory }}"
 DB_ENCRYPTION_KEY = "{{ pulp_certs_dir }}/database_fields.symmetric.key"

--- a/roles/pulp_common/vars/main.yml
+++ b/roles/pulp_common/vars/main.yml
@@ -20,6 +20,7 @@ pulp_collectstatic_ignore_list: |-
 # pip/PyPI only uses dashes, not underscores.
 pulp_install_plugins_normalized: "{{ pulp_install_plugins_normalized_yml | from_yaml }}"
 pulp_certs_dir: "{{ pulp_config_dir }}/certs"
+
 # Users should not set these variables, but instead use `pulp_settings`
 __pulp_common_pulp_settings_defaults:
   databases:
@@ -42,8 +43,10 @@ __pulp_common_pulp_settings_defaults:
   token_signature_algorithm: ES256
   working_directory: "{{ pulp_settings.deploy_root | default(pulp_user_home) | regex_replace('\\/$', '') }}/tmp"
   content_path_prefix: "{{ pulp_settings.content_path_prefix | default('/pulp/content/') }}"
+__pulp_common_pulp_settings_defaults_dependent_vars:
+  file_upload_temp_dir: "{{ pulp_settings.working_directory | default(__pulp_common_pulp_settings_defaults.working_directory) }}"
 
-__pulp_common_merged_pulp_settings: "{{ __pulp_common_pulp_settings_defaults | combine(pulp_settings, recursive=True) }}"
+__pulp_common_merged_pulp_settings: "{{ __pulp_common_pulp_settings_defaults | combine(__pulp_common_pulp_settings_defaults_dependent_vars, recursive=true) | combine(pulp_settings, recursive=True) }}"
 
 __pulpcore_version: '{{ pulpcore_version | default("3.20") }}'
 


### PR DESCRIPTION
not being able to be changed.

Fixes: #1269 