### PR TITLE
3.18: Allow packages to be excluded from upgrade and a repo to be specified for upgrade

### DIFF
--- a/CHANGES/1394.bugfix
+++ b/CHANGES/1394.bugfix
@@ -1,0 +1,1 @@
+Allow packages to be excluded from upgrade and a repo to be specified for upgrade.

--- a/roles/pulp_common/README.md
+++ b/roles/pulp_common/README.md
@@ -200,6 +200,10 @@ Furthermore, the following variables are used, or behave *differently* from abov
 * `pulp_pkg_selinux_name` The name of the package containing the SELinux policies to install. See
   `pulp_install_selinux_policies`, except `git` is not used; the package manager is used instead.
    Defaults to "pulpcore-selinux".
+* `pulp_pkg_exclude_from_upgrade`: Optional. A list of packages that should be excluded from upgrade (Can be
+   used when `pulp_pkg_upgrade_all=true`).
+* `pulp_pkg_upgrade_repo_name`: Optional. yum/dnf package repo to enable during upgrade (Can be used when
+  `pulp_pkg_upgrade_all=true`).
 
 Role Variables for advanced usage
 ---------------------------------

--- a/roles/pulp_common/tasks/install_packages.yml
+++ b/roles/pulp_common/tasks/install_packages.yml
@@ -5,7 +5,8 @@
       yum:
         list: updates
         disablerepo: "*"
-        enablerepo: "{{ __pulp_pkg_repo_name }}"
+        enablerepo: "{{ pulp_pkg_upgrade_repo_name | default(__pulp_pkg_repo_name) }}"
+        exclude: "{{ pulp_pkg_exclude_from_upgrade | default(omit) }}"
       register: updates
 
     - name: List packages to be upgraded
@@ -63,6 +64,7 @@
       yum:
         name: "{{ updates.results | map(attribute='name') | list }}"
         state: latest  # noqa 403
+        exclude: "{{ pulp_pkg_exclude_from_upgrade | default(omit) }}"
         conf_file: "{{ __dnf_conf.path | default(omit) }}"
         # update_only is a needed part of installing older updates
         update_only: true


### PR DESCRIPTION
Backport of #1400 

fixes: #1394
(cherry picked from commit 7092c38f466f0d6c6a22e67b380dc8cca3c0d485)