### PR TITLE
3.9: Fix "Too many open files" error when syncing with

### DIFF
--- a/CHANGES/1289.bugfix
+++ b/CHANGES/1289.bugfix
@@ -1,0 +1,1 @@
+Fix "Too many open files" error when syncing with pulp_ansible.

--- a/roles/pulp_api/templates/pulpcore-api.service.j2
+++ b/roles/pulp_api/templates/pulpcore-api.service.j2
@@ -14,6 +14,8 @@ User={{ pulp_user }}
 Group={{ pulp_group }}
 PIDFile=/run/pulpcore-api.pid
 RuntimeDirectory=pulpcore-api
+LimitNOFILE=524288
+
 ExecStart={{ __pulp_daemons_dir }}/gunicorn pulpcore.app.wsgi:application \
           --bind '{{ pulp_api_bind }}' \
           --workers {{ pulp_api_workers }} \

--- a/roles/pulp_content/templates/pulpcore-content.service.j2
+++ b/roles/pulp_content/templates/pulpcore-content.service.j2
@@ -14,6 +14,8 @@ User={{ pulp_user }}
 Group={{ pulp_group }}
 WorkingDirectory=/var/run/pulpcore-content/
 RuntimeDirectory=pulpcore-content
+LimitNOFILE=524288
+
 ExecStart={{ __pulp_daemons_dir }}/gunicorn pulpcore.content:server \
           --bind '{{ pulp_content_bind }}' \
           --worker-class 'aiohttp.GunicornWebWorker' \

--- a/roles/pulp_workers/templates/pulpcore-worker@.service.j2
+++ b/roles/pulp_workers/templates/pulpcore-worker@.service.j2
@@ -16,6 +16,8 @@ User={{ pulp_user }}
 Group={{ pulp_group }}
 WorkingDirectory=/var/run/pulpcore-worker-%i/
 RuntimeDirectory=pulpcore-worker-%i
+LimitNOFILE=524288
+
 ExecStart={{ __pulp_daemons_dir }}/rq worker \
           -w pulpcore.tasking.worker.PulpWorker \
           --pid=/var/run/pulpcore-worker-%i/reserved-resource-worker-%i.pid \


### PR DESCRIPTION
pulp_ansible.

fixes: #1289
(cherry picked from commit 399d00c2bcaf7ef61faed9bc83a192841f0e6fb5)