### PR TITLE
3.18: Stick to ansible-lint 6.6.z

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
           pip install ansible-core
       - name: Install Ansible-lint
         run: |
-          pip install ansible-lint[yamllint]
+          pip install "ansible-lint[yamllint]<6.7.0"
       - name: Lint test
         run: |
           ansible-lint

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -196,7 +196,7 @@ jobs:
           pip install ansible-core
       - name: Install Ansible-lint
         run: |
-          pip install ansible-lint[yamllint]
+          pip install "ansible-lint[yamllint]<6.7.0"
       - name: Lint test
         run: |
           ansible-lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,7 +168,7 @@ jobs:
           pip install ansible-core
       - name: Install Ansible-lint
         run: |
-          pip install ansible-lint[yamllint]
+          pip install "ansible-lint[yamllint]<6.7.0"
       - name: Lint test
         run: |
           ansible-lint


### PR DESCRIPTION
Because the changes are too intrusive to be worth backporting

[noissue]