### PR TITLE
Add support for pulp_container signing service

### DIFF
--- a/CHANGES/1347.feature
+++ b/CHANGES/1347.feature
@@ -1,0 +1,1 @@
+Add support for pulp_container signing service

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ nav:
       - Pulp Webserver: roles/pulp_webserver.md
       - Pulp Workers: roles/pulp_workers.md
   - Helper Roles:
-      - Pulp Common: roles/pulp_common.md
+      - Pulp Common: helper_roles/pulp_common.md
       - Pulp Repos: helper_roles/pulp_repos.md
       - Galaxy NG post-install: helper_roles/galaxy_post_install.md
       - Pulp RPM prerequisites: helper_roles/pulp_rpm_prerequisites.md

--- a/molecule/source-galaxy/group_vars/all
+++ b/molecule/source-galaxy/group_vars/all
@@ -38,6 +38,7 @@ pulp_settings:
   rh_entitlement_required: insights
   galaxy_auto_sign_collections: true
   galaxy_collection_signing_service: ansible-default
+  galaxy_container_signing_service: container-default
 
 # Galaxy Configuration
 # Set this __galaxy variables according to your needs.
@@ -48,6 +49,7 @@ __galaxy_dev_source_path: 'pulpcore:pulp_ansible:pulp_container:galaxy_ng:galaxy
 # __galaxy_lock_requirements: Set to 0 to avoid pinning of galaxy_ng/setup.py versions
 __galaxy_lock_requirements: '0'
 galaxy_create_default_collection_signing_service: true
+galaxy_create_default_container_signing_service: true
 
 # These variables are used by molecule verify, not the installer itself
 pulp_lib_path: /opt/pulp/devel

--- a/roles/galaxy_post_install/README.md
+++ b/roles/galaxy_post_install/README.md
@@ -7,9 +7,13 @@ It runs by default when `galaxy-ng` is part of `pulp_install_plugins` variable. 
 
 ## Role Variables
 
-* `galaxy_importer_settings`: Key value dictionnary that contains the content of galaxy-importer.cfg to be overwritten.
+* `galaxy_importer_settings`: Key-value dictionary that contains the content of galaxy-importer.cfg to be overwritten.
 * `galaxy_create_default_collection_signing_service` Boolean on whether or not to create collection
