### PR TITLE
Fix installing pulpcore RPMs < 3.15

### DIFF
--- a/CHANGES/1275.bugfix
+++ b/CHANGES/1275.bugfix
@@ -1,0 +1,1 @@
+Fix installing pulpcore RPMs < 3.15 by not installing the undeclared dependencies when pulpcore_version < 3.15.

--- a/roles/pulp_common/tasks/install_packages.yml
+++ b/roles/pulp_common/tasks/install_packages.yml
@@ -87,6 +87,7 @@
         name: "{{ pulp_pkg_undeclared_deps }}"
         state: "{{ pulp_pkg_upgrade_all | ternary('latest','present') }}"
         exclude: '{{ pulp_pkg_exclude | default(omit) }}'
+      when: __pulp_version is version('3.15', '>=')
       notify:
         - Collect static content
         - Restart all Pulp services


### PR DESCRIPTION
by not installing the undeclared dependencies
when pulpcore_version < 3.15.

fixes: #1275