### PR TITLE
Fix molecule ci

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -10,6 +10,10 @@ skip_list:
   - 'no-handler'
   # This accidentally flags the "copy" module with the "content" parameter using jinja2. But template has no "content" parameter.
   - 'template-instead-of-copy'
+  # There's no point in naming import_tasks tasks
+  - name[missing]
+  # sometimes you want to specify something whose syntax is lowercase as the beginning of a task name
+  - name[casing]
 exclude_paths:
   - ./roles/ansible-role-postgresql/
   - ./roles/geerlingguy.postgresql/

--- a/molecule/packages-cluster/molecule.yml
+++ b/molecule/packages-cluster/molecule.yml
@@ -1,25 +1,26 @@
 ---
 dependency:
   name: galaxy
+# This yaml anchor is ignored by molecule, but can be reused in yaml
+# It is ignored in the dependency section, and cannot be a top-level section
+  .platform_base: &platform_base
+    privileged: False
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    tmpfs:
+      # Fixes issues accessing .so files under /tmp during pip builds.
+      # https://github.com/docker/compose/issues/1339
+      - /tmp:exec,mode=1777
+      - /run
+      - /run/lock
+    capabilities:
+      - NET_ADMIN
+      - NET_RAW
+    pre_build_image: true
 driver:
   name: docker
 lint: |
     ansible-lint
-# This is ignored by molecule, but can be reused in yaml
-.platform_base: &platform_base
-  privileged: False
-  volumes:
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  tmpfs:
-    # Fixes issues accessing .so files under /tmp during pip builds.
-    # https://github.com/docker/compose/issues/1339
-    - /tmp:exec,mode=1777
-    - /run
-    - /run/lock
-  capabilities:
-    - NET_ADMIN
-    - NET_RAW
-  pre_build_image: true
 platforms:
   - <<: *platform_base
     name: pulp-api1

--- a/molecule/packages-static/molecule.yml
+++ b/molecule/packages-static/molecule.yml
@@ -1,25 +1,26 @@
 ---
 dependency:
   name: galaxy
+# This yaml anchor is ignored by molecule, but can be reused in yaml
+# It is ignored in the dependency section, and cannot be a top-level section
+  .platform_base: &platform_base
+    privileged: False
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    tmpfs:
+      # Fixes issues accessing .so files under /tmp during pip builds.
+      # https://github.com/docker/compose/issues/1339
+      - /tmp:exec,mode=1777
+      - /run
+      - /run/lock
+    capabilities:
+      - NET_ADMIN
+      - NET_RAW
+    pre_build_image: true
 driver:
   name: docker
 lint: |
     ansible-lint
-# This is ignored by molecule, but can be reused in yaml
-.platform_base: &platform_base
-  privileged: False
-  volumes:
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  tmpfs:
-    # Fixes issues accessing .so files under /tmp during pip builds.
-    # https://github.com/docker/compose/issues/1339
-    - /tmp:exec,mode=1777
-    - /run
-    - /run/lock
-  capabilities:
-    - NET_ADMIN
-    - NET_RAW
-  pre_build_image: true
 platforms:
   - <<: *platform_base
     name: centos-7

--- a/molecule/packages-upgrade/molecule.yml
+++ b/molecule/packages-upgrade/molecule.yml
@@ -1,25 +1,26 @@
 ---
 dependency:
   name: galaxy
+# This yaml anchor is ignored by molecule, but can be reused in yaml
+# It is ignored in the dependency section, and cannot be a top-level section
+  .platform_base: &platform_base
+    privileged: False
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    tmpfs:
+      # Fixes issues accessing .so files under /tmp during pip builds.
+      # https://github.com/docker/compose/issues/1339
+      - /tmp:exec,mode=1777
+      - /run
+      - /run/lock
+    capabilities:
+      - NET_ADMIN
+      - NET_RAW
+    pre_build_image: true
 driver:
   name: docker
 lint: |
     ansible-lint
-# This is ignored by molecule, but can be reused in yaml
-.platform_base: &platform_base
-  privileged: False
-  volumes:
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  tmpfs:
-    # Fixes issues accessing .so files under /tmp during pip builds.
-    # https://github.com/docker/compose/issues/1339
-    - /tmp:exec,mode=1777
-    - /run
-    - /run/lock
-  capabilities:
-    - NET_ADMIN
-    - NET_RAW
-  pre_build_image: true
 platforms:
   - <<: *platform_base
     name: centos-7