-  signing service. See [Variables for the Signing Service](#variables-for-the-signing-service). Defaults to `false`
+  signing service. See [Variables for the Collection Signing Service](#variables-for-the-collection-signing-service)
+  for additional variables that must be set. Defaults to `false`
+* `galaxy_create_default_container_signing_service` Boolean on whether or not to create container
+  signing service. See [Variables for the Container Signing Service](#variables-for-the-container-signing-service)
+  for additional variables that must be set. Defaults to `false`
 
 ## Shared Variables
 
@@ -19,19 +23,18 @@ variables which are documented in that role:
 * `pulp_certs_dir`: The collection signing service gpg key file is placed under this directory.
 * `pulp_scripts_dir`: The collection signing service script is placed under this directory.
 
-## Variables for the Signing Service
+## Variables for the Collection Signing Service
 
 If `galaxy_create_default_collection_signing_service==true`:
 
 1. `pulp_settings.galaxy_collection_signing_service` must be set to "ansible-default".
-  This variable sets the name of the default signing service to use. Defaults to "nothing".
-
+  This variable sets the name of the default collection signing service to use. Defaults to nothing.
 2. 2 files must either be specified by these variables:
 
-* `galaxy_collection_signing_service_key`:  Specify a filepath on the ansible management node.
+    * `galaxy_collection_signing_service_key`:  Specify a filepath on the ansible management node.
 This is the gpg private key that will be imported to performan the gpg signing of the collections.
 Defaults to undefined.
-* `galaxy_collection_signing_service_script` Specify a filepath on the ansible management node.
+    * `galaxy_collection_signing_service_script` Specify a filepath on the ansible management node.
 This is the script that performs the gpg signing of the collections. Defaults to undefined.
 
 Or they must exist on disk (on all pulp hosts e.g. API, content & worker) (these are the paths that
@@ -39,6 +42,27 @@ the variables install them to):
 
 * `{{ pulp_certs_dir }}/galaxy_signing_service.gpg` (default: `/etc/pulp/certs/galaxy_signing_service.gpg`):
 * `{{ pulp_scripts_dir }}/collection_sign.sh` (default: `/var/lib/pulp/scripts/collection_sign.sh`):
+
+## Variables for the Container Signing Service
+
+If `galaxy_create_default_container_signing_service==true`:
+
+1. `pulp_settings.galaxy_container_signing_service` must be set to "container-default".
+  This variable sets the name of the default container signing service to use. Defaults to nothing.
+
+2. 2 files must either be specified by these variables:
+
+    * `galaxy_container_signing_service_key`:  Specify a filepath on the ansible management node.
+This is the gpg private key that will be imported to performan the gpg signing of the containers..
+Defaults to undefined.
+    * `galaxy_container_signing_service_script` Specify a filepath on the ansible management node.
+This is the script that performs the gpg signing of the containers. Defaults to undefined.
+
+Or they must exist on disk (on all pulp hosts e.g. API, content & worker) (these are the paths that
+the variables install them to):
+
+* `{{ pulp_certs_dir }}/container_signing_service.gpg` (default: `/etc/pulp/certs/container_signing_service.gpg`):
+* `{{ pulp_scripts_dir }}/container_sign.sh` (default: `/var/lib/pulp/scripts/container_sign.sh`):
 
 ## License
 

--- a/roles/galaxy_post_install/defaults/main.yml
+++ b/roles/galaxy_post_install/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 galaxy_importer_settings: {}
 galaxy_create_default_collection_signing_service: false
+galaxy_create_default_container_signing_service: false

--- a/roles/galaxy_post_install/files/collection_sign.sh
+++ b/roles/galaxy_post_install/files/collection_sign.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -u
+
 FILE_PATH=$1
 SIGNATURE_PATH="$1.asc"
 

--- a/roles/galaxy_post_install/files/collection_sign.sh.el7
+++ b/roles/galaxy_post_install/files/collection_sign.sh.el7
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -u
+
 FILE_PATH=$1
 SIGNATURE_PATH="$1.asc"
 

--- a/roles/galaxy_post_install/files/container_sign.sh
+++ b/roles/galaxy_post_install/files/container_sign.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -u
+# This GPG_TTY variable might be needed on a container image that is not running as root.
+#export GPG_TTY=$(tty)
+# Create a file with passphrase only if the key is password protected.
+# echo "Galaxy2022" > /tmp/key_password.txt
+# pulp_container SigningService will pass the next 3 variables to the script.
+MANIFEST_PATH=$1
+IMAGE_REFERENCE="$REFERENCE"
+SIGNATURE_PATH="$SIG_PATH"
+# Create container signature using skopeo
+# Include --passphrase-file option if the key is password protected.
+skopeo standalone-sign \
+  $MANIFEST_PATH \
+  $IMAGE_REFERENCE \
+  $PULP_SIGNING_KEY_FINGERPRINT \
+  --output $SIGNATURE_PATH
+# Check the exit status
+STATUS=$?
+if [ $STATUS -eq 0 ]; then
+  echo {\"signature_path\": \"$SIGNATURE_PATH\"}
+else
+  exit $STATUS
+fi

--- a/roles/galaxy_post_install/tasks/collection_signing_service.yml
+++ b/roles/galaxy_post_install/tasks/collection_signing_service.yml
@@ -1,4 +1,9 @@
 ---
+
+- name: Install skopeo for the collection signing service script
+  package:
+    name: skopeo
+
 - name: Import the collection signing service gpg key file
   copy:
     src: "{{ galaxy_collection_signing_service_key }}"
@@ -34,7 +39,7 @@
           galaxy_collection_signing_service_key=/path/to/file.gpg"
   when: galaxy_collection_signing_service_key is undefined
 
-- name: Import the on the collection galaxy signing service script
+- name: Import the collection signing service script
   copy:
     src: "{{ galaxy_collection_signing_service_script }}"
     dest: "{{ pulp_scripts_dir }}/collection_sign.sh"
@@ -44,7 +49,7 @@
   become: true
   when: galaxy_collection_signing_service_script is defined
 
-- name: Check collection galaxy signing service script
+- name: Check collection signing service script
   block:
     - name: Set permissions on the collection signing service script
       file:
@@ -65,18 +70,18 @@
 
 - name: Commands run as pulp_user
   block:
-    - name: Inspect galaxy signing service GPG key file
+    - name: Inspect collection signing service GPG key file
       shell: >
         {{ __pulp_gpg_inspect_command }}
         {{ pulp_certs_dir }}/galaxy_signing_service.gpg | grep -m1 -o -E
         '[A-F0-9]{4} [A-F0-9]{4} [A-F0-9]{4} [A-F0-9]{4} [A-F0-9]{4}  [A-F0-9]{4} [A-F0-9]{4} [A-F0-9]{4} [A-F0-9]{4} [A-F0-9]{4}'
         | tr -d " "
-      register: galaxy_signing_key
+      register: collection_signing_key
       changed_when: false
-      failed_when: galaxy_signing_key.stdout | length != 40
+      failed_when: collection_signing_key.stdout | length != 40
       check_mode: false
 
-    - name: Import galaxy signing service GPG key file
+    - name: Import collection signing service GPG key file
       command: gpg --batch --import {{ pulp_certs_dir }}/galaxy_signing_service.gpg
       register: result
       # Imported successfully: rc 0
@@ -85,10 +90,10 @@
       changed_when: result.stderr is search("imported:")
       failed_when: result.rc not in [0, 2]
 
-    - name: Trust the galaxy signing service GPG key
+    - name: Trust the collection signing service GPG key
       # When using this syntax, "ultimate" trust == 6
       shell: >
-        echo {{ galaxy_signing_key.stdout }}:6 | gpg --import-ownertrust
+        echo {{ collection_signing_key.stdout }}:6 | gpg --import-ownertrust
       register: result
       # changed messages can be either:
       # gpg: inserting ownertrust of 6
@@ -97,18 +102,3 @@
 
   become: true
   become_user: "{{ pulp_user }}"
-
-- name: Set environment variable for the GPG key ID
-  lineinfile:
-    path: /etc/default/pulpcore-worker
-    regexp: '^PULP_SIGNING_KEY_FINGERPRINT='
-    line: PULP_SIGNING_KEY_FINGERPRINT={{ galaxy_signing_key.stdout }}
-    create: True
-    owner: '{{ pulp_user }}'
-    group: '{{ pulp_group }}'
-    mode: "u+rw"
-    serole: _default
-    setype: _default
-    seuser: _default
-  notify: Restart all Pulp services
-  become: true

--- a/roles/galaxy_post_install/tasks/container_signing_service.yml
+++ b/roles/galaxy_post_install/tasks/container_signing_service.yml
@@ -1,0 +1,99 @@
+---
+- name: Import the container signing service gpg key file
+  copy:
+    src: "{{ galaxy_container_signing_service_key }}"
+    dest: "{{ pulp_certs_dir }}/container_signing_service.gpg"
+    mode: 0600
+    owner: "{{ pulp_user }}"
+    group: "{{ pulp_group }}"
+    serole: _default
+    setype: _default
+    seuser: _default
+  become: true
+  when: galaxy_container_signing_service_key is defined
+
+- name: Check container signing service gpg key file
+  block:
+    - name: Set permissions on the container signing service gpg key file
+      file:
+        path: "{{ pulp_certs_dir }}/container_signing_service.gpg"
+        mode: 0600
+        owner: "{{ pulp_user }}"
+        group: "{{ pulp_group }}"
+        serole: _default
+        setype: _default
+        seuser: _default
+      become: true
+  rescue:
+    - name: pulp_installer failure message  ## noqa name
+      fail:
+        msg: >
+          "{{ pulp_certs_dir }}/container_signing_service.gpg does not exist. Create a gpg
+          private key file and either place it there on {{ inventory_hostname }}, or
+          place it somehwere on the ansible management node and set the variable
+          galaxy_container_signing_service_key=/path/to/file.gpg"
+  when: galaxy_container_signing_service_key is undefined
+
+- name: Import the container signing service script
+  copy:
+    src: "{{ galaxy_container_signing_service_script }}"
+    dest: "{{ pulp_scripts_dir }}/container_sign.sh"
+    mode: 0750
+    owner: "{{ pulp_user }}"
+    group: "{{ pulp_group }}"
+  become: true
+  when: galaxy_container_signing_service_script is defined
+
+- name: Check container signing service script
+  block:
+    - name: Set permissions on the container signing service script
+      file:
+        path: "{{ pulp_scripts_dir }}/container_sign.sh"
+        mode: 0750
+        owner: "{{ pulp_user }}"
+        group: "{{ pulp_group }}"
+      become: true
+  rescue:
+    - name: pulp_installer failure message  ## noqa name
+      fail:
+        msg: >
+          "{{ pulp_scripts_dir }}/container_sign.sh does not exist. Obtain a galaxy collections
+          signing service script and either place it there on {{ inventory_hostname }}, or
+          place it somehwere on the ansible management node and set the variable
+          galaxy_container_signing_service_script=/path/to/file.sh"
+  when: galaxy_container_signing_service_script is undefined
+
+- name: Commands run as pulp_user
+  block:
+    - name: Inspect container signing service GPG key file
+      shell: >
+        {{ __pulp_gpg_inspect_command }}
+        {{ pulp_certs_dir }}/container_signing_service.gpg | grep -m1 -o -E
+        '[A-F0-9]{4} [A-F0-9]{4} [A-F0-9]{4} [A-F0-9]{4} [A-F0-9]{4}  [A-F0-9]{4} [A-F0-9]{4} [A-F0-9]{4} [A-F0-9]{4} [A-F0-9]{4}'
+        | tr -d " "
+      register: container_signing_key
+      changed_when: false
+      failed_when: container_signing_key.stdout | length != 40
+      check_mode: false
+
+    - name: Import container signing service GPG key file
+      command: gpg --batch --import {{ pulp_certs_dir }}/container_signing_service.gpg
+      register: result
+      # Imported successfully: rc 0
+      # Already imported: rc 2
+      # If you try to import multiple keys but only some need to be imported: rc 2
+      changed_when: result.stderr is search("imported:")
+      failed_when: result.rc not in [0, 2]
+
+    - name: Trust the container signing service GPG key
+      # When using this syntax, "ultimate" trust == 6
+      shell: >
+        echo {{ container_signing_key.stdout }}:6 | gpg --import-ownertrust
+      register: result
+      # changed messages can be either:
+      # gpg: inserting ownertrust of 6
+      # gpg: changing ownertrust from 3 to 6
+      changed_when: "'ownertrust' in result.stderr"
+
+  become: true
+  become_user: "{{ pulp_user }}"

--- a/roles/galaxy_post_install/tasks/main.yml
+++ b/roles/galaxy_post_install/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - import_tasks: setup_galaxy_api_access_log.yml
 
-- include_tasks: prepare_signing_service.yml
+- include_tasks: prepare_collection_signing_service.yml
   args:
     apply:
       become: yes
@@ -11,5 +11,16 @@
     - developer_user is defined or developer_user_home is defined or __galaxy_build_signing_scripts is defined
     - galaxy_create_default_collection_signing_service
 
-- include_tasks: signing_service.yml
+- include_tasks: collection_signing_service.yml
   when: galaxy_create_default_collection_signing_service
+
+- include_tasks: prepare_container_signing_service.yml
+  args:
+    apply:
+      become: yes
+  when:
+    - developer_user is defined or developer_user_home is defined or __galaxy_build_signing_scripts is defined
+    - galaxy_create_default_container_signing_service
+
+- include_tasks: container_signing_service.yml
+  when: galaxy_create_default_container_signing_service

--- a/roles/galaxy_post_install/tasks/prepare_collection_signing_service.yml
+++ b/roles/galaxy_post_install/tasks/prepare_collection_signing_service.yml
@@ -1,18 +1,19 @@
 ---
-- name: Check if galaxy signing service gpg key exists
+- name: Check if collection signing service gpg key exists
   stat:
     path: "{{ pulp_certs_dir }}/galaxy_signing_service.gpg"
-  register: stat_galaxy_signing_service
+  register: stat_collection_signing_service
 
-- name: Generate galaxy signing service gpg key  # noqa no-changed-when
+- name: Generate collection signing service gpg key  # noqa no-changed-when deprecated-command-syntax
   shell: |
+    mkdir /tmp/collection_gpg
     cat >/tmp/gpg.txt <<EOF
     %echo Generating a basic OpenPGP key
     Key-Type: default
     Key-Length: 4096
     Subkey-Type: default
     Subkey-Length: default
-    Name-Real: Joe Tester
+    Name-Real: Collection Signing Service
     Name-Comment: with no passphrase
     Name-Email: joe@foo.bar
     Expire-Date: 0
@@ -22,17 +23,18 @@
     %commit
     %echo done
     EOF
-    GNUPGHOME=/tmp gpg --batch --gen-key /tmp/gpg.txt
-    GNUPGHOME=/tmp gpg --output {{ pulp_certs_dir }}/galaxy_signing_service.gpg --armor --export-secret-key
-    GNUPGHOME=/tmp gpg --output {{ pulp_certs_dir }}/galaxy_signing_service.asc --armor --export
-  when: not stat_galaxy_signing_service.stat.exists
+    GNUPGHOME=/tmp/collection_gpg gpg --batch --gen-key /tmp/gpg.txt
+    GNUPGHOME=/tmp/collection_gpg gpg --output {{ pulp_certs_dir }}/galaxy_signing_service.gpg --armor --export-secret-key
+    GNUPGHOME=/tmp/collection_gpg gpg --output {{ pulp_certs_dir }}/galaxy_signing_service.asc --armor --export
+    rm -rf /tmp/collection_gpg
+  when: not stat_collection_signing_service.stat.exists
 
-- name: Check if sample galaxy signing service script exists
+- name: Check if sample collection signing service script exists
   stat:
     path: "{{ pulp_scripts_dir }}/collection_sign.sh"
   register: stat_collection_sign_script
 
-- name: Create sample galaxy signing service script (EL7)
+- name: Create sample collection signing service script (EL7)
   copy:
     src: collection_sign.sh.el7
     dest: "{{ pulp_scripts_dir }}/collection_sign.sh"
@@ -42,7 +44,7 @@
     - ansible_facts.distribution_major_version|int == 7
     - not stat_collection_sign_script.stat.exists
 
-- name: Create sample galaxy signing service script
+- name: Create sample collection signing service script
   copy:
     src: collection_sign.sh
     dest: "{{ pulp_scripts_dir }}/collection_sign.sh"

--- a/roles/galaxy_post_install/tasks/prepare_container_signing_service.yml
+++ b/roles/galaxy_post_install/tasks/prepare_container_signing_service.yml
@@ -1,0 +1,42 @@
+---
+- name: Check if container signing service gpg key exists
+  stat:
+    path: "{{ pulp_certs_dir }}/container_signing_service.gpg"
+  register: stat_container_signing_service
+
+- name: Generate container signing service gpg key  # noqa no-changed-when deprecated-command-syntax
+  shell: |
+    mkdir /tmp/container_gpg
+    cat >/tmp/gpg.txt <<EOF
+    %echo Generating a basic OpenPGP key
+    Key-Type: default
+    Key-Length: 4096
+    Subkey-Type: default
+    Subkey-Length: default
+    Name-Real: Container Signing Service
+    Name-Comment: with no passphrase
+    Name-Email: joe@foo.bar
+    Expire-Date: 0
+    %no-ask-passphrase
+    %no-protection
+    # Do a commit here, so that we can later print "done" :-)
+    %commit
+    %echo done
+    EOF
+    GNUPGHOME=/tmp/container_gpg gpg --batch --gen-key /tmp/gpg.txt
+    GNUPGHOME=/tmp/container_gpg gpg --output {{ pulp_certs_dir }}/container_signing_service.gpg --armor --export-secret-key
+    GNUPGHOME=/tmp/container_gpg gpg --output {{ pulp_certs_dir }}/container_signing_service.asc --armor --export
+    rm -rf /tmp/container_gpg
+  when: not stat_container_signing_service.stat.exists
+
+- name: Check if sample container signing service script exists
+  stat:
+    path: "{{ pulp_scripts_dir }}/container_sign.sh"
+  register: stat_container_sign_script
+
+- name: Create sample container signing service script
+  copy:
+    src: container_sign.sh
+    dest: "{{ pulp_scripts_dir }}/container_sign.sh"
+    mode: 0755
+  when: not stat_container_sign_script.stat.exists

--- a/roles/pulp_common/README.md
+++ b/roles/pulp_common/README.md
@@ -170,6 +170,8 @@ file_upload_temp_dir | | `{{ pulp_settings.working_directory }}` <br> ( /var/lib
 media_root | | `{{ pulp_settings.deploy_root }}/media` <br> ( /var/lib/pulp/media ) |  Location where Pulp will store files (the content that is served.)
 static_root | | `{{ pulp_user_home }}{{ pulp_settings.static_url }}` <br> ( /var/lib/pulp/assets/ ) |  Location on disk of the static content served by the pulpcore-api service.
 working_directory | | `{{ pulp_settings.deploy_root }}/tmp` <br> ( /var/lib/pulp/tmp ) | Location of Pulp cache.
+`galaxy_collection_signing_service` | | | The name of the default galaxy_ng collection signing service to use. | Normally set to "ansible-default". See [galaxy_post_install`(../../roles/galaxy_post_install) for the other variables that must also be set.
+`galaxy_container_signing_service` | | | The name of the default galaxy_ng container signing service to use. | Normally set to "container-default". See [galaxy_post_install`(../../roles/galaxy_post_install) for the other variables that must also be set.
 
 * **Example**:
 

--- a/roles/pulp_database/README.md
+++ b/roles/pulp_database/README.md
@@ -36,7 +36,8 @@ Setting these variables controls the behavior of both roles.
   installer with your own; merely setting pulp_settings with 1 setting under it will not blow away all
   the other default settings.
     * `HOST` The hostname or IP address of the pulp database that pulp_common will connect to. This
-      determines the default value of `postgresql_global_config_options`. Defaults to "localhost".
+      determines the default value of `postgresql_global_config_options`, as explained below.
+      Defaults to "localhost".
     * `NAME` The name of the Pulp database to create.  Defaults to `pulp`.
     * `USER` The user account to be created with permissions on the database.  Defaults to `pulp`.
     * `PASSWORD` The password to be created for the user account to talk to the Pulp database.
@@ -77,9 +78,9 @@ Setting these variables controls the behavior of both roles.
     value: 'log'
 ```
 
-  In other words, if set to localhost, postgresql will listen on UNIX sockets (specified by the
+  In other words, if set to "localhost", postgresql will listen on UNIX sockets (which sockets are specified by the
   [external role](https://github.com/geerlingguy/ansible-role-postgresql#readme)), in addition to the
-  default of the loopback interface. If not set to localhost, postgresql will listen on all network interfaces.
+  default of the loopback interface. If not set to "localhost", postgresql will listen on all network interfaces.
 
 * `postgresql_auth_method`: [The password authentication
   method](https://www.postgresql.org/docs/10/auth-methods.html) for PostgreSQL when listening over

--- a/roles/pulp_database_config/README.md
+++ b/roles/pulp_database_config/README.md
@@ -49,20 +49,25 @@ This role also utilizes some of the pulp_common role's variables in its logic:
 * `pulp_certs_dir`: Path where to generate or drop the keys for database fields encryption.
    Defaults to '{{ pulp_config_dir }}/certs' .
 * `pulp_config_dir`
-* `pulp_scripts_dir`: The collection signing service script must exist under this directory
-  with the filename `collection_sign.sh` when `galaxy_create_default_collection_signing_service==true`.
+* `pulp_scripts_dir`: The collection/container signing service scripts exists under this directory
+  with the filename `collection_sign.sh`/`container_sign.sh` when
+  `galaxy_create_default_collection_signing_service==true`/
+  `galaxy_create_default_container_signing_service==true`.
 
 Like other roles that depend on pulp_common, if galaxy-ng is to be installed as a plugin, this role
 will depending on the [`galaxy_post_install`](../helper_roles/galaxy_post_install). This role also
 however utilizes some of the galaxy_post_install role's variables in its logic:
 
-* `galaxy_create_default_collection_signing_service` Defaults to `false`.
+* `galaxy_create_default_collection_signing_service`
+* `galaxy_create_default_container_signing_service`
+* `pulp_settings.galaxy_collection_signing_service`
+* `pulp_settings.galaxy_container_signing_service`
 
 This role understands how to talk to the database server via `pulp_settings_file`,
 which is written to disk in the `pulp_common` role, and whose relevant
 values are set via the following variables:
 
-* `pulp_settings_db_defaults`: See pulp_database README.
+* `pulp_settings.databases.default`: See pulp_database README.
 
 Limitations
 -----------

--- a/roles/pulp_database_config/defaults/main.yml
+++ b/roles/pulp_database_config/defaults/main.yml
@@ -2,5 +2,6 @@
 pulp_db_fields_key: ''
 
 galaxy_create_default_collection_signing_service: false
+galaxy_create_default_container_signing_service: false
 
 pulp_force_change_admin_password: false

--- a/roles/pulp_database_config/tasks/main.yml
+++ b/roles/pulp_database_config/tasks/main.yml
@@ -228,17 +228,17 @@
 
 # This task is located here in pulp_database_config because it depends on the database fields encryption key
 # and on the database migrations having been run.
-- name: Add the galaxy signing service to the Pulp application
+- name: Add the galaxy collection signing service to the Pulp application
   shell: >
     {{ pulp_django_admin_path }} add-signing-service
     {{ __pulp_common_merged_pulp_settings.galaxy_collection_signing_service }}
-    {{ pulp_scripts_dir }}/collection_sign.sh {{ galaxy_signing_key.stdout }}
+    {{ pulp_scripts_dir }}/collection_sign.sh {{ collection_signing_key.stdout }}
   run_once: "{{ __pulp_run_once }}"
   delegate_to: "{{ hostvars['localhost']['pulp_database_config_host'] | default(inventory_hostname) }}"
   environment:
     PULP_SETTINGS: "{{ pulp_settings_file }}"
     LD_LIBRARY_PATH: "{{ pulp_ld_library_path }}"
-    PULP_SIGNING_KEY_FINGERPRINT: "{{ galaxy_signing_key.stdout }}"
+    PULP_SIGNING_KEY_FINGERPRINT: "{{ collection_signing_key.stdout }}"
   register: result
   changed_when: result.rc == 0
   failed_when: >
@@ -246,5 +246,29 @@
     ((result.rc == 1) and
     ('Key (name)=({{ __pulp_common_merged_pulp_settings.galaxy_collection_signing_service }}) already exists.' not in result.stderr))
   when: galaxy_create_default_collection_signing_service
+  become: true
+  become_user: "{{ pulp_user }}"
+
+# This task is located here in pulp_database_config because it depends on the database fields encryption key
+# and on the database migrations having been run.
+- name: Add the galaxy container signing service to the Pulp application
+  shell: >
+    {{ pulp_django_admin_path }} add-signing-service
+    {{ __pulp_common_merged_pulp_settings.galaxy_container_signing_service }}
+    {{ pulp_scripts_dir }}/container_sign.sh {{ container_signing_key.stdout }}
+    --class container:ManifestSigningService
+  run_once: "{{ __pulp_run_once }}"
+  delegate_to: "{{ hostvars['localhost']['pulp_database_config_host'] | default(inventory_hostname) }}"
+  environment:
+    PULP_SETTINGS: "{{ pulp_settings_file }}"
+    LD_LIBRARY_PATH: "{{ pulp_ld_library_path }}"
+    PULP_CONTAINER_SIGNING_KEY_FINGERPRINT: "{{ container_signing_key.stdout }}"
+  register: result
+  changed_when: result.rc == 0
+  failed_when: >
+    (result.rc not in [0, 1]) or
+    ((result.rc == 1) and
+    ('Key (name)=({{ __pulp_common_merged_pulp_settings.galaxy_container_signing_service }}) already exists.' not in result.stderr))
+  when: galaxy_create_default_container_signing_service
   become: true
   become_user: "{{ pulp_user }}"

--- a/roles/pulp_webserver/defaults/main.yml
+++ b/roles/pulp_webserver/defaults/main.yml
@@ -30,8 +30,8 @@ pulp_client_max_body_size: "{{ '1m' if pulp_webserver_server == 'nginx' else '0'
 __pulp_common_merged_pulp_settings:
   content_path_prefix: "/pulp/content/"
 
-pulp_webserver_api_hosts: "{{ [{'address' :pulp_api_bind}] }}"
-pulp_webserver_content_hosts: "{{ [{'address' :pulp_content_bind}] }}"
+pulp_webserver_api_hosts: "{{ [{'address': pulp_api_bind}] }}"
+pulp_webserver_content_hosts: "{{ [{'address': pulp_content_bind}] }}"
 pulp_webserver_api_balancer_apache_parameters: []
 pulp_webserver_content_balancer_apache_parameters: []
 pulp_webserver_api_balancer_nginx_directives: []

--- a/roles/pulp_webserver/vars/main.yml
+++ b/roles/pulp_webserver/vars/main.yml
@@ -10,5 +10,5 @@ __pulp_database_config_host: "{{ hostvars['localhost']['pulp_database_config_hos
 __pulp_install_dir: "{{ hostvars[__pulp_database_config_host]['pulp_install_dir'] }}"
 __pulp_install_source: "{{ hostvars[__pulp_database_config_host]['pulp_install_source'] }}"
 __pulp_python_interpreter: "{{ hostvars[__pulp_database_config_host]['pulp_python_interpreter'] }}"
-__pulp_python_path: "{{ hostvars[__pulp_database_config_host]['pulp_python_path'] | default ('') }}"
-__pulp_subject_alt_name: '{{ pulp_webserver_httpd_servername | regex_search("^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$") | ternary("IP:" + pulp_webserver_httpd_servername , "DNS:" + pulp_webserver_httpd_servername) }}'
+__pulp_python_path: "{{ hostvars[__pulp_database_config_host]['pulp_python_path'] | default('') }}"
+__pulp_subject_alt_name: '{{ pulp_webserver_httpd_servername | regex_search("^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$") | ternary("IP:" + pulp_webserver_httpd_servername, "DNS:" + pulp_webserver_httpd_servername) }}'


### PR DESCRIPTION
Also includes removing the accidentally-written logic to set
PULP_SIGNING_KEY_FINGERPRINT on the pulpcore-worker process.
The signing service scripts (both collection and container)
will have PULP_SIGNING_KEY_FINGERPRINT set according to the
separate per-service entries in the database (stored when
pulpcore-manager add-signing-service is run), 
not according to pulpcore-worker's environment.

Fixes: #1347