### PR TITLE
Re-re-fix Fix source-dynamic CI failing to install

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,7 +82,7 @@ jobs:
         shell: bash
       # https://github.com/ansible-community/molecule-docker/issues/161#issuecomment-1192604356
       - name: Workaround bug with latest molecule and ansible 2.9
-       if: matrix.python != '2.7' && matrix.ansible == 'ansible~=2.9.0'
+        if: matrix.python != '2.7' && matrix.ansible == 'ansible~=2.9.0'
         run: ansible-galaxy collection install community.docker:=3.0.0-a2
         shell: bash
       - name: Molecule dependency


### PR DESCRIPTION
community.docker on ansible 2.9 with python3.

fixes: #1281