### PR TITLE
Added SyslogIdentifier line to help log pulpcore-content messages

### DIFF
--- a/roles/pulp_content/templates/pulpcore-content.service.j2
+++ b/roles/pulp_content/templates/pulpcore-content.service.j2
@@ -23,6 +23,9 @@ WorkingDirectory=/var/run/pulpcore-content/
 RuntimeDirectory=pulpcore-content
 LimitNOFILE=524288
 
+# Labels pulpcore-content messages in syslog appropriately
+SyslogIdentifier=pulp-content-app
+
 # timeout is needed Pulp to service its 1st request on extremely slow
 # machines, such as qemu-emulated 2-core machines
 {% if __pulpcore_version is version('3.33', '>=') -%}


### PR DESCRIPTION
Added the SyslogIdentifer tag in the service file to help show pulpcore-content specific messages in syslog. These can be further extracted with rsyslog.conf.