### PR TITLE
Fix condition to add HSTS header

### DIFF
--- a/CHANGES/1423.bugfix
+++ b/CHANGES/1423.bugfix
@@ -1,0 +1,1 @@
+Fix webserver conf file not setting HSTS header properly

--- a/roles/pulp_webserver/templates/nginx.conf.j2
+++ b/roles/pulp_webserver/templates/nginx.conf.j2
@@ -66,7 +66,7 @@ http {
         ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
         ssl_prefer_server_ciphers on;
 
-{% if pulp_webserver_disable_hsts is not mdellweg.filters.empty %}
+{% if not pulp_webserver_disable_hsts | bool %}
         # HSTS (ngx_http_headers_module is required) (15768000 seconds = 6 months)
         add_header Strict-Transport-Security max-age=15768000;
 {% endif %}

--- a/roles/pulp_webserver/templates/pulp-vhost.conf.j2
+++ b/roles/pulp_webserver/templates/pulp-vhost.conf.j2
@@ -75,7 +75,7 @@ Define pulp-api balancer://pulp-api
   SSLCipherSuite ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
   SSLHonorCipherOrder on
 
-{% if pulp_webserver_disable_hsts is not mdellweg.filters.empty %}
+{% if not pulp_webserver_disable_hsts | bool %}
   # HSTS (15768000 seconds = 6 months)
   Header always set Strict-Transport-Security "max-age=15768000;; includeSubDomains; preload"
 {% endif %}


### PR DESCRIPTION
When running pulp_installer with default https/hsts options (false for pulp_webserver_disable_https and pulp_webserver_disable_hsts), the HSTS header doesn't get added to nginx.conf

`mdellweg.filters.empty` returns true when boolean is false. Switching back to using `bool` rather than changing to 'is empty' as that's easier to understand. 

fixes: #1423