### PR TITLE
Vagrant: Drop support for cloud backends other

### DIFF
--- a/CHANGES/1296.dev
+++ b/CHANGES/1296.dev
@@ -1,0 +1,1 @@
+Vagrant: Drop support for cloud backends other than google in order to fix compatibility with latest forklift.

--- a/vagrant/boxes.d/00-centos.yaml
+++ b/vagrant/boxes.d/00-centos.yaml
@@ -3,7 +3,6 @@
 # more frequently
 centos7:
   box_name:   'generic/centos7'
-  image_name: !ruby/regexp '/CentOS 7.*PV/'
   google_options:
     image_family: 'centos-7'
   pty:        true

--- a/vagrant/boxes.d/00-debian.yaml
+++ b/vagrant/boxes.d/00-debian.yaml
@@ -1,7 +1,6 @@
 debian11:
   box_name: 'debian/bullseye64'
   # box_check_update: false
-  image_name: !ruby/regexp '/Debian 10.*/'
   pty: true
   ansible:
     variables:

--- a/vagrant/boxes.d/00-fedora.yaml
+++ b/vagrant/boxes.d/00-fedora.yaml
@@ -1,6 +1,5 @@
 fedora35:
   box_name: 'fedora/35-cloud-base'
-  image_name: !ruby/regexp '/Fedora 35.*/'
   pty: true
   ansible:
     variables:
@@ -8,7 +7,6 @@ fedora35:
 
 fedora36:
   box_name: 'fedora/36-cloud-base'
-  image_name: !ruby/regexp '/Fedora 36.*/'
   pty: true
   ansible:
     variables:


### PR DESCRIPTION
than google in order to fix compatibility with latest forklift.

fixes: #1296