### PR TITLE
Set environment variables for fixtures

### DIFF
--- a/roles/pulp_devel/defaults/main.yml
+++ b/roles/pulp_devel/defaults/main.yml
@@ -2,5 +2,6 @@
 pulp_devel_install_podman: true
 pulp_devel_package_retries: 5
 pulp_devel_supplement_bashrc: false
+pulp_remote_fixtures_origin: 'https://fixtures.pulpproject.org/'
 pulp_workers: 2
 pulp_scheme: "{{ pulp_webserver_disable_https | default(false) | ternary('http', 'https') }}"

--- a/roles/pulp_devel/templates/django.bashrc.j2
+++ b/roles/pulp_devel/templates/django.bashrc.j2
@@ -1,2 +1,4 @@
 export DJANGO_SETTINGS_MODULE=pulpcore.app.settings
 export PULP_SETTINGS={{ pulp_settings_file }}
+export REMOTE_FIXTURES_ORIGIN={{ pulp_remote_fixtures_origin }}
+export API_HOST={{ ansible_fqdn }}


### PR DESCRIPTION
This commit was induced by the upcoming change in pulpcore where we started replacing the old pulp-smash settings through environment variables.

[noissue]