### PR TITLE
Added run_once loop task "Check if any of said hosts already have the database fields encryption key"

### DIFF
--- a/roles/pulp_database_config/tasks/main.yml
+++ b/roles/pulp_database_config/tasks/main.yml
@@ -108,6 +108,7 @@
       failed_when: false
       with_items: "{{ hostvars['localhost']['__pulp_database_config_hosts'] }}"
       become: true
+      run_once: true
 
     # 'equalto' test is not available on EL7's python-jinja2 2.7 RPM,
     # so we use 'sameas' to compare to true/false, and 'match' to compare strings.


### PR DESCRIPTION
The task "Check if any hosts already have the database fields encryption key"[1] in the "pulp_database_config" shouldn't be executing in all inventory_hostname because it will be run as many nodes as you would have in the inventory,  making many meaningless SSH connections from all inventory_hostnames when the number of inventory hosts is large. It could done delegating into the first node of the inventory or just running once as previous tasks.

roles/pulp_database_config/tasks/main.yml

 94     # This task must be run against all hosts, not just those running pulp_database_config.
 95     # However, running it against all hosts produces a massive data structure where
 96     # __pulp_db_fields_key_path.results has a list of dictionaries, with elements
 97     # "item" (the inventory_hostname) and "stat".
 98     - name: Check if any hosts already have the database fields encryption key
 99       stat:
100         path: "{{ __pulp_db_fields_key_path }}"
101       register: __pulp_db_fields_key_stat
102       delegate_to: "{{ item }}"
103       # We do `failed_when: false` because some hosts, used by 3rd-party roles,
104       # might not have become enabled. pulplift is 1 example, it has localhost.
105       failed_when: false
106       with_items: "{{ groups['all'] }}"
107       become: true
108       run_once: true

Current result
TASK [Check if any hosts already have the database fields encryption key] ********************************************************************************************************************
ok: [aap3 -> aap1] => (item=aap1)
ok: [aap2 -> aap1] => (item=aap1)
ok: [aap1] => (item=aap1)
ok: [aap3 -> aap2] => (item=aap2)
ok: [aap2] => (item=aap2)
ok: [aap1 -> aap2] => (item=aap2)
ok: [aap3] => (item=aap3)
ok: [aap2 -> aap3] => (item=aap3)
ok: [aap1 -> aap3] => (item=aap3)

Expected result
TASK [Check if any hosts already have the database fields encryption key] ********************************************************************************************************************
ok: [aap1] => (item=aap1)
ok: [aap1 -> aap2] => (item=aap2)
ok: [aap1 -> aap3] => (item=aap3)

Thanks in advance,
