### PR TITLE
Install python3-setuptools on Debian and Ubuntu.

### DIFF
--- a/CHANGES/1368.bugfix
+++ b/CHANGES/1368.bugfix
@@ -1,0 +1,1 @@
+Install python3-setuptools on Debian and Ubuntu. Fixes an issue with Ubuntu 20.04 (which is not officially supported.)

--- a/roles/pulp_common/vars/Debian.yml
+++ b/roles/pulp_common/vars/Debian.yml
@@ -3,6 +3,7 @@ pulp_preq_packages:
   - acl              # To prevent failure on Ubuntu 22.04 in the task `pulp.pulp_installer.pulp_common : Upgrade to a recent edition of pip (supporting manylinux2014)`
   - python3
   - python3-dev
+  - python3-setuptools
   - python3-venv
   - libpq-dev
   - gcc              # For psycopg2


### PR DESCRIPTION
Fixes an issue with Ubuntu 20.04 (which is not officially supported.)

fixes: #1368