### PR TITLE
3.15: Fix CI tests with Ansible 2.9 and Python 3 failing

### DIFF
--- a/CHANGES/1330.dev
+++ b/CHANGES/1330.dev
@@ -1,0 +1,1 @@
+Fix CI tests with Ansible 2.9 and Python 3 failing to install prereleases of community.docker due to molecule-docker 2.0.0 being released.

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,7 @@ deps =
     py37: molecule-docker
     py38: molecule-docker
     py39: molecule-docker
+    py38-ansible2.9: molecule-docker~=1.1
     # molecule dep that is incompatible with python 2 as of 1.13.0 & 1.13.1
     sh < 1.13 ; python_version < "3"
     ruamel.yaml < 0.17 ; python_version < "3"


### PR DESCRIPTION
to install prereleases of community.docker

due to molecule-docker 2.0.0 being released.

fixes: #1330