### PR TITLE
3.9: Fix old version of ansible-lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,11 @@ sitepackages = true
 deps =
     ansible2.9: ansible~=2.9.0
     ansible2.10: ansible~=2.10.0
+    # Old version of ansible-lint needs this now
+    py36: rich < 11.0.0
+    py37: rich < 11.0.0
+    py38: rich < 11.0.0
+    py39: rich < 11.0.0
     ansible-lint[yamllint] < 5.0.10
     docker
     molecule


### PR DESCRIPTION
[noissue]