### PR TITLE
Do not create symlinks for collectstatic

### DIFF
--- a/CHANGES/1488.bugfix
+++ b/CHANGES/1488.bugfix
@@ -1,0 +1,1 @@
+Copy static files instead of symlink to avoid pulp failing to start due to stale symlinks after upgrade

--- a/roles/pulp_common/handlers/main.yml
+++ b/roles/pulp_common/handlers/main.yml
@@ -30,7 +30,7 @@
     - pulp_install_selinux_policies|bool or pulp_install_selinux_policies == "auto"
 
 - name: Collect static content
-  command: "{{ pulp_django_admin_path }} collectstatic --clear --noinput --link {{ pulp_collectstatic_ignore_list }}"
+  command: "{{ pulp_django_admin_path }} collectstatic --clear --noinput {{ pulp_collectstatic_ignore_list }}"
   # When run against the same FS, we do not want the multiple nodes'
   # commands to conflict with eachother. It sometimes happens.
   throttle: 1


### PR DESCRIPTION
During upgrade, collectstatic call might leave stale symlinks even with `--clean` option and that causes pulp not to start. After consulting with pulp team, we have agreed it is safer to copy files rather than symlink.

Fixes: #1488 