### PR TITLE
Fix CI tests with Ansible 2.9 and Python 3 failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           pip install docker molecule ${{ matrix.ansible }}
       - name: Workaround bug with latest molecule and ansible 2.9
         if: matrix.python != '2.7' && matrix.ansible == 'ansible~=2.9.0'
-        run: pip install molecule~=3.6.1
+        run: pip install molecule~=3.6.1 molecule-docker~=1.1
         shell: bash
       - name: Setting pulp.pulp_installer collection
         # Downloading dependencies sometimes fails the 1st time, so retry

--- a/.github/workflows/devel_ci.yml
+++ b/.github/workflows/devel_ci.yml
@@ -48,7 +48,7 @@ jobs:
           pip install docker molecule ${{ matrix.ansible }}
       - name: Workaround bug with latest molecule and ansible 2.9
         if: matrix.python != '2.7' && matrix.ansible == 'ansible~=2.9.0'
-        run: pip install molecule~=3.6.1
+        run: pip install molecule~=3.6.1 molecule-docker~=1.1
         shell: bash
       - name: Setting pulp.pulp_installer collection
         # Downloading dependencies sometimes fails the 1st time, so retry

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -73,7 +73,7 @@ jobs:
           pip install docker molecule ${{ matrix.ansible }}
       - name: Workaround bug with latest molecule and ansible 2.9
         if: matrix.python != '2.7' && matrix.ansible == 'ansible~=2.9.0'
-        run: pip install molecule~=3.6.1
+        run: pip install molecule~=3.6.1 molecule-docker~=1.1
         shell: bash
       - name: Setting pulp.pulp_installer collection
         # Downloading dependencies sometimes fails the 1st time, so retry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
           pip install docker molecule ${{ matrix.ansible }}
       - name: Workaround bug with latest molecule and ansible 2.9
         if: matrix.python != '2.7' && matrix.ansible == 'ansible~=2.9.0'
-        run: pip install molecule~=3.6.1
+        run: pip install molecule~=3.6.1 molecule-docker~=1.1
         shell: bash
       - name: Setting pulp.pulp_installer collection
         # Downloading dependencies sometimes fails the 1st time, so retry

--- a/CHANGES/1330.dev
+++ b/CHANGES/1330.dev
@@ -1,0 +1,1 @@
+Fix CI tests with Ansible 2.9 and Python 3 failing to install prereleases of community.docker due to molecule-docker 2.0.0 being released.


### PR DESCRIPTION
to install prereleases of community.docker

due to molecule-docker 2.0.0 being released.

fixes: #1330