### PR TITLE
Fix failure when enabling repos on RHEL

### DIFF
--- a/CHANGES/1398.bugfix
+++ b/CHANGES/1398.bugfix
@@ -1,0 +1,1 @@
+Fix failure when enabling repos on RHEL with the error message `Ansible "register" is not templatable, but we found: {{ reg_variable }}.` Also fix the ability to not attempt to enable any subsequent possible names for the repo after the actual repo name has been found. Also fix the order of the CodeReady Builder repo names: The RHUI names are now 1st.

--- a/roles/pulp_repos/defaults/main.yml
+++ b/roles/pulp_repos/defaults/main.yml
@@ -31,9 +31,9 @@ pulp_pkg_repo_gpgcheck: True
 pulp_install_source: pip
 
 pulp_rhel_codeready_repo:
-  - codeready-builder-for-rhel-8-x86_64-rpms
   - rhui-codeready-builder-for-rhel-8-rhui-rpms
   - codeready-builder-for-rhel-8-rhui-rpms
+  - codeready-builder-for-rhel-8-x86_64-rpms
 rhel7_optional_repo:
   - rhui-rhel-7-server-rhui-optional-rpms
   - rhel-7-server-rhui-optional-rpms
@@ -46,3 +46,5 @@ pulp_rhel7_scl_repo:
   - rhui-rhel-server-rhui-rhscl-7-rpms  # seen on RHEL7.7 on AWS
   - rhel-server-rhscl-7-rpms
   - rhel-workstation-rhscl-7-rpms
+
+__ambiguously_named_repo_enabled: false

--- a/roles/pulp_repos/tasks/ambiguously-named-repo.yml
+++ b/roles/pulp_repos/tasks/ambiguously-named-repo.yml
@@ -1,16 +1,21 @@
 ---
-# NOTE: Keep in sync with pulp_database/tasks/ambiguously-named.repo.yml
-# NOTE: __pulp_common_repo_enabled is named specific to this version of ambiguously-named.repo.yml , since it
-# would bleed over into other runs of other ambiguously-named.repo.yml files.
+# NOTE: Every time you create a loop to call this playbook, you must set in a prior set_fact task:
+# __ambiguously_named_repo_enabled: false
+#
+# We cannot check __ambiguously_named_repo_enabled in the "when:" on the include_tasks,
+# it evaluates at the beginning, rather than in between loop operations.
+# So instead, we apply it to every task. This is equivalent to:
+# https://stackoverflow.com/a/61874047/2930194
 
