### PR TITLE
3.9: Fix failure to install install from pip

### DIFF
--- a/CHANGES/1306.bugfix
+++ b/CHANGES/1306.bugfix
@@ -1,0 +1,1 @@
+Fix failure to install from pip with a async-timeout version error.

--- a/roles/pulp_common/defaults/main.yml
+++ b/roles/pulp_common/defaults/main.yml
@@ -21,6 +21,7 @@ pulp_pip_editable: yes
 pulp_use_system_wide_pkgs: false
 prereq_pip_packages:
   - Jinja2
+  - redis==4.1.4
 pulp_rhel_codeready_repo:
   - codeready-builder-for-rhel-8-x86_64-rpms
   - rhui-codeready-builder-for-rhel-8-rhui-rpms

--- a/roles/pulp_common/templates/requirements.in.j2
+++ b/roles/pulp_common/templates/requirements.in.j2
@@ -15,3 +15,7 @@ pulpcore=={{ __pulp_version }}
 {% endif %}
 
 {%- endfor %}
+
+{% for package in prereq_pip_packages %}
+{{ package }}
+{% endfor %}

--- a/roles/pulp_devel/tasks/install_podman.yml
+++ b/roles/pulp_devel/tasks/install_podman.yml
@@ -7,6 +7,10 @@
   when:
     - ansible_facts.distribution == 'Debian'
     - ansible_facts['distribution_major_version'] == "10"
+  retries: "{{ pulp_devel_package_retries }}"
+  delay: 12
+  register: result
+  until: result is succeeded
 
 - name: Ensure podman repository (Debian-specific)
   apt_repository:
@@ -16,6 +20,10 @@
   when:
     - ansible_facts.distribution == 'Debian'
     - ansible_facts['distribution_major_version'] == "10"
+  retries: "{{ pulp_devel_package_retries }}"
+  delay: 12
+  register: result
+  until: result is succeeded
 
 - name: Ensure backports repository (Debian-specific)
   apt_repository:


### PR DESCRIPTION
with an async-timeout version error

Includes specifying prereq_pip_packages in the preflight check.

It was failing with:
Could not find a version that matches async-timeout<4.0,>=3.0,>=4.0.2 (from redis==4.2.0->pulpcore==3.14.5->-r requirements.in (line 1))

[noissue]

(cherry picked from commit 3bb0760fbd85e0ac107d0292c848bb30b0fa6ac5)