--- a/molecule/release-cluster/molecule.yml
+++ b/molecule/release-cluster/molecule.yml
@@ -1,25 +1,26 @@
 ---
 dependency:
   name: galaxy
+# This yaml anchor is ignored by molecule, but can be reused in yaml
+# It is ignored in the dependency section, and cannot be a top-level section
+  .platform_base: &platform_base
+    privileged: False
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    tmpfs:
+      # Fixes issues accessing .so files under /tmp during pip builds.
+      # https://github.com/docker/compose/issues/1339
+      - /tmp:exec,mode=1777
+      - /run
+      - /run/lock
+    capabilities:
+      - NET_ADMIN
+      - NET_RAW
+    pre_build_image: true
 driver:
   name: docker
 lint: |
     ansible-lint
-# This is ignored by molecule, but can be reused in yaml
-.platform_base: &platform_base
-  privileged: False
-  volumes:
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  tmpfs:
-    # Fixes issues accessing .so files under /tmp during pip builds.
-    # https://github.com/docker/compose/issues/1339
-    - /tmp:exec,mode=1777
-    - /run
-    - /run/lock
-  capabilities:
-    - NET_ADMIN
-    - NET_RAW
-  pre_build_image: true
 platforms:
   - <<: *platform_base
     name: pulp-api1

--- a/molecule/release-galaxy/group_vars/all
+++ b/molecule/release-galaxy/group_vars/all
@@ -23,8 +23,10 @@ pulp_settings:
   rh_entitlement_required: insights
   galaxy_auto_sign_collections: true
   galaxy_collection_signing_service: ansible-default
+  galaxy_container_signing_service: container-default
   telemetry: false
 galaxy_create_default_collection_signing_service: true
+galaxy_create_default_container_signing_service: true
 
 # These variables are used by molecule verify, not the installer itself
 pulp_lib_path: /var/lib/pulp

--- a/molecule/release-galaxy/molecule.yml
+++ b/molecule/release-galaxy/molecule.yml
@@ -3,25 +3,26 @@ dependency:
   name: galaxy
   options:
     role-file: requirements.yml
+# This yaml anchor is ignored by molecule, but can be reused in yaml
+# It is ignored in the dependency section, and cannot be a top-level section
+  .platform_base: &platform_base
+    privileged: False
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    tmpfs:
+      # Fixes issues accessing .so files under /tmp during pip builds.
+      # https://github.com/docker/compose/issues/1339
+      - /tmp:exec,mode=1777
+      - /run
+      - /run/lock
+    capabilities:
+      - NET_ADMIN
+      - NET_RAW
+    pre_build_image: true
 driver:
   name: docker
 lint: |
     ansible-lint
-# This is ignored by molecule, but can be reused in yaml
-.platform_base: &platform_base
-  privileged: False
-  volumes:
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  tmpfs:
-    # Fixes issues accessing .so files under /tmp during pip builds.
-    # https://github.com/docker/compose/issues/1339
-    - /tmp:exec,mode=1777
-    - /run
-    - /run/lock
-  capabilities:
-    - NET_ADMIN
-    - NET_RAW
-  pre_build_image: true
 platforms:
   - <<: *platform_base
     name: centos-7

--- a/molecule/release-static/molecule.yml
+++ b/molecule/release-static/molecule.yml
@@ -1,25 +1,26 @@
 ---
 dependency:
   name: galaxy
+# This yaml anchor is ignored by molecule, but can be reused in yaml
+# It is ignored in the dependency section, and cannot be a top-level section
+  .platform_base: &platform_base
+    privileged: False
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    tmpfs:
+      # Fixes issues accessing .so files under /tmp during pip builds.
+      # https://github.com/docker/compose/issues/1339
+      - /tmp:exec,mode=1777
+      - /run
+      - /run/lock
+    capabilities:
+      - NET_ADMIN
+      - NET_RAW
+    pre_build_image: true
 driver:
   name: docker
 lint: |
     ansible-lint
