### PR TITLE
Fix "pulp_common : Update apt package index"

### DIFF
--- a/CHANGES/1439.bugfix
+++ b/CHANGES/1439.bugfix
@@ -1,0 +1,1 @@
+Fix "pulp_common : Update apt package index" failing when not running ansible against the target system as root.

--- a/roles/pulp_common/tasks/main.yml
+++ b/roles/pulp_common/tasks/main.yml
@@ -74,6 +74,7 @@
   when: ansible_facts.distribution == 'Debian'
   # This is a lie, but necessary for Idempotence test
   changed_when: False
+  become: yes
 
 - name: Gather package facts
   package_facts:


### PR DESCRIPTION
failing when not running against the system directly as root.
    
fixes: #1439
