### PR TITLE
Automatically configure postgresql_hba_entries

### DIFF
--- a/CHANGES/1219.feature
+++ b/CHANGES/1219.feature
@@ -1,0 +1,1 @@
+Automatically configure postgresql_hba_entries based on __pulp_database_merged_pulp_settings.databases.default.HOST

--- a/molecule/packages-cluster/group_vars/all
+++ b/molecule/packages-cluster/group_vars/all
@@ -64,12 +64,6 @@ pulp_settings:
       NAME: pulp
       USER: pulp
       PASSWORD: password
-postgresql_hba_entries:
-  - { type: local, database: all, user: postgres, auth_method: peer }
-  - { type: local, database: all, user: all, auth_method: peer }
-  - { type: host, database: all, user: all, address: '127.0.0.1/32', auth_method: md5 }
-  - { type: host, database: all, user: all, address: '::1/128', auth_method: md5 }
-  - { type: host, database: all, user: all, address: '172.17.0.0/24', auth_method: md5 }
 __pulp_molecule_verify_skip_testinfra_tests: true
 __pulp_molecule_verify_has_db_fields_key: false
 

--- a/molecule/release-cluster/group_vars/all
+++ b/molecule/release-cluster/group_vars/all
@@ -57,12 +57,14 @@ pulp_settings:
       NAME: pulp
       USER: pulp
       PASSWORD: password
+# Configuring postgresql_hba_entries is no longer necessary, but we document this as an alternative to be
+# specified, so we test this value anyway.
 postgresql_hba_entries:
   - { type: local, database: all, user: postgres, auth_method: peer }
   - { type: local, database: all, user: all, auth_method: peer }
   - { type: host, database: all, user: all, address: '127.0.0.1/32', auth_method: md5 }
   - { type: host, database: all, user: all, address: '::1/128', auth_method: md5 }
-  - { type: host, database: all, user: all, address: '172.17.0.0/24', auth_method: md5 }
+  - { type: host, database: all, user: all, ip_address: '{{ ansible_default_ipv4.network }}', ip_mask: '{{ ansible_default_ipv4.netmask }}', auth_method: md5 }
 __pulp_molecule_verify_skip_testinfra_tests: true
 __pulp_molecule_verify_has_db_fields_key: false
 

--- a/molecule/source-cluster/group_vars/all
+++ b/molecule/source-cluster/group_vars/all
@@ -68,12 +68,6 @@ pulp_settings:
       NAME: pulp
       USER: pulp
       PASSWORD: password
-postgresql_hba_entries:
-  - { type: local, database: all, user: postgres, auth_method: peer }
-  - { type: local, database: all, user: all, auth_method: peer }
-  - { type: host, database: all, user: all, address: '127.0.0.1/32', auth_method: md5 }
-  - { type: host, database: all, user: all, address: '::1/128', auth_method: md5 }
-  - { type: host, database: all, user: all, address: '172.17.0.0/24', auth_method: md5 }
 __pulp_molecule_verify_skip_testinfra_tests: true
 __pulp_molecule_verify_has_db_fields_key: false
 

--- a/roles/pulp_database/README.md
+++ b/roles/pulp_database/README.md
@@ -6,7 +6,9 @@ Install a suitable database server for Pulp.
 More specifically, this role does the following:
 
 1. Call the `pulp_repos` role to enable the appropriate SCL (EL7)
