### PR TITLE
Adding support for SLES-15

### DIFF
--- a/roles/pulp_common/vars/SLES-15.yml
+++ b/roles/pulp_common/vars/SLES-15.yml
@@ -1,0 +1,18 @@
+---
+pulp_preq_packages:
+  - python39
+  - python39-devel
+  - python3-selinux     # For ansible itself
+  - python3-policycoreutils  # For ansible itself
+  - gcc                 # For psycopg2
+  - make                # For make docs, and SELinux policy install
+  - git                 # For source install, and SELinux policy install
+  - sudo
+  - gpg2         
+  - pkg-config
+  - libpq5      
+
+# Pulp requires Python 3.8+.
+pulp_python_interpreter: /usr/bin/python3.9
+pulp_python_cryptography:
+  - python3-cryptography

--- a/roles/pulp_database/vars/SLES-15.yml
+++ b/roles/pulp_database/vars/SLES-15.yml
@@ -1,0 +1,15 @@
+---
+# Fedora 34 containers only have python3 by default
+postgresql_python_library: python{{ ansible_python_version is version('3.0.0', '<') | ternary('2', '3') }}-psycopg2
+
+# Geerlingguy.postgresql roles doesn't support F34
+__postgresql_version: "14"
+__postgresql_data_dir: "/var/lib/pgsql/data/"
+__postgresql_bin_path: "/usr/lib/postgresql{{ __postgresql_version }}/bin/"
+__postgresql_config_path: "/var/lib/pgsql/data/"
+__postgresql_daemon:  postgresql
+__postgresql_packages:
+  - "postgresql{{ __postgresql_version | replace('.','') }}"
+  - "postgresql{{ __postgresql_version | replace('.','') }}-server"
+  - "postgresql{{ __postgresql_version | replace('.','') }}-contrib"
+__postgresql_unix_socket_directories_mode: '0755'

--- a/roles/pulp_database/vars/SLES-15.yml
+++ b/roles/pulp_database/vars/SLES-15.yml
@@ -1,8 +1,6 @@
 ---
-# Fedora 34 containers only have python3 by default
 postgresql_python_library: python{{ ansible_python_version is version('3.0.0', '<') | ternary('2', '3') }}-psycopg2
 
-# Geerlingguy.postgresql roles doesn't support F34
 __postgresql_version: "14"
 __postgresql_data_dir: "/var/lib/pgsql/data/"
 __postgresql_bin_path: "/usr/lib/postgresql{{ __postgresql_version }}/bin/"

--- a/roles/pulp_redis/tasks/main.yml
+++ b/roles/pulp_redis/tasks/main.yml
@@ -41,6 +41,26 @@
         - __pulp_os_family == 'RedHat'
         - ansible_facts.distribution_major_version|int == 7
         - pulp_redis_package_name.startswith('rh-')
+        
+    - name: create redis configuration
+      copy:
+        src: /etc/redis/default.conf.example
+        dest: "{{ pulp_redis_conf_file | default(_pulp_redis_conf_file) }}"
+        remote_src: yes
+      when: ansible_os_family == 'Suse'
+        
+    - name: create redis systemd service
+      template:
+        src: "{{ item }}"
+        dest: /etc/systemd/system/{{ pulp_redis_server_name | default(_pulp_redis_server_name) }}.service
+        mode: 0644
+      with_first_found:
+        - files:
+          - "{{ ansible_os_family }}/redis.service.j2"
+          - redis.service.j2
+          paths:
+            - ../templates
+      when: ansible_os_family == 'Suse'
 
     - name: Configure Redis to listen on Unix Domain Socket
       include_tasks: configure_uds.yml

--- a/roles/pulp_redis/templates/redis.service.j2
+++ b/roles/pulp_redis/templates/redis.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Advanced key-value store
+After=network.target
+Documentation=http://redis.io/documentation, man:redis-server(1)
+
+[Service]
+Type=notify
+ExecStart=/usr/sbin/redis-server {{ pulp_redis_conf_file | default(_pulp_redis_conf_file) }}
+Restart=on-failure
+User=redis
+Group=redis
+PrivateTmp=true
+LimitNOFILE=10240
+
+[Install]
+WantedBy=multi-user.target redis.target

