### PR TITLE
3.18: Fix CI tests with Ansible 2.9 and Python 3 failing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,10 @@ jobs:
         run: |
           sudo apt remove ansible
           pip install docker molecule ${{ matrix.ansible }}
+      - name: Workaround bug with latest molecule and ansible 2.9
+        if: matrix.python != '2.7' && matrix.ansible == 'ansible~=2.9.0'
+        run: pip install molecule~=3.6.1 molecule-docker~=1.1
+        shell: bash
       - name: Setting pulp.pulp_installer collection
         # Downloading dependencies sometimes fails the 1st time, so retry
         run: |

--- a/.github/workflows/devel_ci.yml
+++ b/.github/workflows/devel_ci.yml
@@ -46,6 +46,10 @@ jobs:
         run: |
           sudo apt remove ansible
           pip install docker molecule ${{ matrix.ansible }}
+      - name: Workaround bug with latest molecule and ansible 2.9
+        if: matrix.python != '2.7' && matrix.ansible == 'ansible~=2.9.0'
+        run: pip install molecule~=3.6.1 molecule-docker~=1.1
+        shell: bash
       - name: Setting pulp.pulp_installer collection
         # Downloading dependencies sometimes fails the 1st time, so retry
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -71,6 +71,10 @@ jobs:
         run: |
           sudo apt remove ansible
           pip install docker molecule ${{ matrix.ansible }}
+      - name: Workaround bug with latest molecule and ansible 2.9
+        if: matrix.python != '2.7' && matrix.ansible == 'ansible~=2.9.0'
+        run: pip install molecule~=3.6.1 molecule-docker~=1.1
+        shell: bash
       - name: Setting pulp.pulp_installer collection
         # Downloading dependencies sometimes fails the 1st time, so retry
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ jobs:
         run: |
           sudo apt remove ansible
           pip install docker molecule ${{ matrix.ansible }}
+      - name: Workaround bug with latest molecule and ansible 2.9
+        if: matrix.python != '2.7' && matrix.ansible == 'ansible~=2.9.0'
+        run: pip install molecule~=3.6.1 molecule-docker~=1.1
+        shell: bash
       - name: Setting pulp.pulp_installer collection
         # Downloading dependencies sometimes fails the 1st time, so retry
         run: |

--- a/CHANGES/1330.dev
+++ b/CHANGES/1330.dev
@@ -1,0 +1,1 @@
+Fix CI tests with Ansible 2.9 and Python 3 failing to install prereleases of community.docker due to molecule-docker 2.0.0 being released.


### PR DESCRIPTION
to install prereleases of community.docker

due to molecule-docker 2.0.0 being released.

fixes: #1330
(cherry picked from commit acf0ffa0ddf1846444723a2992e0c89de9cefa3b)