### PR TITLE
Run `pulpcore-manager container-repair-media-type`

### DIFF
--- a/CHANGES/1387.feature
+++ b/CHANGES/1387.feature
@@ -1,0 +1,1 @@
+Run `pulpcore-manager container-repair-media-type` when upgrading from a version of pulp-container that needs to be repaired, to a version of pulp-container that has the command. Introduces the variable `pulp_container_repair_media_type`.

--- a/molecule/packages-upgrade/group_vars/all
+++ b/molecule/packages-upgrade/group_vars/all
@@ -6,6 +6,7 @@ pulp_install_selinux_policies: True
 pulp_install_plugins:
   pulp-file:
   pulp-rpm:
+  pulp-container:
 pulp_settings:
   secret_key: secret
   content_origin: "https://{{ ansible_fqdn }}"

--- a/molecule/packages-upgrade/molecule.yml
+++ b/molecule/packages-upgrade/molecule.yml
@@ -24,15 +24,15 @@ platforms:
   - <<: *platform_base
     name: centos-7
     # molecule often fails to pull, so we pull all images in .travis.yml
-    image: quay.io/pulp/pulp-ci-pkgs-c7:3.7.9
+    image: quay.io/pulp/pulp-ci-pkgs-c7:3.7.9-1
     command: /sbin/init
   - <<: *platform_base
     name: centos-8
-    image: quay.io/pulp/pulp-ci-pkgs-c8:3.7.9
+    image: quay.io/pulp/pulp-ci-pkgs-c8:3.7.9-1
     command: /sbin/init
   - <<: *platform_base
     name: centos-9
-    image: quay.io/pulp/pulp-ci-pkgs-c9:3.18.5
+    image: quay.io/pulp/pulp-ci-pkgs-c9:3.18.5-1
     command: /sbin/init
 provisioner:
   name: ansible

--- a/molecule/release-upgrade/converge.yml
+++ b/molecule/release-upgrade/converge.yml
@@ -74,7 +74,7 @@
         that:
           - pip_pkgs.packages['/usr/local/lib/pulp/bin/pip']['pulp-rpm'][0].version is version("3.14.15", "=")
       when: ansible_facts.os_family == 'RedHat'
-# Test updates (upgrade=true on a branch)
+# Test updates (upgrade=true on a branch, also add pulp-container)
 - hosts: all
   force_handlers: True
   tasks:
@@ -89,11 +89,17 @@
           pulp_rpm:
             version: "3.14"
             upgrade: true
+          pulp_container:
+            version: "2.8"
+            upgrade: true
       when: ansible_facts.os_family == 'RedHat'
     - set_fact:
         pulp_install_plugins:
           pulp_file:
             version: "1.8"
+            upgrade: true
+          pulp_container:
+            version: "2.8"
             upgrade: true
       when: ansible_facts.os_family == 'Debian'
     - include_role:
@@ -102,11 +108,12 @@
       pip_package_info:
         clients: "/usr/local/lib/pulp/bin/pip"
       register: pip_pkgs
-    - name: Assert pulpcore>=3.14.6, pulp-file>=1.8.2
+    - name: Assert pulpcore>=3.14.6, pulp-file>=1.8.2, pulp-container>=2.8.0
       assert:
         that:
           - pip_pkgs.packages['/usr/local/lib/pulp/bin/pip']['pulpcore'][0].version is version("3.14.6", ">=")
           - pip_pkgs.packages['/usr/local/lib/pulp/bin/pip']['pulp-file'][0].version is version("1.8.2", ">=")
+          - pip_pkgs.packages['/usr/local/lib/pulp/bin/pip']['pulp-container'][0].version is version("2.8.0", ">=")
     - name: Assert pulp-rpm>=3.14.12
       assert:
         that:
@@ -127,12 +134,18 @@
           pulp_rpm:
             version: "3.18"
             upgrade: false
+          pulp_container:
+            version: "2.14"
+            upgrade: false
       when: ansible_facts.os_family == 'RedHat'
     - set_fact:
         pulp_install_plugins:
           pulp_file:
             version: "1.11"
-            upgrade: fasle
+            upgrade: false
+          pulp_container:
+            version: "2.14"
+            upgrade: false
       when: ansible_facts.os_family == 'Debian'
     - include_role:
         name: pulp_database_config
@@ -140,13 +153,21 @@
       pip_package_info:
         clients: "/usr/local/lib/pulp/bin/pip"
       register: pip_pkgs