-2. Call the external role to install a PostgreSQL database server.
+2. Call the external role
+   ([geerlingguy.postgresql](https://github.com/geerlingguy/ansible-role-postgresql#readme))
+   to install a PostgreSQL database server.
 3. Install the Python bindings to interact with the specified database via
    the role.
 4. Configures the PostgreSQL database to listen on all addresses if the
@@ -28,6 +30,8 @@ This role is **not tightly coupled** to the [pulp_common](../../roles/pulp_commo
   smaller set of settings. The smaller set of settings is listed below. Note that these default settings are merged by the
   installer with your own; merely setting pulp_settings with 1 setting under it will not blow away all
   the other default settings.
+    * `HOST` The hostname or IP address of the pulp database that pulp_common will connect to. This
+      determines the default value of `postgresql_global_config_options`. Defaults to "localhost".
     * `NAME` The name of the Pulp database to create.  Defaults to `pulp`.
     * `USER` The user account to be created with permissions on the database.  Defaults to `pulp`.
     * `PASSWORD` The password to be created for the user account to talk to the Pulp database.
@@ -42,6 +46,70 @@ This role is **not tightly coupled** to the [pulp_common](../../roles/pulp_commo
           USER: pulp
           PASSWORD: password
     ```
+
+* `postgresql_global_config_options`: A list of dictionaries. It is a variable for the
+  [external role](https://github.com/geerlingguy/ansible-role-postgresql#readme)
+  to set multiple options. Pulp has 2 possible default values for this.
+
+  If `pulp_settings.databases.default.HOST==localhost`
+
+```yaml
+  - option: unix_socket_directories
+    value: '{{ postgresql_unix_socket_directories | join(",") }}'
+  - option: log_directory
+    value: 'log'
+```
+
+  If `pulp_settings.databases.default.HOST!=localhost`
+
+```yaml
+  - option: unix_socket_directories
+    value: '{{ postgresql_unix_socket_directories | join(",") }}'
+  - option: listen_addresses
+    value: "*"
+  - option: log_directory
+    value: 'log'
+```
+
+  In other words, if set to localhost, postgresql will listen on UNIX sockets (specified by the
+  [external role](https://github.com/geerlingguy/ansible-role-postgresql#readme)), in addition to the
+  default of the loopback interface. If not set to localhost, postgresql will listen on all network interfaces.
+
+* `postgresql_hba_entries`: A list of dictionaries. It is a variable for the
+  [external role](https://github.com/geerlingguy/ansible-role-postgresql#readme)
+  to configure [client authentication.](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html)
+
+  If `pulp_settings.databases.default.HOST==localhost`
+
+```yaml
+  - { type: local, database: all, user: postgres, auth_method: peer }
+  - { type: local, database: all, user: all, auth_method: peer }
+  - { type: host, database: all, user: all, address: '127.0.0.1/32', auth_method: md5 }
+  - { type: host, database: all, user: all, address: '::1/128', auth_method: md5 }
+```
+
+  If `pulp_settings.databases.default.HOST!=localhost`
+
+```yaml
+  - { type: local, database: all, user: postgres, auth_method: peer }
+  - { type: local, database: all, user: all, auth_method: peer }
+  - { type: host, database: all, user: all, address: '0.0.0.0/0', auth_method: md5 }
+  - { type: host, database: all, user: all, address: '::0/0', auth_method: md5 }
+```
+
+  In other words, if set to localhost, postgresql will authenticate on UNIX sockets and on the loopback interface.
+  If not set to localhost, postgresql will authenticate on a UNIX socket and on all network interfaces.
+
+  For security, you may also consider setting it to the following, which will limit it to local networks:
+
+```yaml
+
+  - { type: local, database: all, user: postgres, auth_method: peer }
+  - { type: local, database: all, user: all, auth_method: peer }
+  - { type: host, database: all, user: all, address: '127.0.0.1/32', auth_method: md5 }
+  - { type: host, database: all, user: all, address: '::1/128', auth_method: md5 }
+  - { type: host, database: all, user: all, ip_address: '{{ ansible_default_ipv4.network }}', ip_mask: '{{ ansible_default_ipv4.netmask }}', auth_method: md5 }
+```
 
 Operating Systems Variables
 ---------------------------

--- a/roles/pulp_database/vars/main.yml
+++ b/roles/pulp_database/vars/main.yml
@@ -28,12 +28,27 @@ __pulp_database_local_postgresql_global_config_options:
     value: 'log'
 
 __pulp_database_remote_postgresql_global_config_options:
+  - option: unix_socket_directories
+    value: '{{ postgresql_unix_socket_directories | join(",") }}'
   - option: listen_addresses
     value: "*"
   - option: log_directory
     value: 'log'
 
+__pulp_database_local_postgresql_hba_entries:
+  - { type: local, database: all, user: postgres, auth_method: peer }
+  - { type: local, database: all, user: all, auth_method: peer }
+  - { type: host, database: all, user: all, address: '127.0.0.1/32', auth_method: md5 }
+  - { type: host, database: all, user: all, address: '::1/128', auth_method: md5 }
+
+__pulp_database_remote_postgresql_hba_entries:
+  - { type: local, database: all, user: postgres, auth_method: peer }
+  - { type: local, database: all, user: all, auth_method: peer }
+  - { type: host, database: all, user: all, address: '0.0.0.0/0', auth_method: md5 }
+  - { type: host, database: all, user: all, address: '::0/0', auth_method: md5 }
+
 postgresql_global_config_options: "{{ (__pulp_database_merged_pulp_settings.databases.default.HOST == 'localhost') | ternary(__pulp_database_local_postgresql_global_config_options, __pulp_database_remote_postgresql_global_config_options) }}"
+postgresql_hba_entries: "{{ (__pulp_database_merged_pulp_settings.databases.default.HOST == 'localhost') | ternary(__pulp_database_local_postgresql_hba_entries, __pulp_database_remote_postgresql_hba_entries) }}"
 
 # The following task has failed in the past for FIPS-enabled systems, so let's see its output:
 # geerlingguy.postgresql : Ensure PostgreSQL users are configured correctly


### PR DESCRIPTION
    based on __pulp_database_merged_pulp_settings.databases.default.HOST
    
    Also document it and postgresql_global_config_options.
    
    Also configure postgresql_global_config_options to include
    unix_socket_directories all the time.
    
    fixes: #1219
