### PR TITLE
Support new entrypoints

### DIFF
--- a/CHANGES/1486.bugfix
+++ b/CHANGES/1486.bugfix
@@ -1,0 +1,1 @@
+Added conditional blocks around the ExecStart parts in pulpcore-api and pulpcore-content systemd units to support the new entrypoints in releases >= 3.33i

--- a/roles/pulp_api/templates/pulpcore-api.service.j2
+++ b/roles/pulp_api/templates/pulpcore-api.service.j2
@@ -25,7 +25,11 @@ LimitNOFILE=524288
 
 # timeout is needed Pulp to service its 1st request on extremely slow
 # machines, such as qemu-emulated 2-core machines
+{% if __pulpcore_version is version('3.33', '>=') -%}
+ExecStart={{ __pulp_daemons_dir }}/pulpcore-api \
+{% else %}
 ExecStart={{ __pulp_daemons_dir }}/gunicorn pulpcore.app.wsgi:application \
+{%- endif %}
           --name pulp-api \
           --bind '{{ pulp_api_bind }}' \
           --workers {{ pulp_api_workers }} \

--- a/roles/pulp_content/templates/pulpcore-content.service.j2
+++ b/roles/pulp_content/templates/pulpcore-content.service.j2
@@ -25,10 +25,14 @@ LimitNOFILE=524288
 
 # timeout is needed Pulp to service its 1st request on extremely slow
 # machines, such as qemu-emulated 2-core machines
+{% if __pulpcore_version is version('3.33', '>=') -%}
+ExecStart={{ __pulp_daemons_dir }}/pulpcore-content \
+{% else %}
 ExecStart={{ __pulp_daemons_dir }}/gunicorn pulpcore.content:server \
           --name pulp-content \
-          --bind '{{ pulp_content_bind }}' \
           --worker-class 'aiohttp.GunicornWebWorker' \
+{% endif %}
+          --bind '{{ pulp_content_bind }}' \
           --workers {{ pulp_content_workers }} \
           --timeout {{ pulp_service_timeout }} \
           --access-logfile -


### PR DESCRIPTION
I know that we are all supposed to use containers now, but some of us have production deployments and would like to be able to upgrade beyond about 3.22 :)

This is a simple change to  permit this, as in recent pulpcore versions pulpcore-api at least refuses to start if not called using the new entrypoint.

I could of course maintain a separate fork, but it  would be very nice to not have to, thank you :)

This should fix issue https://github.com/pulp/pulp_installer/issues/1486
