### PR TITLE
Test release-upgrade with ansible 2.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,8 @@ jobs:
             ansible: "ansible" # currently at 5.3.0
             python: "3.9"
           - test_type: release-upgrade
-            ansible: "ansible-core~=2.11.0" # used by ansible==4.10.0
-            python: "3.6"
+            ansible: "ansible~=2.9.0"
+            python: "2.7"
           # We skip source-upgrade for PR CI because devs can always rebuild
           # their vagrant environments.
           - test_type: packages-upgrade


### PR DESCRIPTION
To see if the pip_package_info task fails due to
the output from `pip list`

WARNING: You are using pip version 21.2.3; however, version 22.2.2 is available. You should consider upgrading via the '/usr/local/lib/pulp/bin/python3 -m pip install --upgrade pip' command.

[noissue]