### PR TITLE
Do not fail if `pulp_settings.media_root` is set

### DIFF
--- a/CHANGES/1402.bugfix
+++ b/CHANGES/1402.bugfix
@@ -1,0 +1,1 @@
+Do not fail if `pulp_settings.media_root` is set to an empty string. This is what is documented to do for S3 object storage.

--- a/roles/pulp_common/tasks/dirs.yml
+++ b/roles/pulp_common/tasks/dirs.yml
@@ -33,6 +33,8 @@
         seuser: _default
         serole: _default
         setype: _default
+      # pulp_installer's object storage docs instruct users to set this to an empty string
+      when: __pulp_common_merged_pulp_settings.media_root | length > 0
 
     - name: Create cache dir for Pulp
       file:


### PR DESCRIPTION
to an empty string.

fixes: #1402