### PR TITLE
Added SyslogIdentifier line to help log pulpcore-worker messages 

### DIFF
--- a/roles/pulp_workers/templates/pulpcore-worker@.service.j2
+++ b/roles/pulp_workers/templates/pulpcore-worker@.service.j2
@@ -23,6 +23,9 @@ WorkingDirectory=/var/run/pulpcore-worker-%i/
 RuntimeDirectory=pulpcore-worker-%i
 LimitNOFILE=524288
 
+# Labels pulpcore-worker messages in syslog appropriately
+SyslogIdentifier=pulpcore-worker-%i
+
 {% if __pulpcore_version is version('3.14', '>=') -%}
 ExecStart={{ __pulp_daemons_dir }}/pulpcore-worker
 {%- else -%}


### PR DESCRIPTION
Added the SyslogIdentifer tag in the service file to help show pulpcore-worker specific messages in syslog. These can be further extracted with rsyslog.conf. 