### PR TITLE
Remove logic to add ppa:directhex/mock-dnf

### DIFF
--- a/CHANGES/1366.removal
+++ b/CHANGES/1366.removal
@@ -1,0 +1,1 @@
+Remove logic to add the repo ppa:directhex/mock-dnf on Ubuntu 20.04 and earlier when pulp-rpm is being installed. The PPA was only ever made available for Ubuntu 16.04, and the installer definitely will not support such an old version of Ubuntu now. Note that there is no known way to install pulp-rpm on Ubuntu 20.04 or 18.04, but it installs on Ubuntu 22.04.

--- a/roles/pulp_rpm_prerequisites/tasks/main.yml
+++ b/roles/pulp_rpm_prerequisites/tasks/main.yml
@@ -16,14 +16,6 @@
   tags:
     - always
 
-- name: Add libmodulemd repo for Ubuntu
-  apt_repository:
-    repo: ppa:directhex/mock-dnf
-  when:
-    - ansible_facts.distribution == "Ubuntu"
-    - ansible_facts.distribution_major_version | int < 22
-  become: true
-
 # Rocky 9.0 lacks this package
 - name: Install zchunk-libs
   dnf:


### PR DESCRIPTION
on Ubuntu 20.04 and earlier

fixes: #1366