### PR TITLE
3.9: Migrate to CentOS Stream 8 in molecule

### DIFF
--- a/.github/vars/main.yaml
+++ b/.github/vars/main.yaml
@@ -3,8 +3,8 @@ molecule_images:
   - name: centos-7
     image: centos:7
     command: /sbin/init
-  - name: centos-8
-    image: centos:8
+  - name: centos-stream8
+    image: centos:stream8
     command: /sbin/init
   - name: fedora-33
     image: fedora:33

--- a/CHANGES/860.removal
+++ b/CHANGES/860.removal
@@ -1,0 +1,1 @@
+CentOS 8 is now EOL, and thus Pulp no longer formally supports it. Pulp now only tests fresh installs with CentOS Stream 8, and with upgrades from CentOS 8 to CentOS Stream 8 (see migration instructions here https://centos.org/centos-stream/).

--- a/molecule/release-static/prepare.yml
+++ b/molecule/release-static/prepare.yml
@@ -51,6 +51,33 @@
       # We aren't really changing the system, so let's minimize the reporting of CHANGED tasks.
       changed_when: False
 
+    - name: Migrate CentOS 8 to CentOS Stream 8
+      block:
+        - name: Get latest CentOS 8 GPG keys and its temporary dependency
+          dnf:
+            name:
+              - https://vault.centos.org/8.5.2111/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm
+              - https://vault.centos.org/8.5.2111/BaseOS/x86_64/os/Packages/centos-linux-repos-8-3.el8.noarch.rpm
+            disablerepo:
+              - baseos
+              - appstream
+              - extras
+          when:
+            - ansible_distribution == "CentOS"
+            - ansible_distribution_version in ["8.3","8.4"]
+
+        - name: Switch to CentOS 8 Stream repos
+          command: dnf -y --disablerepo * --enablerepo extras swap centos-linux-repos centos-stream-repos
+
+        - name: Finish CentOS 8 Stream migration
+          dnf:
+            name:
+              - centos-stream-release
+              - centos-gpg-keys
+      when:
+        - ansible_distribution == "CentOS"
+        - ansible_distribution_version in ["8.3","8.4","8.5"]
+
     # Probably needed due to a mismatch of systemd versions/capabilities between the Ubuntu GHA
     # host and the container
     - name: Update systemd to fix the Ansible systemd module, and inspec (verify phase)

--- a/molecule/source-static/prepare.yml
+++ b/molecule/source-static/prepare.yml
@@ -2,12 +2,6 @@
 - hosts:
     - all
   tasks:
-    - name: Install required packages
-      package:
-        name:
-          - git
-        state: present
-
     - name: Create user {{ developer_user }}
       user:
         name: '{{ developer_user }}'
@@ -49,3 +43,30 @@
       when:
         - ansible_os_family == "RedHat"
         - ansible_distribution_major_version|int == 7
+
+    - name: Migrate CentOS 8 to CentOS Stream 8
+      block:
+        - name: Get latest CentOS 8 GPG keys and its temporary dependency
+          dnf:
+            name:
+              - https://vault.centos.org/8.5.2111/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm
+              - https://vault.centos.org/8.5.2111/BaseOS/x86_64/os/Packages/centos-linux-repos-8-3.el8.noarch.rpm
+            disablerepo:
+              - baseos
+              - appstream
+              - extras
+          when:
+            - ansible_distribution == "CentOS"
+            - ansible_distribution_version in ["8.3","8.4"]
+
+        - name: Switch to CentOS 8 Stream repos
+          command: dnf -y --disablerepo * --enablerepo extras swap centos-linux-repos centos-stream-repos
+
+        - name: Finish CentOS 8 Stream migration
+          dnf:
+            name:
+              - centos-stream-release
+              - centos-gpg-keys
+      when:
+        - ansible_distribution == "CentOS"
+        - ansible_distribution_version in ["8.3","8.4","8.5"]


### PR DESCRIPTION
Resolves CI failing due to 8's repos being no longer available
due to 8's EOL.

Implementation includes testing upgrades from CentOS 8 to CentOS
Stream 8 per instructions here:
https://centos.org/centos-stream/
With an additional step for 8.3 upgrades.

fixes: #860