### PR TITLE
Remove access logs from console

### DIFF
--- a/CHANGES/1422.bugfix
+++ b/CHANGES/1422.bugfix
@@ -1,0 +1,1 @@
+Remove access logging from gunicorn command line options within the pulpcore-api.service file

--- a/roles/pulp_api/templates/pulpcore-api.service.j2
+++ b/roles/pulp_api/templates/pulpcore-api.service.j2
@@ -29,9 +29,7 @@ ExecStart={{ __pulp_daemons_dir }}/gunicorn pulpcore.app.wsgi:application \
           --name pulp-api \
           --bind '{{ pulp_api_bind }}' \
           --workers {{ pulp_api_workers }} \
-          --timeout {{ pulp_service_timeout }} \
-          --access-logfile - \
-          --access-logformat 'pulp [%({correlation-id}o)s]: %(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s"'
+          --timeout {{ pulp_service_timeout }}
 
 # This provides reconnect support for PostgreSQL and Redis. Without reconnect support, if either
 # is not available at startup or becomes disconnected, this process will die and not respawn.


### PR DESCRIPTION
Access logs are already written to the web server's access log.