-    - name: Assert pulpcore>=3.21.0, pulp-file>=1.11.1
+    - name: Assert pulpcore>=3.21.0, pulp-file>=1.11.1, pulp-container >=2.14.0
       assert:
         that:
           - pip_pkgs.packages['/usr/local/lib/pulp/bin/pip']['pulpcore'][0].version is version("3.21.0", ">=")
           - pip_pkgs.packages['/usr/local/lib/pulp/bin/pip']['pulp-file'][0].version is version("1.11.1", ">=")
+          - pip_pkgs.packages['/usr/local/lib/pulp/bin/pip']['pulp-container'][0].version is version("2.14.0", ">=")
     - name: Assert pulp-rpm>=3.18.1
       assert:
         that:
           - pip_pkgs.packages['/usr/local/lib/pulp/bin/pip']['pulp-rpm'][0].version is version("3.18.1", ">=")
       when: ansible_facts.os_family == 'RedHat'
+    - name: Show the output of container-repair-media-type
+      debug:
+        var: repair_pip
+    - name: Assert that container-repair-media-type was run
+      assert:
+        that:
+          - '"Successfully repaired" in repair_pip.stdout'

--- a/roles/pulp_common/tasks/install_packages.yml
+++ b/roles/pulp_common/tasks/install_packages.yml
@@ -1,4 +1,15 @@
 ---
+# We test for all the possible package names, including ones used in the past
+- name: Set a fact for the version of pulp-container installed prior to upgrade
+  set_fact:
+    pulp_container_old_version: "{{ ansible_facts.packages[item].0.version }}"
+  when: ansible_facts.packages[item] is defined
+  with_items:
+    - python3-pulp-container
+    - python38-pulp-container
+    - python39-pulp-container
+    - tfm-pulpcore-python3-pulp-container
+
 - name: Prepare to install the Pulp packages
   block:
     - name: "Enumerate the list of updates from the {{ __pulp_pkg_repo_name }} repo"

--- a/roles/pulp_common/tasks/install_pip.yml
+++ b/roles/pulp_common/tasks/install_pip.yml
@@ -138,7 +138,7 @@
     - name: Obtain list of packages in the venv to see if any plugins are installed
       pip_package_info:
         clients: "{{ pulp_install_dir }}/bin/pip"
-      register: pip_pkgs
+      register: pip_pkgs_preinstall
 
     - name: Create requirements.in file to check pulpcore/plugin compatibility
       template:
@@ -314,11 +314,11 @@
     - name: Obtain list of packages & versions in the venv after pulpcore install
       pip_package_info:
         clients: "{{ pulp_install_dir }}/bin/pip"
-      register: pip_pkgs
+      register: pip_pkgs_midinstall
 
     - name: Set __pulpcore_version to the pulpcore that was installed  ## noqa jinja
       set_fact:
-        __pulpcore_version: "{{ pip_pkgs.packages[pulp_install_dir + '/bin/pip'].pulpcore[0].version }}"
+        __pulpcore_version: "{{ pip_pkgs_midinstall.packages[pulp_install_dir + '/bin/pip'].pulpcore[0].version }}"
       when: pulp_source_dir is defined
 
     - name: Patch md5usedforsecurity in Django (devel only)
@@ -340,7 +340,7 @@
         state: present
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
-      when: pip_pkgs.packages[pulp_install_dir + '/bin/pip'].dynaconf[0].version is version("3.1.1", "<")
+      when: pip_pkgs_midinstall.packages[pulp_install_dir + '/bin/pip'].dynaconf[0].version is version("3.1.1", "<")
 
     - name: Upgrade django-storages if it is older than 1.12.2
       pip:
@@ -349,8 +349,8 @@
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
       when:
-        - pip_pkgs.packages[pulp_install_dir + '/bin/pip']['django-storages'] is defined
-        - pip_pkgs.packages[pulp_install_dir + '/bin/pip']['django-storages'][0].version is version("1.12.2", "<")
+        - pip_pkgs_midinstall.packages[pulp_install_dir + '/bin/pip']['django-storages'] is defined
+        - pip_pkgs_midinstall.packages[pulp_install_dir + '/bin/pip']['django-storages'][0].version is version("1.12.2", "<")
 
     - name: Create constraints file to lock the django and pulpcore version when plugins are installed
       template:
@@ -425,6 +425,11 @@
         state: present
         virtualenv: '{{ pulp_install_dir }}'
         virtualenv_command: '{{ pulp_python_interpreter }} -m venv'
+
+    - name: Obtain list of packages & versions in the venv after plugins install
+      pip_package_info:
+        clients: "{{ pulp_install_dir }}/bin/pip"
+      register: pip_pkgs_postinstall
 
   become: true
   become_user: '{{ pulp_user }}'