-# This is ignored by molecule, but can be reused in yaml
-.platform_base: &platform_base
-  privileged: False
-  volumes:
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  tmpfs:
-    # Fixes issues accessing .so files under /tmp during pip builds.
-    # https://github.com/docker/compose/issues/1339
-    - /tmp:exec,mode=1777
-    - /run
-    - /run/lock
-  capabilities:
-    - NET_ADMIN
-    - NET_RAW
-  pre_build_image: true
 platforms:
   - <<: *platform_base
     name: centos-7

--- a/molecule/release-upgrade/molecule.yml
+++ b/molecule/release-upgrade/molecule.yml
@@ -1,25 +1,26 @@
 ---
 dependency:
   name: galaxy
+# This yaml anchor is ignored by molecule, but can be reused in yaml
+# It is ignored in the dependency section, and cannot be a top-level section
+  .platform_base: &platform_base
+    privileged: False
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    tmpfs:
+      # Fixes issues accessing .so files under /tmp during pip builds.
+      # https://github.com/docker/compose/issues/1339
+      - /tmp:exec,mode=1777
+      - /run
+      - /run/lock
+    capabilities:
+      - NET_ADMIN
+      - NET_RAW
+    pre_build_image: true
 driver:
   name: docker
 lint: |
     ansible-lint
-# This is ignored by molecule, but can be reused in yaml
-.platform_base: &platform_base
-  privileged: False
-  volumes:
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  tmpfs:
-    # Fixes issues accessing .so files under /tmp during pip builds.
-    # https://github.com/docker/compose/issues/1339
-    - /tmp:exec,mode=1777
-    - /run
-    - /run/lock
-  capabilities:
-    - NET_ADMIN
-    - NET_RAW
-  pre_build_image: true
 platforms:
   - <<: *platform_base
     name: centos-7

--- a/molecule/scenario_resources/tests/testinfra_default.py
+++ b/molecule/scenario_resources/tests/testinfra_default.py
@@ -77,8 +77,8 @@ def test_pulp_status_redirect(host):
     assert '301' in output
 
 
-def test_pulp_status_max_1_redirect(host):
-    output = host.check_output("curl http://localhost/pulp/api/v3/status/ --max-redirs 1 -skL -w ' status: %{http_code}'")
+def test_pulp_status_max_2_redirect(host):
+    output = host.check_output("curl http://localhost/pulp/api/v3/status/ --max-redirs 2 -skL -w ' status: %{http_code}'")
     assert 'status: 200' in output
     assert 'database_connection' in output
 

--- a/molecule/source-cluster/molecule.yml
+++ b/molecule/source-cluster/molecule.yml
@@ -1,25 +1,26 @@
 ---
 dependency:
   name: galaxy
+# This yaml anchor is ignored by molecule, but can be reused in yaml
+# It is ignored in the dependency section, and cannot be a top-level section
+  .platform_base: &platform_base
+    privileged: False
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    tmpfs:
+      # Fixes issues accessing .so files under /tmp during pip builds.
+      # https://github.com/docker/compose/issues/1339
+      - /tmp:exec,mode=1777
+      - /run
+      - /run/lock
+    capabilities:
+      - NET_ADMIN
+      - NET_RAW
+    pre_build_image: true
 driver:
   name: docker
 lint: |
     ansible-lint
-# This is ignored by molecule, but can be reused in yaml
-.platform_base: &platform_base
-  privileged: False
-  volumes:
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  tmpfs:
-    # Fixes issues accessing .so files under /tmp during pip builds.
-    # https://github.com/docker/compose/issues/1339
-    - /tmp:exec,mode=1777
-    - /run
-    - /run/lock
-  capabilities:
-    - NET_ADMIN
-    - NET_RAW
-  pre_build_image: true
 platforms:
   - <<: *platform_base
     name: pulp-api1
@@ -74,9 +75,6 @@ scenario:
     - converge
     - side_effect
     - verify
-  playbooks:
-    prepare: prepare.yml
-
 verifier:
   name: ansible
   directory: tests

--- a/molecule/source-galaxy/molecule.yml
+++ b/molecule/source-galaxy/molecule.yml
@@ -3,25 +3,26 @@ dependency:
   name: galaxy
   options:
     role-file: requirements.yml