-- name: "Determine which file in /etc/yum.repos.d/ has the {{ __ambiguously_named_repo }} repo"
+- name: "Determine which file in /etc/yum.repos.d/ has the repo {{ __ambiguously_named_repo }}"
   shell: grep -l -E "^\[{{ __ambiguously_named_repo }}\]" /etc/yum.repos.d/*.repo
   register: repo_file
   changed_when: false
   failed_when: false
   check_mode: False
+  when: not __ambiguously_named_repo_enabled
 
-- name: "Enable the {{ __ambiguously_named_repo }} repo"
+- name: "Enable the repo {{ __ambiguously_named_repo }}"
   ini_file:
     path: "{{ repo_file.stdout }}"
     section: "{{ __ambiguously_named_repo }}"
@@ -18,6 +23,16 @@
     value: "1"
     no_extra_spaces: true
     mode: '0644'
-  when: repo_file.rc == 0
-  register: "{{ reg_variable }}"
+  register: __ambiguously_named_repo_result
   become: true
+  when:
+    - repo_file.rc == 0
+    - not __ambiguously_named_repo_enabled
+
+# Effectively break the loop, the repeated tasks will be skipped
+- name: Set a fact that the repo has been successfully enabled
+  set_fact:
+    __ambiguously_named_repo_enabled: true
+  when:
+    - repo_file.rc == 0
+    - not __ambiguously_named_repo_enabled

--- a/roles/pulp_repos/tasks/main.yml
+++ b/roles/pulp_repos/tasks/main.yml
@@ -50,6 +50,8 @@
   become: true
   when: __pulp_repos_epel_enable_default and pulp_repos_epel_enable and pulp_repos_enable
 
+# __ambiguously_named_repo_enabled has already been set in the role defaults
+#
 # Try multiple possible names for the rhel7 optional repo until it is found.
 # The query ensures that a single string rather than a list of strings is valid.
 - name: Find and enable the first found name of the RHEL7 Optional repo
@@ -57,17 +59,21 @@
   loop: "{{ rhel7_optional_repo }}"
   loop_control:
     loop_var: __ambiguously_named_repo
-  vars:
-    reg_variable: "__pulp_common_repo_enabled"
   when:
     - __pulp_os_family == 'RedHat'
     - ansible_facts.distribution_major_version|int == 7
     # Works for both strings and lists to make sure not empty
     - rhel7_optional_repo is not none
     - rhel7_optional_repo | length > 0
-    # Prevents running again once completed.
-    - __pulp_common_repo_enabled is not defined
     - __pulp_repos_rhel_optional_enable_default and pulp_repos_rhel_optional_enable and pulp_repos_enable
+
+- name: Set the variable stating that the RHEL CodeReady Builder repo has not yet been enabled
+  set_fact:
+    __ambiguously_named_repo_enabled: false
+  when:
+    - ansible_facts.distribution == "RedHat"
+    - ansible_facts.distribution_major_version|int >= 8
+    - __pulp_repos_rhel_codeready_enable_default and pulp_repos_rhel_codeready_enable and pulp_repos_enable
 
 # Note: There are at least 3 needs for this repo:
 # 1. pulp_devel needs it for at least python-django-bash-completion
@@ -84,16 +90,12 @@
   loop: "{{ pulp_rhel_codeready_repo }}"
   loop_control:
     loop_var: __ambiguously_named_repo
-  vars:
-    reg_variable: "__pulp_codeready_repo_enabled"
   when:
     - ansible_facts.distribution == "RedHat"
     - ansible_facts.distribution_major_version|int >= 8
     # Works for both strings and lists to make sure not empty
     - pulp_rhel_codeready_repo is not none
     - pulp_rhel_codeready_repo | length > 0
-    # Prevents running again once completed.
-    - __pulp_codeready_repo_enabled is not defined
     - __pulp_repos_rhel_codeready_enable_default and pulp_repos_rhel_codeready_enable and pulp_repos_enable
 
 - name: Enable the CentOS/Rocky CRB repo
@@ -188,6 +190,13 @@
 
 - name: Enable SCL repository
   block:
+    - name: Set the variable stating that the SCL repo has not yet been enabled
+      set_fact:
+        __ambiguously_named_repo_enabled: false
+      when:
+        - ansible_facts.distribution == "RedHat"
+        - ansible_facts.distribution_major_version|int == 7
+
     # Try multiple possible names for the rhel7 SCL repo until it is found.
     # The query ensures that a single string rather than a list of strings is valid.
     - name: Find and enable the first found name of the RHEL7 SCL repo
@@ -195,16 +204,12 @@
       loop: "{{ pulp_rhel7_scl_repo }}"
       loop_control:
         loop_var: __ambiguously_named_repo
-      vars:
-        reg_variable: "__pulp_database_repo_enabled"
       when:
         - ansible_facts.distribution == "RedHat"
         - ansible_facts.distribution_major_version|int == 7
         # Works for both strings and lists to make sure not empty
         - pulp_rhel7_scl_repo is not none
         - pulp_rhel7_scl_repo | length > 0
-        # Prevents running again once completed. Specific to the role name.
-        - __pulp_database_repo_enabled is not defined
 
     - name: Install SCL repo packages on CentOS 7
       package:


### PR DESCRIPTION
with the error message `Ansible "register" is not templatable, but we found: {{ reg_variable }}.`

Also fix the ability to not attempt to enable any subsequent possible names for the repo after the actual repo name has been found.

Also fix the order of the CodeReady Builder repo names: The RHUI names are now 1st

fixes: #1398