--- a/roles/pulp_common/templates/pip_constraints_for_plugins.txt.j2
+++ b/roles/pulp_common/templates/pip_constraints_for_plugins.txt.j2
@@ -1,1 +1,1 @@
-pulpcore=={{ pip_pkgs.packages[pulp_install_dir + '/bin/pip'].pulpcore[0].version }}
+pulpcore=={{ pip_pkgs_midinstall.packages[pulp_install_dir + '/bin/pip'].pulpcore[0].version }}

--- a/roles/pulp_common/templates/requirements.in.j2
+++ b/roles/pulp_common/templates/requirements.in.j2
@@ -17,7 +17,7 @@ git+{{ value['git_url']}}{{ value['git_revision'] | ternary('@', '') }}{{ value[
 {% endfor %}
 # Any plugins listed below were already installed but not specified in
 # pulp_install_plugins
-{% for plugin in pip_pkgs.packages[pulp_install_dir + '/bin/pip'].keys() %}
+{% for plugin in pip_pkgs_preinstall.packages[pulp_install_dir + '/bin/pip'].keys() %}
 {% if "galaxy-ng" in pulp_install_plugins_normalized.keys() and plugin in ["pulp-ansible", "pulp-container"] and plugin not in pulp_install_plugins_normalized.keys() %}
 {% elif ("pulp-" in plugin or plugin in pulp_irregularly_named_plugins) and plugin not in pulp_install_plugins_normalized.keys() %}
 {{ plugin }}

--- a/roles/pulp_database_config/README.md
+++ b/roles/pulp_database_config/README.md
@@ -20,6 +20,11 @@ Role Variables
    one wants to import. The path is on the Ansible management node.
    It is used to encrypt certain fields in the database (such as credentials.)
    If not specified, a new key will be generated. (Only generated if one doesn't exist.)
+* `pulp_container_repair_media_type`: Whether or not to run the command `pulpcore-manager
+   container-repair-media-type`, which fixes an issue with OCI manifests by modifying the
+   database. Accepts `True`, `False`, or `auto`. Defaults to `auto`, which runs the command
+   if pulp-container is currently installed at a version where the database is affected,
+   and if pulp-container is being upgraded to a version where the repair command is present.
 
 Role Variables for advanced usage
 ---------------------------------

--- a/roles/pulp_database_config/defaults/main.yml
+++ b/roles/pulp_database_config/defaults/main.yml
@@ -5,3 +5,5 @@ galaxy_create_default_collection_signing_service: false
 galaxy_create_default_container_signing_service: false
 
 pulp_force_change_admin_password: false
+
+pulp_container_repair_media_type: "auto"

--- a/roles/pulp_database_config/tasks/main.yml
+++ b/roles/pulp_database_config/tasks/main.yml
@@ -226,6 +226,95 @@
     PULP_SETTINGS: "{{ pulp_settings_file }}"
     LD_LIBRARY_PATH: "{{ pulp_ld_library_path }}"
 
+# We run the command when:
+# 1. The old version is <= 2.9.5 or (>=2.10.0 and <= 2.10.4 ) or (>= 2.11.0 and <= 2.11.1)
+#    or (>= 2.12.0 and <= 2.12.2) or ==2.13.0
+# 2. The new version is (>= 2.9.7 and < 2.10.0) or (>= 2.10.8 and < 2.11.0) or (>= 2.11.2 and < 2.12.0)
+#    or (>= 2.12.3 and < 2.13.0) or >= 2.13.2
+- name: Run the pulpcore-manager container-repair-media-type command (pip mode)
+  command: "{{ pulp_django_admin_path }} container-repair-media-type"
+  register: repair_pip
+  failed_when: '"Successfully repaired" not in repair_pip.stdout'
+  changed_when: '"Successfully repaired 0 manifests." not in repair_pip.stdout'
+  when:
+    - pip_pkgs_preinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'] is defined
+    - >
+      pulp_container_repair_media_type | bool or
+      (pulp_container_repair_media_type == "auto" and
+      ((pip_pkgs_preinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.9.5", "<=")) or
+      (pip_pkgs_preinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.10.0", ">=") and
+      pip_pkgs_preinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.10.4", "<=")) or
+      (pip_pkgs_preinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.11.0", ">=") and
+      pip_pkgs_preinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.11.1", "<=")) or
+      (pip_pkgs_preinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.12.0", ">=") and
+      pip_pkgs_preinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.12.2", "<=")) or
+      pip_pkgs_preinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.13.0", "=="))
+      and
+      ((pip_pkgs_postinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.9.7", ">=") and
+      pip_pkgs_postinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.10.0", "<") ) or
+      (pip_pkgs_postinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.10.8", ">=") and
+      pip_pkgs_postinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.11.0", "<")) or
+      (pip_pkgs_postinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.11.1", ">=") and
+      pip_pkgs_postinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.12.0", "<")) or
+      (pip_pkgs_postinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.12.3", ">=") and
+      pip_pkgs_postinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.13.0", "<")) or
+      pip_pkgs_postinstall.packages[pulp_install_dir + '/bin/pip']['pulp-container'][0].version is version("2.13.2", ">="))
+      )
+  run_once: "{{ __pulp_run_once }}"
+  delegate_to: "{{ hostvars['localhost']['pulp_database_config_host'] | default(inventory_hostname) }}"
+  become: true
+  become_user: '{{ pulp_user }}'
+  environment:
+    PULP_SETTINGS: "{{ pulp_settings_file }}"
+    LD_LIBRARY_PATH: "{{ pulp_ld_library_path }}"
+
+- name: Show output from the repair command
+  debug:
+    var: repair_pip
+    verbosity: 1
+
+- name: Run the pulpcore-manager container-repair-media-type command (packages mode)
+  command: "{{ pulp_django_admin_path }} container-repair-media-type"
+  register: repair_packages
+  failed_when: '"Successfully repaired" not in repair_packages.stdout'
+  changed_when: '"Successfully repaired 0 manifests." not in repair_packages.stdout'
+  when:
+    - pulp_container_old_version is defined
+    - >
+      pulp_container_repair_media_type | bool or
+      (pulp_container_repair_media_type == "auto" and
+      ((pulp_container_old_version is version("2.9.5", "<=")) or
+      (pulp_container_old_version is version("2.10.0", ">=") and
+      pulp_container_old_version is version("2.10.4", "<=")) or
+      (pulp_container_old_version is version("2.11.0", ">=") and
+      pulp_container_old_version is version("2.11.1", "<=")) or
+      (pulp_container_old_version is version("2.12.0", ">=") and
+      pulp_container_old_version is version("2.12.2", "<=")) or
+      pulp_container_old_version is version("2.13.0", "=="))
+      and
+      ((ansible_facts.packages[pulp_pkg_name_prefix + 'pulp-container'][0].version is version("2.9.7", ">=") and
+      ansible_facts.packages[pulp_pkg_name_prefix + 'pulp-container'][0].version is version("2.10.0", "<") ) or
+      (ansible_facts.packages[pulp_pkg_name_prefix + 'pulp-container'][0].version is version("2.10.8", ">=") and
+      ansible_facts.packages[pulp_pkg_name_prefix + 'pulp-container'][0].version is version("2.11.0", "<")) or
+      (ansible_facts.packages[pulp_pkg_name_prefix + 'pulp-container'][0].version is version("2.11.1", ">=") and
+      ansible_facts.packages[pulp_pkg_name_prefix + 'pulp-container'][0].version is version("2.12.0", "<")) or
+      (ansible_facts.packages[pulp_pkg_name_prefix + 'pulp-container'][0].version is version("2.12.3", ">=") and
+      ansible_facts.packages[pulp_pkg_name_prefix + 'pulp-container'][0].version is version("2.13.0", "<")) or
+      ansible_facts.packages[pulp_pkg_name_prefix + 'pulp-container'][0].version is version("2.13.2", ">="))
+      )
+  run_once: "{{ __pulp_run_once }}"
+  delegate_to: "{{ hostvars['localhost']['pulp_database_config_host'] | default(inventory_hostname) }}"
+  become: true
+  become_user: '{{ pulp_user }}'
+  environment:
+    PULP_SETTINGS: "{{ pulp_settings_file }}"
+    LD_LIBRARY_PATH: "{{ pulp_ld_library_path }}"
+
+- name: Show output from the repair command
+  debug:
+    var: repair_packages
+    verbosity: 1
+
 # This task is located here in pulp_database_config because it depends on the database fields encryption key
 # and on the database migrations having been run.
 - name: Add the galaxy collection signing service to the Pulp application


### PR DESCRIPTION
when upgrading from a version of pulp-container that needs to be repaired, to a version of pulp-container that has the command.


The container images for packages-upgrade were updated to include (old & affected versions of) pulp-container.

Currently, packages-upgrade can only upgrade pulp-container to 2.10.7. So the repair command is skipped for it, as intended.

release-upgrade, during its final application of the pulp_database_config role, upgrades pulp-container to the latest version. So the repair command is in fact run for it.

fixes: #1387