### PR TITLE
pulp_webserver: fix nginx template indent

### DIFF
--- a/CHANGES/1365.bugfix
+++ b/CHANGES/1365.bugfix
@@ -1,0 +1,1 @@
+Fix the jinja2 indent for the nginx template in the pulp_webserver role.

--- a/roles/pulp_webserver/templates/nginx.conf.j2
+++ b/roles/pulp_webserver/templates/nginx.conf.j2
@@ -139,9 +139,9 @@ http {
 {% if not pulp_webserver_disable_https | bool %}
     server {
         listen {{ pulp_webserver_http_port }} default_server;
-        {% if ansible_facts['all_ipv6_addresses'] is defined and ansible_facts['all_ipv6_addresses'] | length > 0 -%}
+{% if ansible_facts['all_ipv6_addresses'] is defined and ansible_facts['all_ipv6_addresses'] | length > 0 %}
         listen [::]:{{ pulp_webserver_http_port }} default_server;
-        {%- endif %}
+{% endif %}
         server_name _;
         return 301 https://$host$request_uri;
     }


### PR DESCRIPTION
5e5f0ef introduced a condition for nginx IPv6 binding but due to a
wrong jinja2 condition indent, the final nginx configuration puts the
server_name field on the same line than the listen IPv6.

```
server {
    listen 80 default_server;
    listen [::]:80 default_server;        server_name _;
    return 301 https://$host$request_uri;
}
```

This fixes the template indent issue.

```
server {
    listen 80 default_server;
    listen [::]:80 default_server;
    server_name _;
    return 301 https://$host$request_uri;
}
```

Closes: #1365

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>