+# This yaml anchor is ignored by molecule, but can be reused in yaml
+# It is ignored in the dependency section, and cannot be a top-level section
+  .platform_base: &platform_base
+    privileged: False
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    tmpfs:
+      # Fixes issues accessing .so files under /tmp during pip builds.
+      # https://github.com/docker/compose/issues/1339
+      - /tmp:exec,mode=1777
+      - /run
+      - /run/lock
+    capabilities:
+      - NET_ADMIN
+      - NET_RAW
+    pre_build_image: true
 driver:
   name: docker
 lint: |
     ansible-lint
-# This is ignored by molecule, but can be reused in yaml
-.platform_base: &platform_base
-  privileged: False
-  volumes:
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  tmpfs:
-    # Fixes issues accessing .so files under /tmp during pip builds.
-    # https://github.com/docker/compose/issues/1339
-    - /tmp:exec,mode=1777
-    - /run
-    - /run/lock
-  capabilities:
-    - NET_ADMIN
-    - NET_RAW
-  pre_build_image: true
 platforms:
   - <<: *platform_base
     name: centos-7
@@ -59,9 +60,6 @@ scenario:
     - idempotence
     - side_effect
     - verify
-  playbooks:
-    prepare: prepare.yml
-
 verifier:
   name: ansible
   directory: tests

--- a/molecule/source-static/molecule.yml
+++ b/molecule/source-static/molecule.yml
@@ -1,25 +1,26 @@
 ---
 dependency:
   name: galaxy
+# This yaml anchor is ignored by molecule, but can be reused in yaml
+# It is ignored in the dependency section, and cannot be a top-level section
+  .platform_base: &platform_base
+    privileged: False
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    tmpfs:
+      # Fixes issues accessing .so files under /tmp during pip builds.
+      # https://github.com/docker/compose/issues/1339
+      - /tmp:exec,mode=1777
+      - /run
+      - /run/lock
+    capabilities:
+      - NET_ADMIN
+      - NET_RAW
+    pre_build_image: true
 driver:
   name: docker
 lint: |
     ansible-lint
-# This is ignored by molecule, but can be reused in yaml
-.platform_base: &platform_base
-  privileged: False
-  volumes:
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  tmpfs:
-    # Fixes issues accessing .so files under /tmp during pip builds.
-    # https://github.com/docker/compose/issues/1339
-    - /tmp:exec,mode=1777
-    - /run
-    - /run/lock
-  capabilities:
-    - NET_ADMIN
-    - NET_RAW
-  pre_build_image: true
 platforms:
   - <<: *platform_base
     name: centos-7
@@ -65,8 +66,6 @@ scenario:
     - idempotence
     - side_effect
     - verify
-  playbooks:
-    prepare: prepare.yml
 verifier:
   name: ansible
   directory: tests

--- a/molecule/source-upgrade/molecule.yml
+++ b/molecule/source-upgrade/molecule.yml
@@ -1,25 +1,26 @@
 ---
 dependency:
   name: galaxy
+# This yaml anchor is ignored by molecule, but can be reused in yaml
+# It is ignored in the dependency section, and cannot be a top-level section
+  .platform_base: &platform_base
+    privileged: False
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    tmpfs:
+      # Fixes issues accessing .so files under /tmp during pip builds.
+      # https://github.com/docker/compose/issues/1339
+      - /tmp:exec,mode=1777
+      - /run
+      - /run/lock
+    capabilities:
+      - NET_ADMIN
+      - NET_RAW
+    pre_build_image: true
 driver:
   name: docker
 lint: |
     ansible-lint
-# This is ignored by molecule, but can be reused in yaml
-.platform_base: &platform_base
-  privileged: False
-  volumes:
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  tmpfs:
-    # Fixes issues accessing .so files under /tmp during pip builds.
-    # https://github.com/docker/compose/issues/1339
-    - /tmp:exec,mode=1777
-    - /run
-    - /run/lock
-  capabilities:
-    - NET_ADMIN
-    - NET_RAW
-  pre_build_image: true
 platforms:
   - <<: *platform_base
     name: centos-7


### PR DESCRIPTION
release-galaxy CI has curl error code 47 (too many redirects) during molecule verify phase. That is an existing issue that started prior to the 2 breakages that are fixed by this PR.