### PR TITLE
3.15: Fix "Too many open files" error when syncing with

### DIFF
--- a/CHANGES/1289.bugfix
+++ b/CHANGES/1289.bugfix
@@ -1,0 +1,1 @@
+Fix "Too many open files" error when syncing with pulp_ansible.

--- a/roles/pulp_api/templates/pulpcore-api.service.j2
+++ b/roles/pulp_api/templates/pulpcore-api.service.j2
@@ -20,6 +20,7 @@ User={{ pulp_user }}
 Group={{ pulp_group }}
 PIDFile=/run/pulpcore-api.pid
 RuntimeDirectory=pulpcore-api
+LimitNOFILE=524288
 
 # timeout is needed Pulp to service its 1st request on extremely slow
 # machines, such as qemu-emulated 2-core machines

--- a/roles/pulp_content/templates/pulpcore-content.service.j2
+++ b/roles/pulp_content/templates/pulpcore-content.service.j2
@@ -19,6 +19,7 @@ User={{ pulp_user }}
 Group={{ pulp_group }}
 WorkingDirectory=/var/run/pulpcore-content/
 RuntimeDirectory=pulpcore-content
+LimitNOFILE=524288
 
 # timeout is needed Pulp to service its 1st request on extremely slow
 # machines, such as qemu-emulated 2-core machines

--- a/roles/pulp_workers/templates/pulpcore-worker@.service.j2
+++ b/roles/pulp_workers/templates/pulpcore-worker@.service.j2
@@ -20,6 +20,8 @@ User={{ pulp_user }}
 Group={{ pulp_group }}
 WorkingDirectory=/var/run/pulpcore-worker-%i/
 RuntimeDirectory=pulpcore-worker-%i
+LimitNOFILE=524288
+
 {% if __pulp_version is version('3.13', '>=') -%}
 ExecStart={{ __pulp_daemons_dir }}/pulpcore-worker
 {%- else -%}


### PR DESCRIPTION
pulp_ansible.

fixes: #1289
(cherry picked from commit 399d00c2bcaf7ef61faed9bc83a192841f0e6fb5)