### PR TITLE
Fix failure on task "Set crypto policy for Fedora"

### DIFF
--- a/CHANGES/1431.bugfix
+++ b/CHANGES/1431.bugfix
@@ -1,0 +1,1 @@
+Fix failure on task "Set crypto policy for Fedora" on Fedora 35 due to `update-crypto-policies` not being installed.

--- a/roles/pulp_devel/tasks/main.yml
+++ b/roles/pulp_devel/tasks/main.yml
@@ -67,6 +67,13 @@
   become: true
   become_user: "{{ developer_user }}"
 
+- name: Install update-crypto-policies command on Fedora
+  become: true
+  package:
+    name: crypto-policies-scripts
+  when:
+    - ansible_facts.distribution == "Fedora"
+
 - name: Set crypto policy for Fedora (to allow using CDN certificates)
   become: true
   command: update-crypto-policies --set LEGACY


### PR DESCRIPTION
on Fedora 35 due to `update-crypto-policies` not being installed.

fixes: #1431