--- a/roles/pulp_redis/vars/SLES-15.yml
+++ b/roles/pulp_redis/vars/SLES-15.yml
@@ -1,0 +1,3 @@
+---
+_pulp_redis_server_name: redis
+_pulp_redis_conf_file: '/etc/redis/redis.conf'

--- a/roles/pulp_rpm_prerequisites/vars/SLES-15.yml
+++ b/roles/pulp_rpm_prerequisites/vars/SLES-15.yml
@@ -1,0 +1,24 @@
+---
+# vars file for pulp_rpm_prerequisites on Fedora
+# Also used by RHEL8 / CentOS8
+rpm_prereq_packages:
+  - gcc
+  - make
+  - cairo-devel
+  - python3-psycopg2
+  - cmake
+  - libbz2-devel
+  - libexpat-devel
+  - file-devel
+  - glib2-devel
+  - gobject-introspection-devel
+  - libcurl-devel
+  - libmodulemd-devel
+  - libxml2-devel
+  - libopenssl-devel 
+  - python3-devel
+  - rpm-devel
+  - sqlite3-devel 
+  - xz-devel
+  - zlib-devel
+  - libzck-devel  

--- a/roles/pulp_rpm_prerequisites/vars/SLES-15.yml
+++ b/roles/pulp_rpm_prerequisites/vars/SLES-15.yml
@@ -1,6 +1,5 @@
 ---
-# vars file for pulp_rpm_prerequisites on Fedora
-# Also used by RHEL8 / CentOS8
+# vars file for pulp_rpm_prerequisites on SLES-15
 rpm_prereq_packages:
   - gcc
   - make

--- a/roles/pulp_webserver/vars/SLES-15.yml
+++ b/roles/pulp_webserver/vars/SLES-15.yml
@@ -1,0 +1,20 @@
+---
+# We set the following to mod_ssl as httpd is a dependency
+# and hence will be pulled.
+pulp_seboolean_packages:
+  - python3-selinux-3.0-1.20.x86_64 
+  - python3-semanage-3.0-1.19.x86_64  
+pulp_firewall_dependencies:
+  - python3-firewall
+pulp_webserver_apache_package:
+  - mod_ssl
+  # workaround an undeclared dependency, for the centos:8stream container image
+  # https://bugzilla.redhat.com/show_bug.cgi?id=2050888
+  - hostname
+pulp_webserver_apache_service: httpd
+pulp_webserver_apache_vhost_dir: /etc/httpd/conf.d
+pulp_webserver_apache_snippets_dir: /etc/httpd/pulp
+pulp_webserver_apache_log_dir: /var/log/httpd
+pulp_webserver_trusted_root_certificates_path: /etc/pki/trust/anchors/
+pulp_webserver_trusted_root_certificates_update_bin: update-ca-certificates
+

--- a/roles/pulp_webserver/vars/SLES-15.yml
+++ b/roles/pulp_webserver/vars/SLES-15.yml
@@ -2,14 +2,12 @@
 # We set the following to mod_ssl as httpd is a dependency
 # and hence will be pulled.
 pulp_seboolean_packages:
-  - python3-selinux-3.0-1.20.x86_64 
-  - python3-semanage-3.0-1.19.x86_64  
+  - python3-selinux
+  - python3-semanage
 pulp_firewall_dependencies:
   - python3-firewall
 pulp_webserver_apache_package:
   - mod_ssl
-  # workaround an undeclared dependency, for the centos:8stream container image
-  # https://bugzilla.redhat.com/show_bug.cgi?id=2050888
   - hostname
 pulp_webserver_apache_service: httpd
 pulp_webserver_apache_vhost_dir: /etc/httpd/conf.d
@@ -17,4 +15,3 @@ pulp_webserver_apache_snippets_dir: /etc/httpd/pulp
 pulp_webserver_apache_log_dir: /var/log/httpd
 pulp_webserver_trusted_root_certificates_path: /etc/pki/trust/anchors/
 pulp_webserver_trusted_root_certificates_update_bin: update-ca-certificates
-


### PR DESCRIPTION
Adding support for SLES 15 SP3, 

**Pre-reqs**
SLES packages should be available to install from packagehub (registered account).

Dependency PR raised in geerlingguy.postgresql [#225](https://github.com/geerlingguy/ansible-role-postgresql/pull/225)

Things to do:
- [ ] Test installation with selinux in enforcing mode.
- [ ] Add SLES-15.yml in roles/pulp_devel. (Add devel packages for SLES-15) 