### PR TITLE
Added SyslogIdentifier line to help log pulpcore-api messages

### DIFF
--- a/roles/pulp_api/templates/pulpcore-api.service.j2
+++ b/roles/pulp_api/templates/pulpcore-api.service.j2
@@ -23,6 +23,9 @@ PIDFile=/run/pulpcore-api.pid
 RuntimeDirectory=pulpcore-api
 LimitNOFILE=524288
 
+# Labels pulpcore-api messages in syslog appropriately
+SyslogIdentifier=pulp-wsgi-server
+
 # timeout is needed Pulp to service its 1st request on extremely slow
 # machines, such as qemu-emulated 2-core machines
 {% if __pulpcore_version is version('3.33', '>=') -%}


### PR DESCRIPTION
Added the SyslogIdentifer tag in the service file to help show pulpcore-apispecific messages in syslog. These can be further extracted with rsyslog.conf.