### PR TITLE
Revert "3.21 CI: Update molecule vars"

### DIFF
--- a/.github/workflows/galaxy_ci.yml
+++ b/.github/workflows/galaxy_ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          pip install galaxy_ng==4.6
+          pip install galaxy_ng
           PULPCORE_VERSION=$(pip show pulpcore | sed -n -e "s/Version: //p")
           echo "PULPCORE_VERSION=$PULPCORE_VERSION"
           sed -i "s/PLACEHOLDER/$PULPCORE_VERSION/" molecule/release-galaxy/group_vars/all
@@ -53,7 +53,7 @@ jobs:
         run: |
           python -m venv venv
           source venv/bin/activate
-          pip install git+https://github.com/ansible/galaxy_ng.git@stable-4.6
+          pip install git+https://github.com/ansible/galaxy_ng.git
 
           PULPCORE_VERSION=$(pip show pulpcore | sed -n -e "s/Version: //p")
           echo "PULPCORE_VERSION=$PULPCORE_VERSION"

--- a/molecule/release-cluster/group_vars/all
+++ b/molecule/release-cluster/group_vars/all
@@ -4,9 +4,7 @@ pulp_configure_firewall: none
 pulp_default_admin_password: password
 pulp_install_plugins:
   pulp-file:
-    version: "1.11"
   pulp-container:
-    version: "2.14"
 pulp_redis_bind: '0.0.0.0:6379'
 pulp_api_bind: "{{ ansible_default_ipv4['address'] }}:24817"
 pulp_content_bind: "{{ ansible_default_ipv4['address'] }}:24816"

--- a/molecule/release-static/group_vars/all
+++ b/molecule/release-static/group_vars/all
@@ -10,20 +10,18 @@ pulp_install_plugins:
   # pulp-certguard:
   pulp-container:
     extras: VitaminC
-    version: "2.14"
   # pulp-cookbook:
   # pulp-deb:
   pulp-file:
     extras:
      - VitaminC
      - VitaminD
-    version: "1.11"
+    version: "1.10.3"
   # pulp-gem:
   # pulp-maven:
   # pulp-npm:
   # pulp-python:
   pulp-rpm:
-    version: "3.18"
 pulp_settings:
   content_origin: "https://{{ ansible_fqdn }}"
   secret_key: secret

--- a/molecule/source-cluster/group_vars/all
+++ b/molecule/source-cluster/group_vars/all
@@ -3,15 +3,15 @@ __pulp_run_once: true
 pulp_default_admin_password: password
 pulp_source_dir: '/var/lib/pulp/devel/pulpcore'
 pulp_git_url: "https://github.com/pulp/pulpcore"
-pulp_git_revision: "3.21"
+pulp_git_revision: "3.22"
 pulp_install_plugins:
   pulp-file:
     git_url: "https://github.com/pulp/pulp_file"
-    git_revision: "1.11"
+    git_revision: "main"
     source_dir: "/var/lib/pulp/devel/pulp_file"
   pulp-container:
     git_url: "https://github.com/pulp/pulp_container"
-    git_revision: "2.14"
+    git_revision: "main"
     source_dir: "/var/lib/pulp/devel/pulp_container"
 developer_user_home: /var/lib/pulp
 developer_user: pulp

--- a/molecule/source-static/group_vars/all
+++ b/molecule/source-static/group_vars/all
@@ -2,7 +2,7 @@
 pulp_default_admin_password: password
 pulp_source_dir: '/var/lib/pulp/devel/pulpcore'
 pulp_git_url: "https://github.com/pulp/pulpcore"
-pulp_git_revision: "3.21"
+pulp_git_revision: "3.22"
 pulp_api_bind: "unix:/var/run/pulpcore-api/pulpcore-api.sock"
 pulp_content_bind: "unix:/var/run/pulpcore-content/pulpcore-content.sock"
 pulp_redis_bind: "unix://var/run/redis/redis.sock"
@@ -22,7 +22,7 @@ pulp_install_plugins:
   #   source_dir: "/var/lib/pulp/devel/pulp_deb"
   pulp-file:
     git_url: "https://github.com/pulp/pulp_file"
-    git_revision: "1.11"
+    git_revision: "main"
     source_dir: "/var/lib/pulp/devel/pulp_file"
     extras: VitaminC
   # pulp-gem:
@@ -35,7 +35,7 @@ pulp_install_plugins:
   #   source_dir: "/var/lib/pulp/devel/pulp_python"
   pulp-rpm:
     git_url: "https://github.com/pulp/pulp_rpm"
-    git_revision: "3.18"
+    git_revision: "main"
     source_dir: "/var/lib/pulp/devel/pulp_rpm"
     extras:
      - VitaminC

--- a/molecule/source-upgrade/group_vars/all
+++ b/molecule/source-upgrade/group_vars/all
@@ -2,7 +2,7 @@
 pulp_default_admin_password: password
 pulp_source_dir: '/var/lib/pulp/devel/pulpcore'
 pulp_git_url: "https://github.com/pulp/pulpcore"
-pulp_git_revision: "3.21"
+pulp_git_revision: "3.22"
 pulp_upgrade: true
 # Needed to determine whether or not pulpcore was actually upgraded, to
 # trigger the handler.
@@ -10,12 +10,12 @@ pulp_pip_editable: false
 pulp_install_plugins:
   pulp-file:
     git_url: "https://github.com/pulp/pulp_file"
-    git_revision: "1.11"
+    git_revision: "main"
     upgrade: true
     source_dir: "/var/lib/pulp/devel/pulp_file"
   pulp-rpm:
     git_url: "https://github.com/pulp/pulp_rpm"
-    git_revision: "3.18"
+    git_revision: "main"
     upgrade: true
     source_dir: "/var/lib/pulp/devel/pulp_rpm"
 developer_user_home: /var/lib/pulp

--- a/molecule/source-upgrade/host_vars/debian-11
+++ b/molecule/source-upgrade/host_vars/debian-11
@@ -3,7 +3,6 @@ pulp_install_plugins:
     upgrade: true
     git_url: "https://github.com/pulp/pulp_file"
     source_dir: "/var/lib/pulp/devel/pulp_file"
-    git_revision: "1.11"
   # pulp-rpm:
   #   upgrade: true
   #   source_dir: "/var/lib/pulp/devel/pulp_rpm"


### PR DESCRIPTION
This reverts commit 357b7127ded451932979d3cbbeaaba6f929f7616.

It was meant for the 3.21 branch.

[noissue]