### PR TITLE
Fix galaxy-ng UI not loading

### DIFF
--- a/CHANGES/1384.bugfix
+++ b/CHANGES/1384.bugfix
@@ -1,0 +1,1 @@
+Fix galaxy-ng UI not loading due to pulp_installer overriding pulp_setting.static_url from "/static/" to "/assets/".

--- a/molecule/scenario_resources/tests/testinfra_default.py
+++ b/molecule/scenario_resources/tests/testinfra_default.py
@@ -20,6 +20,26 @@ def test_pulp_home(host):
     assert False
 
 
+def test_pulp_static_dir(host):
+
+  galaxy_installed_dir = host.file("/etc/galaxy-importer")
+  static_dir = host.file("/var/lib/pulp/assets")
+  static_dir_alt = host.file("/opt/pulp/assets")
+  static_dir_galaxy = host.file("/var/lib/pulp/static")
+
+  if galaxy_installed_dir.exists:
+    assert static_dir_galaxy.user == "pulp"
+    assert static_dir_galaxy.group == "pulp"
+  elif static_dir.exists:
+    assert static_dir.user == "pulp"
+    assert static_dir.group == "pulp"
+  elif static_dir_alt.exists:
+    assert static_dir_alt.user == "pulp"
+    assert static_dir_alt.group == "pulp"
+  else:
+    assert False
+
+
 @pytest.mark.parametrize("service", [
     "pulpcore-api", "pulpcore-content", "pulpcore-worker@1", "pulpcore-worker@2"
 ])

--- a/roles/pulp_common/vars/main.yml
+++ b/roles/pulp_common/vars/main.yml
@@ -38,14 +38,14 @@ __pulp_common_pulp_settings_defaults:
   media_root: "{{ pulp_settings.deploy_root | default(pulp_user_home) | regex_replace('\\/$', '') }}/media"
   private_key_path: "{{ pulp_certs_dir }}/token_private_key.pem"
   public_key_path: "{{ pulp_certs_dir }}/token_public_key.pem"
-  static_root: "{{ pulp_settings.deploy_root | default(pulp_user_home) | regex_replace('\\/$', '') }}{{ pulp_settings.static_url | default('/assets/') | regex_replace('\\/$', '') }}"
-  static_url: "/assets/"
+  static_url: "{{ (pulp_install_plugins_normalized['galaxy-ng'] is defined) | ternary('/static/','/assets/') }}"
   token_server: "{{ pulp_webserver_disable_https | default(false) | ternary('http', 'https') }}://{{ ansible_facts.fqdn }}/token/"
   token_signature_algorithm: ES256
   working_directory: "{{ pulp_settings.deploy_root | default(pulp_user_home) | regex_replace('\\/$', '') }}/tmp"
   content_path_prefix: "/pulp/content/"
 __pulp_common_pulp_settings_defaults_dependent_vars:
   file_upload_temp_dir: "{{ pulp_settings.working_directory | default(__pulp_common_pulp_settings_defaults.working_directory) }}"
+  static_root: "{{ pulp_settings.deploy_root | default(pulp_user_home) | regex_replace('\\/$', '') }}{{ pulp_settings.static_url | default(__pulp_common_pulp_settings_defaults.static_url) | regex_replace('\\/$', '') }}"
 
 __pulp_common_merged_pulp_settings: "{{ __pulp_common_pulp_settings_defaults | combine(__pulp_common_pulp_settings_defaults_dependent_vars, recursive=true) | combine(pulp_settings, recursive=True) }}"
 


### PR DESCRIPTION
due to pulp_installer overriding pulp_setting.static_url from "/static/" to "/assets/"

fixes: #1384